### PR TITLE
Fix usage of some deprecated cloud types

### DIFF
--- a/apps/mm2txt/main.cpp
+++ b/apps/mm2txt/main.cpp
@@ -193,19 +193,30 @@ void run_mm2txt()
             saveToTxt(*genxyz, filName, printHeader);
         }
 #if MRPT_VERSION < 0x030000  // <3.0.0
-        else if (auto* xyzirt = dynamic_cast<const mrpt::maps::CPointsMapXYZIRT*>(pts); xyzirt)
+        else
         {
-            xyzirt->saveXYZIRT_to_text_file(filName);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+            if (auto* xyzirt = dynamic_cast<const mrpt::maps::CPointsMapXYZIRT*>(pts); xyzirt)
+            {
+                xyzirt->saveXYZIRT_to_text_file(filName);
+            }
+            else if (auto* xyzi = dynamic_cast<const mrpt::maps::CPointsMapXYZI*>(pts); xyzi)
+            {
+                xyzi->saveXYZI_to_text_file(filName);
+            }
+            else
+            {
+                pts->save3D_to_text_file(filName);
+            }
+#pragma GCC diagnostic pop
         }
-        else if (auto* xyzi = dynamic_cast<const mrpt::maps::CPointsMapXYZI*>(pts); xyzi)
-        {
-            xyzi->saveXYZI_to_text_file(filName);
-        }
-#endif
+#else
         else
         {
             pts->save3D_to_text_file(filName);
         }
+#endif
     }
 }
 

--- a/apps/txt2mm/main.cpp
+++ b/apps/txt2mm/main.cpp
@@ -37,6 +37,11 @@
 
 const char* VALID_FORMATS = "(xyz|xyzi|xyzirt|xyzrgb|xyzrgb_normalized)";
 
+// Replicated here from CGenericPointsMap until MRPT 2.15.3 is minimum required version:
+constexpr static std::string_view POINT_FIELD_INTENSITY = "intensity";
+constexpr static std::string_view POINT_FIELD_RING_ID   = "ring";
+constexpr static std::string_view POINT_FIELD_TIMESTAMP = "t";
+
 using namespace std::string_literals;
 
 // CLI flags:
@@ -162,7 +167,7 @@ int main(int argc, char** argv)
         {
             ASSERT_GE_(nCols, 4U);
             auto pts = mrpt::maps::CGenericPointsMap::Create();
-            pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
+            pts->registerField_float(POINT_FIELD_INTENSITY);
             pts->reserve(nRows);
             if (nCols > 4)
             {
@@ -174,8 +179,7 @@ int main(int argc, char** argv)
             for (size_t i = 0; i < nRows; i++)
             {
                 pts->insertPointFast(data(i, idxX + 0), data(i, idxX + 1), data(i, idxX + 2));
-                pts->insertPointField_float(
-                    mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY, data(i, idxI));
+                pts->insertPointField_float(POINT_FIELD_INTENSITY, data(i, idxI));
             }
 
             pc = pts;
@@ -184,9 +188,9 @@ int main(int argc, char** argv)
         {
             ASSERT_GE_(nCols, 6U);
             auto pts = mrpt::maps::CGenericPointsMap::Create();
-            pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
-            pts->registerField_uint16(mrpt::maps::CPointsMap::POINT_FIELD_RING_ID);
-            pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP);
+            pts->registerField_float(POINT_FIELD_INTENSITY);
+            pts->registerField_uint16(POINT_FIELD_RING_ID);
+            pts->registerField_float(POINT_FIELD_TIMESTAMP);
             pts->reserve(nRows);
             if (nCols > 6)
             {
@@ -198,13 +202,10 @@ int main(int argc, char** argv)
             for (size_t i = 0; i < nRows; i++)
             {
                 pts->insertPointFast(data(i, idxX + 0), data(i, idxX + 1), data(i, idxX + 2));
-                pts->insertPointField_float(
-                    mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY, data(i, idxI));
+                pts->insertPointField_float(POINT_FIELD_INTENSITY, data(i, idxI));
                 pts->insertPointField_uint16(
-                    mrpt::maps::CPointsMap::POINT_FIELD_RING_ID,
-                    static_cast<uint16_t>(data(i, idxR)));
-                pts->insertPointField_float(
-                    mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP, data(i, idxT));
+                    POINT_FIELD_RING_ID, static_cast<uint16_t>(data(i, idxR)));
+                pts->insertPointField_float(POINT_FIELD_TIMESTAMP, data(i, idxT));
             }
 
             pc = pts;

--- a/apps/txt2mm/main.cpp
+++ b/apps/txt2mm/main.cpp
@@ -161,12 +161,8 @@ int main(int argc, char** argv)
         else if (format == "xyzi")
         {
             ASSERT_GE_(nCols, 4U);
-#if MRPT_VERSION >= 0x20f00  // 2.15.0
             auto pts = mrpt::maps::CGenericPointsMap::Create();
-            pts->registerField_float("intensity");
-#else
-            auto pts = mrpt::maps::CPointsMapXYZI::Create();
-#endif
+            pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
             pts->reserve(nRows);
             if (nCols > 4)
             {
@@ -178,11 +174,8 @@ int main(int argc, char** argv)
             for (size_t i = 0; i < nRows; i++)
             {
                 pts->insertPointFast(data(i, idxX + 0), data(i, idxX + 1), data(i, idxX + 2));
-#if MRPT_VERSION >= 0x20f00  // 2.15.0
-                pts->insertPointField_float("intensity", data(i, idxI));
-#else
-                pts->insertPointField_Intensity(data(i, idxI));
-#endif
+                pts->insertPointField_float(
+                    mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY, data(i, idxI));
             }
 
             pc = pts;
@@ -190,14 +183,10 @@ int main(int argc, char** argv)
         else if (format == "xyzirt")
         {
             ASSERT_GE_(nCols, 6U);
-#if MRPT_VERSION >= 0x20f00  // 2.15.0
             auto pts = mrpt::maps::CGenericPointsMap::Create();
-            pts->registerField_float("intensity");
-            pts->registerField_uint16("ring");
-            pts->registerField_float("timestamp");
-#else
-            auto pts = mrpt::maps::CPointsMapXYZI::Create();
-#endif
+            pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
+            pts->registerField_uint16(mrpt::maps::CPointsMap::POINT_FIELD_RING_ID);
+            pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP);
             pts->reserve(nRows);
             if (nCols > 6)
             {
@@ -209,15 +198,13 @@ int main(int argc, char** argv)
             for (size_t i = 0; i < nRows; i++)
             {
                 pts->insertPointFast(data(i, idxX + 0), data(i, idxX + 1), data(i, idxX + 2));
-#if MRPT_VERSION >= 0x20f00  // 2.15.0
-                pts->insertPointField_float("intensity", data(i, idxI));
-                pts->insertPointField_uint16("ring", static_cast<uint16_t>(data(i, idxR)));
-                pts->insertPointField_float("timestamp", data(i, idxT));
-#else
-                pts->insertPointField_Intensity(data(i, idxI));
-                pts->insertPointField_Ring(data(i, idxR));
-                pts->insertPointField_Timestamp(data(i, idxT));
-#endif
+                pts->insertPointField_float(
+                    mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY, data(i, idxI));
+                pts->insertPointField_uint16(
+                    mrpt::maps::CPointsMap::POINT_FIELD_RING_ID,
+                    static_cast<uint16_t>(data(i, idxR)));
+                pts->insertPointField_float(
+                    mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP, data(i, idxT));
             }
 
             pc = pts;

--- a/mp2p_icp_filters/include/mp2p_icp_filters/FilterBase.h
+++ b/mp2p_icp_filters/include/mp2p_icp_filters/FilterBase.h
@@ -29,6 +29,7 @@
 #include <mrpt/obs/obs_frwds.h>
 #include <mrpt/rtti/CObject.h>
 #include <mrpt/system/COutputLogger.h>
+#include <mrpt/version.h>
 
 namespace mrpt::system
 {
@@ -116,6 +117,18 @@ void apply_filter_pipeline(
 [[nodiscard]] FilterPipeline filter_pipeline_from_yaml_file(
     const std::string&                  filename,
     const mrpt::system::VerbosityLevel& vLevel = mrpt::system::LVL_INFO);
+
+// For convenience, define shortcut names for common point cloud field names:
+#if MRPT_VERSION >= 0x20f03  // 2.15.3
+constexpr auto POINT_FIELD_INTENSITY = mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY;
+constexpr auto POINT_FIELD_RING_ID   = mrpt::maps::CPointsMap::POINT_FIELD_RING_ID;
+constexpr auto POINT_FIELD_TIMESTAMP = mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP;
+#else
+// Define here locally, until MRPT 2.15.3 is the minimum required version:
+constexpr static std::string_view POINT_FIELD_INTENSITY = "intensity";
+constexpr static std::string_view POINT_FIELD_RING_ID   = "ring";
+constexpr static std::string_view POINT_FIELD_TIMESTAMP = "t";
+#endif
 
 /** @} */
 

--- a/mp2p_icp_filters/src/FilterByIntensity.cpp
+++ b/mp2p_icp_filters/src/FilterByIntensity.cpp
@@ -109,11 +109,9 @@ void FilterByIntensity::filter(mp2p_icp::metric_map_t& inOut) const
 
     const auto& xs = pc.getPointsBufferRef_x();
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
-    const auto* ptrI = pc.getPointsBufferRef_float_field("intensity");
-#else
-    const auto* ptrI = pc.getPointsBufferRef_intensity();
-#endif
+    const auto* ptrI =
+        pc.getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
+
     if (!ptrI || ptrI->empty())
     {
         THROW_EXCEPTION_FMT(

--- a/mp2p_icp_filters/src/FilterByIntensity.cpp
+++ b/mp2p_icp_filters/src/FilterByIntensity.cpp
@@ -109,8 +109,7 @@ void FilterByIntensity::filter(mp2p_icp::metric_map_t& inOut) const
 
     const auto& xs = pc.getPointsBufferRef_x();
 
-    const auto* ptrI =
-        pc.getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
+    const auto* ptrI = pc.getPointsBufferRef_float_field(POINT_FIELD_INTENSITY);
 
     if (!ptrI || ptrI->empty())
     {

--- a/mp2p_icp_filters/src/FilterNormalizeIntensity.cpp
+++ b/mp2p_icp_filters/src/FilterNormalizeIntensity.cpp
@@ -62,11 +62,7 @@ void FilterNormalizeIntensity::filter(mp2p_icp::metric_map_t& inOut) const
 
     auto& pc = *pcPtr;
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
-    auto* IsPtr = pc.getPointsBufferRef_float_field("intensity");
-#else
-    auto* IsPtr = pc.getPointsBufferRef_intensity();
-#endif
+    auto* IsPtr = pc.getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
 
     ASSERTMSG_(
         IsPtr != nullptr,

--- a/mp2p_icp_filters/src/FilterNormalizeIntensity.cpp
+++ b/mp2p_icp_filters/src/FilterNormalizeIntensity.cpp
@@ -62,7 +62,7 @@ void FilterNormalizeIntensity::filter(mp2p_icp::metric_map_t& inOut) const
 
     auto& pc = *pcPtr;
 
-    auto* IsPtr = pc.getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
+    auto* IsPtr = pc.getPointsBufferRef_float_field(POINT_FIELD_INTENSITY);
 
     ASSERTMSG_(
         IsPtr != nullptr,

--- a/mp2p_icp_filters/src/Generator.cpp
+++ b/mp2p_icp_filters/src/Generator.cpp
@@ -30,8 +30,8 @@
 #include <mrpt/config/CConfigFileMemory.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/get_env.h>
+#include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/maps/CMultiMetricMap.h>
-#include <mrpt/maps/CPointsMapXYZIRT.h>
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/CObservation3DRangeScan.h>
@@ -185,13 +185,13 @@ bool Generator::filterVelodyneScan(  //
 {
     mrpt::maps::CPointsMap::Ptr outPc = GetOrCreatePointLayer(
         out, params.target_layer, false /*does not allow empty name*/,
-        "mrpt::maps::CPointsMapXYZIRT" /* creation class if not existing */);
+        "mrpt::maps::CGenericPointsMap" /* creation class if not existing */);
     ASSERT_(outPc);
 
-    auto m = std::dynamic_pointer_cast<mrpt::maps::CPointsMapXYZIRT>(outPc);
+    auto m = std::dynamic_pointer_cast<mrpt::maps::CGenericPointsMap>(outPc);
     ASSERTMSG_(
         m,
-        "Output layer must be of type mrpt::maps::CPointsMapXYZIRT for the "
+        "Output layer must be of type mrpt::maps::CGenericPointsMap for the "
         "specialized filterVelodyneScan() generator.");
 
     m->insertObservation(pc, robotPose);

--- a/tests/test-mp2p_FilterByExpression.cpp
+++ b/tests/test-mp2p_FilterByExpression.cpp
@@ -54,7 +54,7 @@ void FilterByExpression_SpatialFiltering()
 
 void FilterByExpression_IntensityAndLogic()
 {
-    constexpr auto INTENSITY = mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY;
+    constexpr auto INTENSITY = POINT_FIELD_INTENSITY;
 
     auto pc = mrpt::maps::CGenericPointsMap::Create();
     pc->registerField_float(INTENSITY);
@@ -88,12 +88,12 @@ void FilterByExpression_IntensityAndLogic()
 void FilterByExpression_CustomFields()
 {
     auto pc = mrpt::maps::CGenericPointsMap::Create();
-    pc->registerField_uint16(mrpt::maps::CPointsMap::POINT_FIELD_RING_ID);
+    pc->registerField_uint16(POINT_FIELD_RING_ID);
     pc->registerField_uint8("SEMANTICS");
     pc->registerField_double("latitude");
 
     pc->insertPoint(0, 0, 0);
-    pc->insertPointField_uint16(mrpt::maps::CPointsMap::POINT_FIELD_RING_ID, 32);
+    pc->insertPointField_uint16(POINT_FIELD_RING_ID, 32);
     pc->insertPointField_uint8("SEMANTICS", 12);
     pc->insertPointField_double("latitude", 3.14);
 

--- a/tests/test-mp2p_FilterDecimateVoxels.cpp
+++ b/tests/test-mp2p_FilterDecimateVoxels.cpp
@@ -32,7 +32,7 @@ using namespace mp2p_icp;
 mrpt::maps::CPointsMap::Ptr createTestPoints(size_t n_x, size_t n_y)
 {
     auto pc = mrpt::maps::CGenericPointsMap::Create();
-    pc->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
+    pc->registerField_float(POINT_FIELD_INTENSITY);
 
     // Create a 2D grid of points, 10x10. Each point has a small, known Z-offset.
     for (size_t i = 0; i < n_x; ++i)
@@ -45,7 +45,7 @@ mrpt::maps::CPointsMap::Ptr createTestPoints(size_t n_x, size_t n_y)
             float intensity = static_cast<float>(i * n_y + j);
 
             pc->insertPointFast(x, y, z);
-            pc->insertPointField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY, intensity);
+            pc->insertPointField_float(POINT_FIELD_INTENSITY, intensity);
         }
     }
     return pc;
@@ -194,7 +194,7 @@ void test_decimate_method(
     }
 
     // The output should also have intensity.
-    ASSERT_(output_pc->hasPointField(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY));
+    ASSERT_(output_pc->hasPointField(POINT_FIELD_INTENSITY));
     std::cout << " Success ✅." << std::endl;
 }
 

--- a/tests/test-mp2p_FilterDecimateVoxels.cpp
+++ b/tests/test-mp2p_FilterDecimateVoxels.cpp
@@ -20,7 +20,7 @@
 
 #include <mp2p_icp/metricmap.h>
 #include <mp2p_icp_filters/FilterDecimateVoxels.h>
-#include <mrpt/maps/CPointsMapXYZI.h>
+#include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/math/ops_containers.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/version.h>
@@ -31,7 +31,9 @@ using namespace mp2p_icp;
 // Helper to create a consistent point map for testing
 mrpt::maps::CPointsMap::Ptr createTestPoints(size_t n_x, size_t n_y)
 {
-    auto pc = mrpt::maps::CPointsMapXYZI::Create();
+    auto pc = mrpt::maps::CGenericPointsMap::Create();
+    pc->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
+
     // Create a 2D grid of points, 10x10. Each point has a small, known Z-offset.
     for (size_t i = 0; i < n_x; ++i)
     {
@@ -43,12 +45,7 @@ mrpt::maps::CPointsMap::Ptr createTestPoints(size_t n_x, size_t n_y)
             float intensity = static_cast<float>(i * n_y + j);
 
             pc->insertPointFast(x, y, z);
-#if MRPT_VERSION >= 0x020f00
-            pc->insertPointField_float(
-                mrpt::maps::CPointsMapXYZI::POINT_FIELD_INTENSITY, intensity);
-#else
-            pc->insertPointField_Intensity(intensity);
-#endif
+            pc->insertPointField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY, intensity);
         }
     }
     return pc;
@@ -196,10 +193,8 @@ void test_decimate_method(
         ASSERT_NEAR_(bb.min.z, 0.0f, 0.2f);
     }
 
-    // Since we created CPointsMapXYZI, the output should also have intensity.
-#if MRPT_VERSION >= 0x020f00
-    ASSERT_(output_pc->hasPointField(mrpt::maps::CPointsMapXYZI::POINT_FIELD_INTENSITY));
-#endif
+    // The output should also have intensity.
+    ASSERT_(output_pc->hasPointField(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY));
     std::cout << " Success ✅." << std::endl;
 }
 

--- a/tests/test-mp2p_Filters.cpp
+++ b/tests/test-mp2p_Filters.cpp
@@ -38,7 +38,7 @@ using namespace mp2p_icp;
 namespace
 {
 
-constexpr std::string_view INTENSITY = "intensity";
+constexpr std::string_view INTENSITY = mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY;
 
 // Helper to create a test point cloud with known positions and intensities
 mrpt::maps::CPointsMap::Ptr createTestPointsWithIntensity(
@@ -204,10 +204,12 @@ void test_FilterByIntensity_ThreeLayers()
     ASSERT_EQUAL_(low_pc->size() + mid_pc->size() + high_pc->size(), input_pc->size());
 
     // Verify intensity ranges
-#if MRPT_VERSION >= 0x020f00
-    const auto* ptrI_low  = low_pc->getPointsBufferRef_float_field("intensity");
-    const auto* ptrI_mid  = mid_pc->getPointsBufferRef_float_field("intensity");
-    const auto* ptrI_high = high_pc->getPointsBufferRef_float_field("intensity");
+    const auto* ptrI_low =
+        low_pc->getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
+    const auto* ptrI_mid =
+        mid_pc->getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
+    const auto* ptrI_high =
+        high_pc->getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
 
     if (ptrI_low)
     {
@@ -233,7 +235,6 @@ void test_FilterByIntensity_ThreeLayers()
             ASSERT_GT_(I, 0.7f);
         }
     }
-#endif
 
     std::cout << "Success ✅" << std::endl;
 }
@@ -614,7 +615,7 @@ void test_FilterMLS_DistinctCloudProjection()
     {
         avg_z += z;
     }
-    avg_z /= mls_pc->size();
+    avg_z /= static_cast<double>(mls_pc->size());
 
     // Average z should be closer to 2.0 than the distinct cloud's z=3.0
     ASSERT_LT_(std::abs(avg_z - 2.0f), 0.5f);

--- a/tests/test-mp2p_Filters.cpp
+++ b/tests/test-mp2p_Filters.cpp
@@ -38,7 +38,7 @@ using namespace mp2p_icp;
 namespace
 {
 
-constexpr std::string_view INTENSITY = mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY;
+constexpr std::string_view INTENSITY = POINT_FIELD_INTENSITY;
 
 // Helper to create a test point cloud with known positions and intensities
 mrpt::maps::CPointsMap::Ptr createTestPointsWithIntensity(
@@ -204,12 +204,9 @@ void test_FilterByIntensity_ThreeLayers()
     ASSERT_EQUAL_(low_pc->size() + mid_pc->size() + high_pc->size(), input_pc->size());
 
     // Verify intensity ranges
-    const auto* ptrI_low =
-        low_pc->getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
-    const auto* ptrI_mid =
-        mid_pc->getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
-    const auto* ptrI_high =
-        high_pc->getPointsBufferRef_float_field(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
+    const auto* ptrI_low  = low_pc->getPointsBufferRef_float_field(POINT_FIELD_INTENSITY);
+    const auto* ptrI_mid  = mid_pc->getPointsBufferRef_float_field(POINT_FIELD_INTENSITY);
+    const auto* ptrI_high = high_pc->getPointsBufferRef_float_field(POINT_FIELD_INTENSITY);
 
     if (ptrI_low)
     {

--- a/tests/test-mp2p_deskew.cpp
+++ b/tests/test-mp2p_deskew.cpp
@@ -411,8 +411,10 @@ mrpt::maps::CSimplePointsMap simulate_gt_local_points(
             return fields;
         }();
 
-        ASSERT_EQUAL_(outFields.count("intensity"), 1);
-        ASSERT_EQUAL_(outFields.count("t"), 1);
+        ASSERT_EQUAL_(
+            outFields.count(std::string(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY)), 1);
+        ASSERT_EQUAL_(
+            outFields.count(std::string(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP)), 1);
 
         for (size_t i = 0; i < deskewedPts->size(); i++)
         {
@@ -556,9 +558,8 @@ mrpt::maps::CSimplePointsMap simulate_gt_local_points(
     }  // end for each timestep
 
     // Now, reconstruct the points within the SM:
-    const auto sm2mmPipeline = mrpt::containers::yaml::FromText(
-        mrpt::format(
-            R"yaml(
+    const auto sm2mmPipeline = mrpt::containers::yaml::FromText(mrpt::format(
+        R"yaml(
 # --------------------------------------------------------
 # 1) Generator (observation -> local frame metric maps)
 # --------------------------------------------------------
@@ -595,7 +596,7 @@ filters:
       # one or more layers to remove
       pointcloud_layer_to_remove: ["raw"]
     )yaml",
-            mrpt::typemeta::enum2str(p.deskew_method).c_str(), p.outputMapClass.c_str()));
+        mrpt::typemeta::enum2str(p.deskew_method).c_str(), p.outputMapClass.c_str()));
 
     mp2p_icp::metric_map_t            mm;
     mp2p_icp_filters::sm2mm_options_t sm2mm_opts;
@@ -655,7 +656,11 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 #endif
 
         const std::vector<std::string> outputMapClasses = {
-            "mrpt::maps::CPointsMapXYZIRT", "mrpt::maps::CGenericPointsMap"};
+#if MRPT_VERSION < 0x030000
+            "mrpt::maps::CPointsMapXYZIRT",
+#endif
+            "mrpt::maps::CGenericPointsMap"
+        };
 
         const std::vector<std::pair<float, float>> test_velocities = {
             {0.0f, 1e-6f},  // stationary

--- a/tests/test-mp2p_deskew.cpp
+++ b/tests/test-mp2p_deskew.cpp
@@ -242,9 +242,11 @@ mrpt::maps::CGenericPointsMap::Ptr simulate_skewed_points(
     const mrpt::Clock::time_point& stamp, const mrpt::poses::CPose3DInterpolator& gtKeyframes,
     const std::vector<mrpt::math::TPoint3D>& gtPoints, const double lidar_scan_period)
 {
+    using namespace mp2p_icp_filters;
+
     auto pts = mrpt::maps::CGenericPointsMap::Create();
-    pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP);
-    pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
+    pts->registerField_float(POINT_FIELD_TIMESTAMP);
+    pts->registerField_float(POINT_FIELD_INTENSITY);
 
     // Simulate a scan where each point is acquired at a different time during the scan period.
     // Assume points are acquired sequentially over [stamp, stamp + lidar_scan_period)
@@ -271,9 +273,8 @@ mrpt::maps::CGenericPointsMap::Ptr simulate_skewed_points(
         // Add to map, with time offset
         pts->insertPointFast(pt_local.x, pt_local.y, pt_local.z);
 
-        pts->insertPointField_float(
-            mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP, static_cast<float>(rel_time));
-        pts->insertPointField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY, 1.0f);
+        pts->insertPointField_float(POINT_FIELD_TIMESTAMP, static_cast<float>(rel_time));
+        pts->insertPointField_float(POINT_FIELD_INTENSITY, 1.0f);
 
 #if 0
         std::cout << "PT[" << i << "] x: " << pt_local.x << ", y: " << pt_local.y
@@ -300,6 +301,8 @@ mrpt::maps::CSimplePointsMap simulate_gt_local_points(
 // === DESKEW TEST ===
 [[nodiscard]] SimulationResult run_deskew_test(const SimulationParams& p)
 {
+    using namespace mp2p_icp_filters;
+
     // Generate test data:
     const auto gtPoints = create_gt_points(p);
 
@@ -411,10 +414,8 @@ mrpt::maps::CSimplePointsMap simulate_gt_local_points(
             return fields;
         }();
 
-        ASSERT_EQUAL_(
-            outFields.count(std::string(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY)), 1);
-        ASSERT_EQUAL_(
-            outFields.count(std::string(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP)), 1);
+        ASSERT_EQUAL_(outFields.count(std::string(POINT_FIELD_INTENSITY)), 1);
+        ASSERT_EQUAL_(outFields.count(std::string(POINT_FIELD_TIMESTAMP)), 1);
 
         for (size_t i = 0; i < deskewedPts->size(); i++)
         {
@@ -443,6 +444,8 @@ mrpt::maps::CSimplePointsMap simulate_gt_local_points(
 // === DESKEW TEST VIA SM2MM  ===
 [[nodiscard]] SimulationResult run_deskew_in_sm2mm_test(const SimulationParams& p)
 {
+    using namespace mp2p_icp_filters;
+
     // Generate test data:
     const auto gtPoints = create_gt_points(p);
 
@@ -621,8 +624,8 @@ filters:
         return fields;
     }();
 
-    ASSERT_EQUAL_(outFields.count(std::string(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY)), 1);
-    ASSERT_EQUAL_(outFields.count(std::string(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP)), 1);
+    ASSERT_EQUAL_(outFields.count(std::string(POINT_FIELD_INTENSITY)), 1);
+    ASSERT_EQUAL_(outFields.count(std::string(POINT_FIELD_TIMESTAMP)), 1);
 
     for (size_t i = 0; i < deskewedPts->size(); i++)
     {

--- a/tests/test-mp2p_deskew.cpp
+++ b/tests/test-mp2p_deskew.cpp
@@ -22,7 +22,7 @@
 #include <mp2p_icp/metricmap.h>
 #include <mp2p_icp_filters/FilterDeskew.h>
 #include <mp2p_icp_filters/sm2mm.h>
-#include <mrpt/maps/CPointsMapXYZIRT.h>
+#include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/math/TPoint3D.h>
 #include <mrpt/math/TTwist3D.h>
@@ -47,7 +47,7 @@ struct SimulationParams
     mp2p_icp_filters::MotionCompensationMethod deskew_method =
         mp2p_icp_filters::MotionCompensationMethod::None;
 
-    std::string outputMapClass = "mrpt::maps::CPointsMapXYZIRT";
+    std::string outputMapClass = "mrpt::maps::CGenericPointsMap";
 };
 
 struct SimulationResult
@@ -238,11 +238,13 @@ Scenario simulate_scenario(const SimulationParams& p)
     return s;
 }
 
-mrpt::maps::CPointsMapXYZIRT::Ptr simulate_skewed_points(
+mrpt::maps::CGenericPointsMap::Ptr simulate_skewed_points(
     const mrpt::Clock::time_point& stamp, const mrpt::poses::CPose3DInterpolator& gtKeyframes,
     const std::vector<mrpt::math::TPoint3D>& gtPoints, const double lidar_scan_period)
 {
-    auto pts = mrpt::maps::CPointsMapXYZIRT::Create();
+    auto pts = mrpt::maps::CGenericPointsMap::Create();
+    pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP);
+    pts->registerField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY);
 
     // Simulate a scan where each point is acquired at a different time during the scan period.
     // Assume points are acquired sequentially over [stamp, stamp + lidar_scan_period)
@@ -269,11 +271,9 @@ mrpt::maps::CPointsMapXYZIRT::Ptr simulate_skewed_points(
         // Add to map, with time offset
         pts->insertPointFast(pt_local.x, pt_local.y, pt_local.z);
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
-        pts->insertPointField_float("t", static_cast<float>(rel_time));
-#else
-        pts->insertPointField_Timestamp(static_cast<float>(rel_time));
-#endif
+        pts->insertPointField_float(
+            mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP, static_cast<float>(rel_time));
+        pts->insertPointField_float(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY, 1.0f);
 
 #if 0
         std::cout << "PT[" << i << "] x: " << pt_local.x << ", y: " << pt_local.y
@@ -556,8 +556,9 @@ mrpt::maps::CSimplePointsMap simulate_gt_local_points(
     }  // end for each timestep
 
     // Now, reconstruct the points within the SM:
-    const auto sm2mmPipeline = mrpt::containers::yaml::FromText(mrpt::format(
-        R"yaml(
+    const auto sm2mmPipeline = mrpt::containers::yaml::FromText(
+        mrpt::format(
+            R"yaml(
 # --------------------------------------------------------
 # 1) Generator (observation -> local frame metric maps)
 # --------------------------------------------------------
@@ -594,7 +595,7 @@ filters:
       # one or more layers to remove
       pointcloud_layer_to_remove: ["raw"]
     )yaml",
-        mrpt::typemeta::enum2str(p.deskew_method).c_str(), p.outputMapClass.c_str()));
+            mrpt::typemeta::enum2str(p.deskew_method).c_str(), p.outputMapClass.c_str()));
 
     mp2p_icp::metric_map_t            mm;
     mp2p_icp_filters::sm2mm_options_t sm2mm_opts;
@@ -619,8 +620,8 @@ filters:
         return fields;
     }();
 
-    ASSERT_EQUAL_(outFields.count("intensity"), 1);
-    ASSERT_EQUAL_(outFields.count("t"), 1);
+    ASSERT_EQUAL_(outFields.count(std::string(mrpt::maps::CPointsMap::POINT_FIELD_INTENSITY)), 1);
+    ASSERT_EQUAL_(outFields.count(std::string(mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP)), 1);
 
     for (size_t i = 0; i < deskewedPts->size(); i++)
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switched tests to a generic point-cloud map and standardized field identifiers (intensity, timestamp, ring) for consistent creation and validation.

* **Apps**
  * Unified import/export handling for various point formats with a consolidated fallback path for unknown point types.

* **Filters**
  * Simplified intensity access and normalized point insertion to use unified field identifiers and a consistent insertion pathway.

* **Chores**
  * Added centralized public constants for common point-field names to unify usage across the project.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->