### PR TITLE
mm2txt and mm2ply now have a --export-fields flag

### DIFF
--- a/apps/mm2ply/README.md
+++ b/apps/mm2ply/README.md
@@ -9,6 +9,7 @@ A command-line tool to export the layers of a MOLA metric map (*.mm) file as PLY
 ## Features
 
 - Exports all point cloud layers from a metric map file
+- Selectively exports specific fields in a custom order
 - Supports both ASCII and binary PLY formats
 - Preserves all point fields (coordinates, colors, intensities, etc.)
 - Automatic field name mapping for standard color attributes
@@ -21,7 +22,7 @@ This tool is built as part of the MOLA framework. Please refer to the [MOLA docu
 ## Usage
 
 ```bash
-mm2ply -i <input.mm> [-o <output_prefix>] [-b]
+mm2ply -i <input.mm> [-o <output_prefix>] [-b] [--export-fields <field1,field2,...>]
 ```
 
 ### Arguments
@@ -29,6 +30,7 @@ mm2ply -i <input.mm> [-o <output_prefix>] [-b]
 - `-i, --input <file.mm>` (required): Input metric map file
 - `-o, --output <prefix>` (optional): Prefix for output PLY files. If not specified, uses the input filename without extension
 - `-b, --binary` (optional): Export in binary format instead of ASCII (default: ASCII)
+- `--export-fields <field1,field2,...>` (optional): Comma-separated list of fields to export in the specified order. If not provided, all available fields will be exported. Spaces around commas are allowed
 
 ### Examples
 
@@ -50,6 +52,24 @@ Export in binary format for smaller file sizes:
 mm2ply -i mymap.mm -b
 ```
 
+Export only specific fields in a custom order:
+
+```bash
+mm2ply -i mymap.mm --export-fields "x,y,z,intensity"
+```
+
+Export selected fields in binary format:
+
+```bash
+mm2ply -i mymap.mm -b --export-fields "x, y, z, color_r, color_g, color_b"
+```
+
+Export only 2D coordinates and intensity:
+
+```bash
+mm2ply -i mymap.mm --export-fields "x,y,intensity"
+```
+
 ## Output
 
 The tool creates separate PLY files for each point cloud layer in the metric map. Files are named using the pattern:
@@ -62,14 +82,26 @@ For example, if your map contains layers named "raw" and "filtered", you'll get:
 - `mymap_raw.ply`
 - `mymap_filtered.ply`
 
+## Field Selection
+
+When using the `--export-fields` option:
+
+- Fields must be specified as a comma-separated list
+- Spaces around commas are allowed (e.g., `"x, y, z"` or `"x,y,z"`)
+- Fields will be exported in the exact order specified
+- All specified fields must exist in the point cloud, or an error will be raised
+- The tool validates field availability and reports available fields if a requested field is not found
+- Color fields (`color_r`, `color_g`, `color_b`) are automatically mapped to PLY standard names (`red`, `green`, `blue`) in the output file
+
 ## Supported Point Fields
 
 The tool automatically exports all point attributes, including:
 
 - **Coordinates**: x, y, z (float)
 - **Colors**: Automatically maps `color_r/color_rf` → `red`, `color_g/color_gf` → `green`, `color_b/color_bf` → `blue`
-- **Custom float fields**: Exported as float properties
-- **Custom double fields**: Exported as double properties
-- **Custom uint16 fields**: Exported as ushort properties
-- **Custom uint8 fields**: Exported as uchar properties
+- **Custom float fields**: Exported as float properties (e.g., intensity, normals, curvature)
+- **Custom double fields**: Exported as double properties (e.g., time, timestamps) (MRPT ≥ 2.15.3)
+- **Custom uint16 fields**: Exported as ushort properties (e.g., ring, color channels) (MRPT ≥ 2.15.3)
+- **Custom uint8 fields**: Exported as uchar properties (MRPT ≥ 2.15.3)
 
+The specific fields exported depend on the point cloud type in each layer. Use `--export-fields` to select only the fields you need.

--- a/apps/mm2txt/README.md
+++ b/apps/mm2txt/README.md
@@ -1,4 +1,137 @@
 # mm2txt
 
-A CLI tool to export the layers of a metric map (`*.mm`) as CSV/TXT files.
+A command-line tool to export the layers of a MOLA metric map (*.mm) file as CSV/TXT files.
 
+## Overview
+
+`mm2txt` is part of the MOLA project. It converts point cloud layers from metric map files into human-readable text format, making it easy to process and analyze point cloud data in spreadsheet applications, scripting languages, or custom data processing pipelines.
+
+## Features
+
+- Exports all or selected point cloud layers from a metric map file
+- Selectively exports specific fields in a custom order
+- Automatically detects and exports all point fields (coordinates, intensities, colors, timestamps, etc.)
+- Generates header row with field names for easy data parsing
+- Supports multiple point cloud types (CGenericPointsMap, CPointsMapXYZI, CPointsMapXYZIRT)
+- Space-delimited format compatible with most data analysis tools
+- Selective layer export for processing only the data you need
+
+## Installation
+
+This tool is built as part of the MOLA framework. Please refer to the [MOLA documentation](https://github.com/MOLAorg/mola) for build and installation instructions.
+
+## Usage
+
+```bash
+mm2txt <input.mm> [-l <layer_name>] [--export-fields <field1,field2,...>]
+```
+
+### Arguments
+
+- `input` (required): Input metric map file (*.mm)
+- `-l, --layer <name>` (optional): Layer to export. If not provided, all layers will be exported. This argument can appear multiple times to export specific layers
+- `--export-fields <field1,field2,...>` (optional): Comma-separated list of fields to export in the specified order. If not provided, all available fields will be exported. Spaces around commas are allowed
+
+### Examples
+
+Export all layers from a metric map:
+
+```bash
+mm2txt mymap.mm
+```
+
+Export only specific layers:
+
+```bash
+mm2txt mymap.mm -l raw -l filtered
+```
+
+Export a single layer:
+
+```bash
+mm2txt mymap.mm -l global
+```
+
+Export only specific fields in a custom order:
+
+```bash
+mm2txt mymap.mm --export-fields "x,y,z,intensity"
+```
+
+Export selected fields from specific layers:
+
+```bash
+mm2txt mymap.mm -l raw --export-fields "x, y, z, ring, time"
+```
+
+Export only 2D coordinates and intensity:
+
+```bash
+mm2txt mymap.mm --export-fields "x,y,intensity"
+```
+
+## Output
+
+The tool creates separate TXT files for each exported point cloud layer. Files are named using the pattern:
+
+```
+<input_filename>_<layer_name>.txt
+```
+
+For example, if your map file is `mymap.mm` and contains layers named "raw" and "filtered", you'll get:
+- `mymap.mm_raw.txt`
+- `mymap.mm_filtered.txt`
+
+## File Format
+
+Each output file is a space-delimited text file with:
+
+- **Header row**: Column names for all point fields
+- **Data rows**: One row per point, with values for each field
+
+Example output (all fields):
+
+```
+x y z intensity ring time
+1.234 5.678 0.123 45.6 0 12345.678
+2.345 6.789 0.234 67.8 1 12345.679
+...
+```
+
+Example output (selected fields):
+
+```
+x y z intensity
+1.234 5.678 0.123 45.6
+2.345 6.789 0.234 67.8
+...
+```
+
+## Field Selection
+
+When using the `--export-fields` option:
+
+- Fields must be specified as a comma-separated list
+- Spaces around commas are allowed (e.g., `"x, y, z"` or `"x,y,z"`)
+- Fields will be exported in the exact order specified
+- All specified fields must exist in the point cloud, or an error will be raised
+- The tool validates field availability and reports available fields if a requested field is not found
+- This option is only supported for **CGenericPointsMap** point clouds; for legacy types (CPointsMapXYZI, CPointsMapXYZIRT), all fields are exported with a warning
+
+## Supported Point Fields
+
+The tool automatically exports all available point attributes:
+
+- **Coordinates**: x, y, z (mandatory, float)
+- **Float fields**: intensity, normals, curvature, custom float attributes
+- **Uint16 fields**: ring, color channels, custom uint16 attributes
+- **Double fields**: time, timestamps, custom double attributes (MRPT ≥ 2.15.3)
+- **Uint8 fields**: custom uint8 attributes (MRPT ≥ 2.15.3)
+
+The specific fields exported depend on the point cloud type in each layer. Use `--export-fields` to select only the fields you need.
+
+## Supported Point Cloud Types
+
+- **CGenericPointsMap**: Generic point clouds with custom fields (full support for `--export-fields`)
+- **CPointsMapXYZI** (Deprecated): Point clouds with intensity values (`--export-fields` not supported)
+- **CPointsMapXYZIRT** (Deprecated): Point clouds with intensity, ring, and time information (`--export-fields` not supported)

--- a/apps/mm2txt/main.cpp
+++ b/apps/mm2txt/main.cpp
@@ -25,6 +25,7 @@
 #include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/system/os.h>
+#include <mrpt/system/string_utils.h>
 #include <mrpt/version.h>
 
 #if MRPT_VERSION < 0x030000  // <3.0.0
@@ -46,8 +47,16 @@ TCLAP::MultiArg<std::string> argLayers(
     "appear several times.",
     false, "layerName", cmd);
 
+TCLAP::ValueArg<std::string> argExportFields(
+    "", "export-fields",
+    "Comma-separated list of fields to export (e.g., 'x,y,z,intensity'). If not "
+    "provided, all available fields will be exported. Fields will be exported in "
+    "the specified order.",
+    false, "", "field1,field2,...", cmd);
+
 bool saveToTxt(
-    const mrpt::maps::CGenericPointsMap& pts, const std::string& fileName, bool printHeader)
+    const mrpt::maps::CGenericPointsMap& pts, const std::string& fileName, bool printHeader,
+    const std::vector<std::string>& selectedFields = {})
 {
     FILE* f = mrpt::system::os::fopen(fileName.c_str(), "wt");
     if (!f)
@@ -63,30 +72,51 @@ bool saveToTxt(
     const auto& uint8Fields  = pts.uint8_fields();
 #endif
 
-    // header?
-    if (printHeader)
+    // Determine which fields to export and in what order
+    std::vector<std::string> fieldsToExport;
+
+    if (selectedFields.empty())
     {
-        // xyz are mandatory:
-        mrpt::system::os::fprintf(f, "x y z ");
+        // Export all fields in default order
+        fieldsToExport.push_back("x");
+        fieldsToExport.push_back("y");
+        fieldsToExport.push_back("z");
 
         for (const auto& [name, _] : floatFields)
         {
-            mrpt::system::os::fprintf(f, "%.*s ", static_cast<int>(name.length()), name.data());
+            fieldsToExport.push_back(std::string(name));
         }
         for (const auto& [name, _] : uint16Fields)
         {
-            mrpt::system::os::fprintf(f, "%.*s ", static_cast<int>(name.length()), name.data());
+            fieldsToExport.push_back(std::string(name));
         }
 #if MRPT_VERSION >= 0x020f03  // 2.15.3
         for (const auto& [name, _] : doubleFields)
         {
-            mrpt::system::os::fprintf(f, "%.*s ", static_cast<int>(name.length()), name.data());
+            fieldsToExport.push_back(std::string(name));
         }
         for (const auto& [name, _] : uint8Fields)
         {
-            mrpt::system::os::fprintf(f, "%.*s ", static_cast<int>(name.length()), name.data());
+            fieldsToExport.push_back(std::string(name));
         }
 #endif
+    }
+    else
+    {
+        // Use selected fields in specified order
+        fieldsToExport = selectedFields;
+    }
+
+    // header?
+    if (printHeader)
+    {
+        for (size_t i = 0; i < fieldsToExport.size(); i++)
+        {
+            const auto& fieldName = fieldsToExport[i];
+            mrpt::system::os::fprintf(
+                f, "%.*s%s", static_cast<int>(fieldName.length()), fieldName.data(),
+                (i + 1 < fieldsToExport.size()) ? " " : "");
+        }
         mrpt::system::os::fprintf(f, "\n");
     }
 
@@ -100,31 +130,59 @@ bool saveToTxt(
         return true;
     }
 
-    const std::size_t n = floatFields.begin()->second.size();
+    const std::size_t n = xs.size();
 
     for (size_t i = 0; i < n; i++)
     {
-        // X Y Z are mandatory fields:
-        mrpt::system::os::fprintf(f, "%f %f %f ", xs.at(i), ys.at(i), zs.at(i));
+        for (size_t fieldIdx = 0; fieldIdx < fieldsToExport.size(); fieldIdx++)
+        {
+            const auto& fieldName = fieldsToExport[fieldIdx];
 
-        for (const auto& [_, values] : floatFields)
-        {
-            mrpt::system::os::fprintf(f, "%f ", values.at(i));
-        }
-        for (const auto& [_, values] : uint16Fields)
-        {
-            mrpt::system::os::fprintf(f, "%u ", values.at(i));
-        }
+            // Check coordinate fields
+            if (fieldName == "x")
+            {
+                mrpt::system::os::fprintf(f, "%f", xs.at(i));
+            }
+            else if (fieldName == "y")
+            {
+                mrpt::system::os::fprintf(f, "%f", ys.at(i));
+            }
+            else if (fieldName == "z")
+            {
+                mrpt::system::os::fprintf(f, "%f", zs.at(i));
+            }
+            // Check float fields
+            else if (floatFields.count(fieldName))
+            {
+                mrpt::system::os::fprintf(f, "%f", floatFields.at(fieldName).at(i));
+            }
+            // Check uint16 fields
+            else if (uint16Fields.count(fieldName))
+            {
+                mrpt::system::os::fprintf(f, "%u", uint16Fields.at(fieldName).at(i));
+            }
 #if MRPT_VERSION >= 0x020f03  // 2.15.3
-        for (const auto& [_, values] : doubleFields)
-        {
-            mrpt::system::os::fprintf(f, "%lf ", values.at(i));
-        }
-        for (const auto& [_, values] : uint8Fields)
-        {
-            mrpt::system::os::fprintf(f, "%i ", static_cast<int>(values.at(i)));
-        }
+            // Check double fields
+            else if (doubleFields.count(fieldName))
+            {
+                mrpt::system::os::fprintf(f, "%lf", doubleFields.at(fieldName).at(i));
+            }
+            // Check uint8 fields
+            else if (uint8Fields.count(fieldName))
+            {
+                mrpt::system::os::fprintf(
+                    f, "%i", static_cast<int>(uint8Fields.at(fieldName).at(i)));
+            }
 #endif
+            else
+            {
+                // Field not found - this should have been caught earlier
+                mrpt::system::os::fprintf(f, "0");
+            }
+
+            // Add separator or newline
+            mrpt::system::os::fprintf(f, "%s", (fieldIdx + 1 < fieldsToExport.size()) ? " " : "");
+        }
         mrpt::system::os::fprintf(f, "\n");
     }
 
@@ -166,6 +224,49 @@ void run_mm2txt()
         }
     }
 
+    // Parse export fields if specified
+    std::vector<std::string> selectedFields;
+    if (argExportFields.isSet())
+    {
+        const auto&              fieldsStr = argExportFields.getValue();
+        std::vector<std::string> tokens;
+        mrpt::system::tokenize(fieldsStr, ", \t", tokens);
+
+        // Remove empty tokens and trim
+        for (auto& token : tokens)
+        {
+            if (!token.empty())
+            {
+                selectedFields.push_back(token);
+            }
+        }
+
+        if (selectedFields.empty())
+        {
+            THROW_EXCEPTION("--export-fields specified but no valid fields found!");
+        }
+
+        std::cout << "Exporting only selected fields: ";
+        for (size_t i = 0; i < selectedFields.size(); i++)
+        {
+            std::cout << selectedFields[i];
+            if (i + 1 < selectedFields.size())
+            {
+                std::cout << ", ";
+            }
+        }
+        std::cout << std::endl;
+    }
+
+    const auto printSelectedFieldsWarning = [&selectedFields]()
+    {
+        if (!selectedFields.empty())
+        {
+            std::cerr << "Warning: --export-fields not supported for legacy point map types, "
+                         "exporting all fields.\n";
+        }
+    };
+
     const auto baseFilName = mrpt::system::extractFileName(filInput);
 
     // Export them:
@@ -189,8 +290,57 @@ void run_mm2txt()
 
         if (auto* genxyz = dynamic_cast<const mrpt::maps::CGenericPointsMap*>(pts); genxyz)
         {
+            // Validate selected fields exist in this point cloud
+            if (!selectedFields.empty())
+            {
+                const auto& floatFields  = genxyz->float_fields();
+                const auto& uint16Fields = genxyz->uint16_fields();
+#if MRPT_VERSION >= 0x020f03  // 2.15.3
+                const auto& doubleFields = genxyz->double_fields();
+                const auto& uint8Fields  = genxyz->uint8_fields();
+#endif
+
+                for (const auto& field : selectedFields)
+                {
+                    bool found =
+                        (field == "x" || field == "y" || field == "z" || floatFields.count(field) ||
+                         uint16Fields.count(field));
+#if MRPT_VERSION >= 0x020f03  // 2.15.3
+                    found = found || doubleFields.count(field) || uint8Fields.count(field);
+#endif
+
+                    if (!found)
+                    {
+                        std::cerr << "Warning: Field '" << field << "' not found in layer '" << name
+                                  << "'. Available fields: x, y, z";
+                        for (const auto& [fname, _] : floatFields)
+                        {
+                            std::cerr << ", " << fname;
+                        }
+                        for (const auto& [fname, _] : uint16Fields)
+                        {
+                            std::cerr << ", " << fname;
+                        }
+#if MRPT_VERSION >= 0x020f03  // 2.15.3
+                        for (const auto& [fname, _] : doubleFields)
+                        {
+                            std::cerr << ", " << fname;
+                        }
+                        for (const auto& [fname, _] : uint8Fields)
+                        {
+                            std::cerr << ", " << fname;
+                        }
+#endif
+                        std::cerr << std::endl;
+                        THROW_EXCEPTION_FMT(
+                            "Field '%s' specified in --export-fields not found in layer '%s'",
+                            field.c_str(), name.c_str());
+                    }
+                }
+            }
+
             bool printHeader = true;
-            saveToTxt(*genxyz, filName, printHeader);
+            saveToTxt(*genxyz, filName, printHeader, selectedFields);
         }
 #if MRPT_VERSION < 0x030000  // <3.0.0
         else
@@ -199,14 +349,18 @@ void run_mm2txt()
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             if (auto* xyzirt = dynamic_cast<const mrpt::maps::CPointsMapXYZIRT*>(pts); xyzirt)
             {
+                printSelectedFieldsWarning();
                 xyzirt->saveXYZIRT_to_text_file(filName);
             }
             else if (auto* xyzi = dynamic_cast<const mrpt::maps::CPointsMapXYZI*>(pts); xyzi)
             {
+                printSelectedFieldsWarning();
+
                 xyzi->saveXYZI_to_text_file(filName);
             }
             else
             {
+                printSelectedFieldsWarning();
                 pts->save3D_to_text_file(filName);
             }
 #pragma GCC diagnostic pop
@@ -214,6 +368,7 @@ void run_mm2txt()
 #else
         else
         {
+            printSelectedFieldsWarning();
             pts->save3D_to_text_file(filName);
         }
 #endif

--- a/docs/source/app_mm2txt.rst
+++ b/docs/source/app_mm2txt.rst
@@ -13,6 +13,7 @@ Features
 --------
 
 - Exports all or selected point cloud layers from a metric map file
+- Selectively exports specific fields in a custom order
 - Automatically detects and exports all point fields (coordinates, intensities, colors, timestamps, etc.)
 - Generates header row with field names for easy data parsing
 - Supports multiple point cloud types (CGenericPointsMap, CPointsMapXYZI, CPointsMapXYZIRT)
@@ -24,13 +25,14 @@ Usage
 
 .. code-block:: bash
 
-   mm2txt <input.mm> [-l <layer_name>] [-l <layer_name>] ...
+   mm2txt <input.mm> [-l <layer_name>] [--export-fields <field1,field2,...>]
 
 Arguments
 ^^^^^^^^^
 
 - ``input`` (required): Input metric map file (\*.mm)
 - ``-l, --layer <name>`` (optional): Layer to export. If not provided, all layers will be exported. This argument can appear multiple times to export specific layers
+- ``--export-fields <field1,field2,...>`` (optional): Comma-separated list of fields to export in the specified order. If not provided, all available fields will be exported. Spaces around commas are allowed
 
 Examples
 ^^^^^^^^
@@ -52,6 +54,24 @@ Export a single layer:
 .. code-block:: bash
 
    mm2txt mymap.mm -l global
+
+Export only specific fields in a custom order:
+
+.. code-block:: bash
+
+   mm2txt mymap.mm --export-fields "x,y,z,intensity"
+
+Export selected fields from specific layers:
+
+.. code-block:: bash
+
+   mm2txt mymap.mm -l raw --export-fields "x, y, z, ring, time"
+
+Export only 2D coordinates and intensity:
+
+.. code-block:: bash
+
+   mm2txt mymap.mm --export-fields "x,y,intensity"
 
 Output
 ------
@@ -75,7 +95,7 @@ Each output file is a space-delimited text file with:
 - **Header row**: Column names for all point fields
 - **Data rows**: One row per point, with values for each field
 
-Example output:
+Example output (all fields):
 
 .. code-block:: text
 
@@ -83,6 +103,27 @@ Example output:
    1.234 5.678 0.123 45.6 0 12345.678
    2.345 6.789 0.234 67.8 1 12345.679
    ...
+
+Example output (selected fields):
+
+.. code-block:: text
+
+   x y z intensity
+   1.234 5.678 0.123 45.6
+   2.345 6.789 0.234 67.8
+   ...
+
+Field Selection
+---------------
+
+When using the ``--export-fields`` option:
+
+- Fields must be specified as a comma-separated list
+- Spaces around commas are allowed (e.g., ``"x, y, z"`` or ``"x,y,z"``)
+- Fields will be exported in the exact order specified
+- All specified fields must exist in the point cloud, or an error will be raised
+- The tool validates field availability and reports available fields if a requested field is not found
+- This option is only supported for **CGenericPointsMap** point clouds; for legacy types (CPointsMapXYZI, CPointsMapXYZIRT), all fields are exported with a warning
 
 Supported Point Fields
 ----------------------
@@ -93,12 +134,13 @@ The tool automatically exports all available point attributes:
 - **Float fields**: intensity, normals, curvature, custom float attributes
 - **Uint16 fields**: ring, color channels, custom uint16 attributes
 - **Double fields**: time, timestamps, custom double attributes (MRPT ≥ 2.15.3)
+- **Uint8 fields**: custom uint8 attributes (MRPT ≥ 2.15.3)
 
-The specific fields exported depend on the point cloud type in each layer.
+The specific fields exported depend on the point cloud type in each layer. Use ``--export-fields`` to select only the fields you need.
 
 Supported Point Cloud Types
 ---------------------------
 
-- **CGenericPointsMap**: Generic point clouds with custom fields
-- **CPointsMapXYZI** (Deprecated): Point clouds with intensity values
-- **CPointsMapXYZIRT** (Deprecated): Point clouds with intensity, ring, and time information
+- **CGenericPointsMap**: Generic point clouds with custom fields (full support for ``--export-fields``)
+- **CPointsMapXYZI** (Deprecated): Point clouds with intensity values (``--export-fields`` not supported)
+- **CPointsMapXYZIRT** (Deprecated): Point clouds with intensity, ring, and time information (``--export-fields`` not supported)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --export-fields to mm2ply and mm2txt to select and order exported point-cloud fields per-layer; supports ASCII and binary outputs.

* **Bug Fixes / UX**
  * Improved validation and clearer warnings/errors when requested fields are missing or unsupported; legacy point-map types warn and fall back to full export.

* **Documentation**
  * Expanded usage, examples, field-selection rules, supported-field/type notes, and formatting guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->