### PR TITLE
Allow ICP matching against voxel metric map types

### DIFF
--- a/mp2p_icp/src/ICP_LibPointmatcher.cpp
+++ b/mp2p_icp/src/ICP_LibPointmatcher.cpp
@@ -50,7 +50,7 @@ static PointMatcher<double>::DataPoints pointsToPM(const metric_map_t& pc)
     for (const auto& ly : pc.layers)
     {
         // const std::string&                 name = ly.first;
-        auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(ly.second);
+        auto pts = mp2p_icp::MapToPointsMap(*ly.second);
         if (!pts) continue;  // Not a point cloud layer
 
         const auto xs = pts->getPointsBufferRef_x();

--- a/mp2p_icp/src/Matcher_Point2Line.cpp
+++ b/mp2p_icp/src/Matcher_Point2Line.cpp
@@ -45,12 +45,11 @@ void Matcher_Point2Line::implMatchOneLayer(
 {
     MRPT_START
 
-    const auto* pcGlobalPtr =
-        dynamic_cast<const mrpt::maps::CPointsMap*>(&pcGlobalMap);
+    const auto* pcGlobalPtr = mp2p_icp::MapToPointsMap(pcGlobalMap);
     if (!pcGlobalPtr)
         THROW_EXCEPTION_FMT(
-            "This class only supports global maps of point cloud types, but "
-            "found type '%s'",
+            "This class only supports global maps of types convertible to "
+            "point cloud types, but found type '%s'",
             pcGlobalMap.GetRuntimeClass()->className);
     const auto& pcGlobal = *pcGlobalPtr;
 

--- a/mp2p_icp/src/Matcher_Point2Plane.cpp
+++ b/mp2p_icp/src/Matcher_Point2Plane.cpp
@@ -74,12 +74,11 @@ void Matcher_Point2Plane::implMatchOneLayer(
 {
     MRPT_START
 
-    const auto* pcGlobalPtr =
-        dynamic_cast<const mrpt::maps::CPointsMap*>(&pcGlobalMap);
+    const auto* pcGlobalPtr = mp2p_icp::MapToPointsMap(pcGlobalMap);
     if (!pcGlobalPtr)
         THROW_EXCEPTION_FMT(
-            "This class only supports global maps of point cloud types, but "
-            "found type '%s'",
+            "This class only supports global maps of types convertible to "
+            "point cloud types, but found type '%s'",
             pcGlobalMap.GetRuntimeClass()->className);
     const auto& pcGlobal = *pcGlobalPtr;
 

--- a/mp2p_icp/src/Matcher_Points_Base.cpp
+++ b/mp2p_icp/src/Matcher_Points_Base.cpp
@@ -76,8 +76,7 @@ bool Matcher_Points_Base::impl_match(
 
             const mrpt::maps::CMetricMap::Ptr& lcLayerMap = itLocal->second;
             ASSERT_(lcLayerMap);
-            const auto lcLayer =
-                std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(lcLayerMap);
+            const auto lcLayer = mp2p_icp::MapToPointsMap(*lcLayerMap);
             if (!lcLayer)
                 THROW_EXCEPTION_FMT(
                     "Local layer map must be a point cloud, but found type "
@@ -89,9 +88,7 @@ bool Matcher_Points_Base::impl_match(
             // Ensure we have the KD-tree parameters desired by the user:
             if (kdtree_leaf_max_points_.has_value())
             {
-                if (const auto glLayerPts =
-                        std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(
-                            glLayer);
+                if (auto glLayerPts = mp2p_icp::MapToPointsMap(*glLayer);
                     glLayerPts &&
                     glLayerPts->kdtree_search_params.leaf_max_size !=
                         *kdtree_leaf_max_points_)

--- a/mp2p_icp/src/Matcher_Points_DistanceThreshold.cpp
+++ b/mp2p_icp/src/Matcher_Points_DistanceThreshold.cpp
@@ -45,12 +45,11 @@ void Matcher_Points_DistanceThreshold::implMatchOneLayer(
 {
     MRPT_START
 
-    const auto* pcGlobalPtr =
-        dynamic_cast<const mrpt::maps::CPointsMap*>(&pcGlobalMap);
+    const auto* pcGlobalPtr = mp2p_icp::MapToPointsMap(pcGlobalMap);
     if (!pcGlobalPtr)
         THROW_EXCEPTION_FMT(
-            "This class only supports global maps of point cloud types, but "
-            "found type '%s'",
+            "This class only supports global maps of types convertible to "
+            "point cloud types, but found type '%s'",
             pcGlobalMap.GetRuntimeClass()->className);
     const auto& pcGlobal = *pcGlobalPtr;
 

--- a/mp2p_icp/src/Matcher_Points_InlierRatio.cpp
+++ b/mp2p_icp/src/Matcher_Points_InlierRatio.cpp
@@ -44,12 +44,11 @@ void Matcher_Points_InlierRatio::implMatchOneLayer(
     ASSERT_GT_(inliersRatio, 0.0);
     ASSERT_LT_(inliersRatio, 1.0);
 
-    const auto* pcGlobalPtr =
-        dynamic_cast<const mrpt::maps::CPointsMap*>(&pcGlobalMap);
+    const auto* pcGlobalPtr = mp2p_icp::MapToPointsMap(pcGlobalMap);
     if (!pcGlobalPtr)
         THROW_EXCEPTION_FMT(
-            "This class only supports global maps of point cloud types, but "
-            "found type '%s'",
+            "This class only supports global maps of types convertible to "
+            "point cloud types, but found type '%s'",
             pcGlobalMap.GetRuntimeClass()->className);
     const auto& pcGlobal = *pcGlobalPtr;
 

--- a/mp2p_icp/src/QualityEvaluator_Voxels.cpp
+++ b/mp2p_icp/src/QualityEvaluator_Voxels.cpp
@@ -80,15 +80,13 @@ double QualityEvaluator_Voxels::evaluate(
             return 0;
         }
 
-        auto ptsG =
-            std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itG->second);
-        auto ptsL =
-            std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itL->second);
+        auto ptsG = mp2p_icp::MapToPointsMap(*itG->second);
+        auto ptsL = mp2p_icp::MapToPointsMap(*itL->second);
         ASSERT_(ptsG);
         ASSERT_(ptsL);
 
         mrpt::maps::CSimplePointsMap localTransformed;
-        localTransformed.insertAnotherMap(ptsL.get(), localPose);
+        localTransformed.insertAnotherMap(ptsL, localPose);
 
         // resize voxel grids?
         MRPT_TODO("Check against current size too, for many layers");

--- a/mp2p_icp_filters/src/FilterBoundingBox.cpp
+++ b/mp2p_icp_filters/src/FilterBoundingBox.cpp
@@ -75,11 +75,11 @@ void FilterBoundingBox::filter(mp2p_icp::metric_map_t& inOut) const
     ASSERT_(!params_.output_pointcloud_layer.empty());
 
     // Create if new: Append to existing layer, if already existed.
-    mrpt::maps::CPointsMap::Ptr outPc;
+    mrpt::maps::CPointsMap* outPc = nullptr;
     if (auto itLy = inOut.layers.find(params_.output_pointcloud_layer);
         itLy != inOut.layers.end())
     {
-        outPc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itLy->second);
+        outPc = mp2p_icp::MapToPointsMap(*itLy->second);
         if (!outPc)
             THROW_EXCEPTION_FMT(
                 "Layer '%s' must be of point cloud type.",
@@ -87,8 +87,9 @@ void FilterBoundingBox::filter(mp2p_icp::metric_map_t& inOut) const
     }
     else
     {
-        outPc = mrpt::maps::CSimplePointsMap::Create();
-        inOut.layers[params_.output_pointcloud_layer] = outPc;
+        auto newMap = mrpt::maps::CSimplePointsMap::Create();
+        outPc       = newMap.get();
+        inOut.layers[params_.output_pointcloud_layer] = newMap;
     }
 
     outPc->reserve(outPc->size() + pc.size() / 10);

--- a/mp2p_icp_filters/src/FilterDecimateVoxels.cpp
+++ b/mp2p_icp_filters/src/FilterDecimateVoxels.cpp
@@ -74,11 +74,11 @@ void FilterDecimateVoxels::filter(mp2p_icp::metric_map_t& inOut) const
     ASSERT_(!params_.output_pointcloud_layer.empty());
 
     // Create if new: Append to existing layer, if already existed.
-    mrpt::maps::CPointsMap::Ptr outPc;
+    mrpt::maps::CPointsMap* outPc = nullptr;
     if (auto itLy = inOut.layers.find(params_.output_pointcloud_layer);
         itLy != inOut.layers.end())
     {
-        outPc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itLy->second);
+        outPc = mp2p_icp::MapToPointsMap(*itLy->second);
         if (!outPc)
             THROW_EXCEPTION_FMT(
                 "Layer '%s' must be of point cloud type.",
@@ -86,16 +86,18 @@ void FilterDecimateVoxels::filter(mp2p_icp::metric_map_t& inOut) const
     }
     else
     {
-        outPc = mrpt::maps::CSimplePointsMap::Create();
-        inOut.layers[params_.output_pointcloud_layer] = outPc;
+        auto newMap = mrpt::maps::CSimplePointsMap::Create();
+        inOut.layers[params_.output_pointcloud_layer] = newMap;
+
+        outPc = newMap.get();
     }
 
     // In:
-    mrpt::maps::CPointsMap::Ptr pcPtr;
+    mrpt::maps::CPointsMap* pcPtr = nullptr;
     if (auto itLy = inOut.layers.find(params_.input_pointcloud_layer);
         itLy != inOut.layers.end())
     {
-        pcPtr = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itLy->second);
+        pcPtr = mp2p_icp::MapToPointsMap(*itLy->second);
         if (!pcPtr)
             THROW_EXCEPTION_FMT(
                 "Layer '%s' must be of point cloud type.",

--- a/mp2p_icp_map/include/mp2p_icp/metricmap.h
+++ b/mp2p_icp_map/include/mp2p_icp/metricmap.h
@@ -207,6 +207,24 @@ class metric_map_t : public mrpt::serialization::CSerializable,
     }
 };
 
+/** Function to extract the CPointsMap for any kind of
+ * CMetricMap, if there exists a conversion that makes sense for matching
+ * against it.
+ * Typically:
+ *  - Any derived type of mrpt::maps::CPointsMap: just does a dynamic_cast.
+ *  - An mrpt::maps::CVoxelMap: gets the equivalent points map with cached
+ *    occupied voxels (requires MRPT >=2.11.0).
+ *
+ * Returns an empty shared_ptr if conversion is not possible.
+ *
+ * \note The use of raw pointers here imply the lifetime of the input "map"
+ *       must be longer than that of its use within the Matcher.
+ */
+const mrpt::maps::CPointsMap* MapToPointsMap(const mrpt::maps::CMetricMap& map);
+
+/// \overload for non-const input maps.
+mrpt::maps::CPointsMap* MapToPointsMap(mrpt::maps::CMetricMap& map);
+
 /** A bit field with a bool for each metric_map_t entity.
  *  Useful, for example, to keep track of which elements have already been
  * matched during the matching pipeline.
@@ -230,8 +248,7 @@ struct pointcloud_bitfield_t
         for (const auto& kv : pc.layers)
         {
             ASSERT_(kv.second);
-            auto pts =
-                std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(kv.second);
+            auto pts = mp2p_icp::MapToPointsMap(*kv.second);
             if (!pts) continue;
             point_layers[kv.first].assign(pts->size(), initBoolValue);
         }

--- a/mp2p_icp_map/include/mp2p_icp/metricmap.h
+++ b/mp2p_icp_map/include/mp2p_icp/metricmap.h
@@ -173,9 +173,9 @@ class metric_map_t : public mrpt::serialization::CSerializable,
         mrpt::opengl::CSetOfObjects& o, const render_params_points_t& p) const;
 
     /** Used inside get_visualization_points(), renders points only. */
-    static void get_visualization_point_layer(
+    static void get_visualization_map_layer(
         mrpt::opengl::CSetOfObjects& o, const render_params_point_layer_t& p,
-        const mrpt::maps::CPointsMap::Ptr& pts);
+        const mrpt::maps::CMetricMap::Ptr& map);
 
     /** Returns a shared_ptr to this object, if it was already created initially
      * as a shared_ptr, or an empty pointer otherwise.

--- a/mp2p_icp_map/include/mp2p_icp/render_params.h
+++ b/mp2p_icp_map/include/mp2p_icp/render_params.h
@@ -91,6 +91,8 @@ struct render_params_point_layer_t
     /** If set, it overrides `color` and defines a "recolorize by coordinate"
      * mode. */
     std::optional<color_mode_t> colorMode;
+
+    bool render_voxelmaps_as_points = false;
 };
 
 /** Used in metric_map_t::get_visualization() */

--- a/mp2p_icp_map/src/metricmap.cpp
+++ b/mp2p_icp_map/src/metricmap.cpp
@@ -22,6 +22,11 @@
 #include <mrpt/serialization/optional_serialization.h>
 #include <mrpt/serialization/stl_serialization.h>
 #include <mrpt/version.h>
+// voxelmaps?
+#if MRPT_VERSION >= 0x020b00
+#include <mrpt/maps/CVoxelMap.h>
+#include <mrpt/maps/CVoxelMapRGB.h>
+#endif
 
 #include <algorithm>
 #include <iterator>
@@ -515,4 +520,46 @@ mrpt::maps::CPointsMap::Ptr metric_map_t::point_layer(
             name.c_str(), ptr->GetRuntimeClass()->className);
 
     return ret;
+}
+
+const mrpt::maps::CPointsMap* mp2p_icp::MapToPointsMap(
+    const mrpt::maps::CMetricMap& map)
+{
+    if (auto ptsMap = dynamic_cast<const mrpt::maps::CPointsMap*>(&map); ptsMap)
+    {
+        return ptsMap;
+    }
+#if MRPT_VERSION >= 0x020b00
+    if (auto voxelMap = dynamic_cast<const mrpt::maps::CVoxelMap*>(&map);
+        voxelMap)
+    {
+        return voxelMap->getOccupiedVoxels().get();
+    }
+    if (auto voxelRGBMap = dynamic_cast<const mrpt::maps::CVoxelMapRGB*>(&map);
+        voxelRGBMap)
+    {
+        return voxelRGBMap->getOccupiedVoxels().get();
+    }
+#endif
+    return {};
+}
+
+mrpt::maps::CPointsMap* mp2p_icp::MapToPointsMap(mrpt::maps::CMetricMap& map)
+{
+    if (auto ptsMap = dynamic_cast<mrpt::maps::CPointsMap*>(&map); ptsMap)
+    {
+        return ptsMap;
+    }
+#if MRPT_VERSION >= 0x020b00
+    if (auto voxelMap = dynamic_cast<mrpt::maps::CVoxelMap*>(&map); voxelMap)
+    {
+        return voxelMap->getOccupiedVoxels().get();
+    }
+    if (auto voxelRGBMap = dynamic_cast<mrpt::maps::CVoxelMapRGB*>(&map);
+        voxelRGBMap)
+    {
+        return voxelRGBMap->getOccupiedVoxels().get();
+    }
+#endif
+    return {};
 }

--- a/mp2p_icp_map/src/metricmap.cpp
+++ b/mp2p_icp_map/src/metricmap.cpp
@@ -179,10 +179,7 @@ void metric_map_t::get_visualization_points(
                     "exist in this metric_map_t object",
                     kv.first.c_str());
 
-            get_visualization_point_layer(
-                o, kv.second,
-                std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(
-                    itPts->second));
+            get_visualization_map_layer(o, kv.second, itPts->second);
         }
     }
     else
@@ -190,23 +187,38 @@ void metric_map_t::get_visualization_points(
         // render all layers with the same params:
         for (const auto& kv : layers)
         {
-            auto pts =
-                std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(kv.second);
-            if (!pts) continue;  // not a point cloud.
-
-            get_visualization_point_layer(o, p.allLayers, pts);
+            get_visualization_map_layer(o, p.allLayers, kv.second);
         }
     }
 
     MRPT_END
 }
 
-void metric_map_t::get_visualization_point_layer(
+void metric_map_t::get_visualization_map_layer(
     mrpt::opengl::CSetOfObjects& o, const render_params_point_layer_t& p,
-    const mrpt::maps::CPointsMap::Ptr& pts)
+    const mrpt::maps::CMetricMap::Ptr& map)
 {
-    ASSERT_(pts);
-    if (pts->empty()) return;
+    auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(map);
+
+#if MRPT_VERSION >= 0x020b00
+    auto voxelMap    = std::dynamic_pointer_cast<mrpt::maps::CVoxelMap>(map);
+    auto voxelRGBMap = std::dynamic_pointer_cast<mrpt::maps::CVoxelMapRGB>(map);
+
+    if (p.render_voxelmaps_as_points && (voxelMap || voxelRGBMap))
+    {
+        // get occupied voxel XYZ coordinates only:
+        if (voxelMap) pts = voxelMap->getOccupiedVoxels();
+        if (voxelRGBMap) pts = voxelRGBMap->getOccupiedVoxels();
+    }
+    else
+    {
+        // Render as real voxelmaps:
+        map->getVisualizationInto(o);
+        return;
+    }
+#endif
+
+    if (pts && pts->empty()) return;  // quick return if empty point cloud
 
     if (p.colorMode.has_value())
     {


### PR DESCRIPTION
To do:
- [X] Make ICP to run against voxelmaps
- [x] Update the map visualizers to show voxelmaps too.

