### PR TITLE
Add trivial FilterDecimate for fast downsampling without spatial awareness

### DIFF
--- a/apps/icp-run/main.cpp
+++ b/apps/icp-run/main.cpp
@@ -32,8 +32,6 @@
 #include <mrpt/system/datetime.h>
 #include <mrpt/system/filesystem.h>
 
-#include <fstream>
-
 // CLI flags:
 static TCLAP::CmdLine cmd("icp-run");
 
@@ -122,7 +120,10 @@ static mrpt::obs::CRawlog::Ptr load_rawlog(const std::string& filename)
     mrpt::img::CImage::setImagesPathBase(mrpt::obs::CRawlog::detectImagesDirectory(filename));
 
     auto& r = rawlogsCache[filename];
-    if (r) return r;
+    if (r)
+    {
+        return r;
+    }
     r = mrpt::obs::CRawlog::Create();
 
     std::cout << "Loading rawlog file `" << filename << "`..." << std::endl;
@@ -184,7 +185,7 @@ static mp2p_icp::metric_map_t::Ptr load_input_pc(const std::string& filename, bo
     {
         const auto sepPos      = extPos + 7;
         const auto fil         = filename.substr(0, sepPos);
-        const auto rawlogIndex = std::stod(filename.substr(sepPos + 1));
+        const auto rawlogIndex = std::stoi(filename.substr(sepPos + 1));
 
         const auto r = load_rawlog(fil);
 
@@ -257,7 +258,10 @@ void runIcp()
     // ------------------------------
     auto [icp, icpParams] = mp2p_icp::icp_pipeline_from_yaml(cfg);
 
-    if (argGenerateDebugFiles.isSet()) icpParams.generateDebugFiles = true;
+    if (argGenerateDebugFiles.isSet())
+    {
+        icpParams.generateDebugFiles = true;
+    }
 
     const auto initialGuess = mrpt::math::TPose3D::FromString(argInitialGuess.getValue());
 
@@ -301,7 +305,10 @@ void runIcp()
         }
     }
 
-    if (argProfile.isSet()) icp->profiler().enable(true);
+    if (argProfile.isSet())
+    {
+        icp->profiler().enable(true);
+    }
 
     const double t_ini = mrpt::Clock::nowDouble();
 
@@ -321,7 +328,10 @@ int main(int argc, char** argv)
     try
     {
         // Parse arguments:
-        if (!cmd.parse(argc, argv)) return 1;  // should exit.
+        if (!cmd.parse(argc, argv))
+        {
+            return 1;  // should exit.
+        }
 
         runIcp();
     }

--- a/apps/mm-filter/main.cpp
+++ b/apps/mm-filter/main.cpp
@@ -83,12 +83,18 @@ void run_mm_filter(Cli& cli)
         std::string errMsg;
         const auto  plugins = cli.arg_plugins.getValue();
         std::cout << "Loading plugin(s): " << plugins << std::endl;
-        if (!mrpt::system::loadPluginModules(plugins, errMsg)) throw std::runtime_error(errMsg);
+        if (!mrpt::system::loadPluginModules(plugins, errMsg))
+        {
+            throw std::runtime_error(errMsg);
+        }
     }
 
     const auto& filInput = cli.argInput.getValue();
 
-    if (cli.argPipeline.isSet()) ASSERT_FILE_EXISTS_(cli.argPipeline.getValue());
+    if (cli.argPipeline.isSet())
+    {
+        ASSERT_FILE_EXISTS_(cli.argPipeline.getValue());
+    }
 
     std::cout << "[mm-filter] Reading input map from: '" << filInput << "'..." << std::endl;
 
@@ -141,7 +147,9 @@ void run_mm_filter(Cli& cli)
     std::cout << "[mm-filter] Writing metric map to: '" << filOut << "'..." << std::endl;
 
     if (!mm.save_to_file(filOut))
+    {
         THROW_EXCEPTION_FMT("Error writing to target file '%s'", filOut.c_str());
+    }
 }
 }  // namespace
 
@@ -152,7 +160,10 @@ int main(int argc, char** argv)
         Cli cli;
 
         // Parse arguments:
-        if (!cli.cmd.parse(argc, argv)) return 1;  // should exit.
+        if (!cli.cmd.parse(argc, argv))
+        {
+            return 1;  // should exit.
+        }
 
         run_mm_filter(cli);
     }

--- a/apps/mm-georef/main.cpp
+++ b/apps/mm-georef/main.cpp
@@ -159,14 +159,17 @@ void run_mm_georef(Cli& cli)
         std::string errMsg;
         const auto  plugins = cli.arg_plugins.getValue();
         std::cout << "Loading plugin(s): " << plugins << std::endl;
-        if (!mrpt::system::loadPluginModules(plugins, errMsg)) throw std::runtime_error(errMsg);
+        if (!mrpt::system::loadPluginModules(plugins, errMsg))
+        {
+            throw std::runtime_error(errMsg);
+        }
     }
 
     if (cli.argExtract.isSet())
     {
         return run_mm_extract(cli);
     }
-    else if (cli.argInject.isSet())
+    if (cli.argInject.isSet())
     {
         return run_mm_inject(cli);
     }
@@ -184,7 +187,10 @@ int main(int argc, char** argv)
         Cli cli;
 
         // Parse arguments:
-        if (!cli.cmd.parse(argc, argv)) return 1;  // should exit.
+        if (!cli.cmd.parse(argc, argv))
+        {
+            return 1;  // should exit.
+        }
 
         run_mm_georef(cli);
     }

--- a/apps/mm-info/main.cpp
+++ b/apps/mm-info/main.cpp
@@ -52,7 +52,10 @@ int main(int argc, char** argv)
     try
     {
         // Parse arguments:
-        if (!cmd.parse(argc, argv)) return 1;  // should exit.
+        if (!cmd.parse(argc, argv))
+        {
+            return 1;  // should exit.
+        }
 
         run_mm_info();
     }

--- a/docs/source/mp2p_icp_filters.rst
+++ b/docs/source/mp2p_icp_filters.rst
@@ -278,6 +278,60 @@ Useful for edge extraction (LOAM-style).
 
 ---
 
+Filter: `FilterDecimate`
+------------------------
+
+**Description**: Naive point cloud downsampling that reduces the number of points by keeping only one out of every N points.
+The filter can be configured either with a fixed decimation factor or by specifying a target maximum size (in which case the decimation factor is computed automatically).
+
+If the output layer already exists, new points are accumulated on it; previous contents are not cleared.
+
+.. note::
+   This filter is non-deterministic regarding the spatial distribution of points, as it relies purely on the internal storage order.
+   For spatially-aware downsampling, consider using :cpp:class:`FilterDecimateVoxels` or :cpp:class:`FilterDecimateAdaptive` instead.
+
+**Parameters**:
+
+* **input\_layer** (:cpp:type:`std::string`, default: `raw`): The input point cloud layer name.
+
+* **output\_layer** (:cpp:type:`std::string`): The output layer name for the decimated cloud.
+
+* **decimation** (:cpp:type:`uint32\_t`, default: `0`): Keep one out of every N points.
+  If greater than 0, this parameter takes precedence over ``target_max_size``.
+  For example, ``decimation=10`` keeps every 10th point, resulting in approximately 10% of the original points.
+
+* **target\_max\_size** (:cpp:type:`uint64\_t`, default: `0`): Target maximum number of points in the output cloud.
+  Used only if ``decimation`` is 0.
+  The decimation factor is computed automatically to achieve approximately this many output points.
+
+.. code-block:: yaml
+
+    filters:
+      #...
+      # Example 1: Fixed decimation factor
+      - class_name: mp2p_icp_filters::FilterDecimate
+        params:
+          input_layer: 'raw'
+          output_layer: 'decimated'
+          decimation: 5  # Keep every 5th point
+
+      # Example 2: Target maximum size
+      - class_name: mp2p_icp_filters::FilterDecimate
+        params:
+          input_layer: 'raw'
+          output_layer: 'decimated'
+          target_max_size: 10000  # Aim for ~10k points
+
+.. rubric:: Before → After Screenshot
+
+.. image:: decimate_example.png
+   :alt: Screenshot showing point cloud before and after applying FilterDecimate
+
+|
+
+---
+
+
 Filter: `FilterDecimateAdaptive`
 --------------------------------
 

--- a/mp2p_icp_filters/CMakeLists.txt
+++ b/mp2p_icp_filters/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIB_SRCS
   src/FilterByRange.cpp
   src/FilterByRing.cpp
   src/FilterCurvature.cpp
+  src/FilterDecimate.cpp
   src/FilterDecimateAdaptive.cpp
   src/FilterDecimateVoxels.cpp
   src/FilterDeleteLayer.cpp
@@ -47,6 +48,7 @@ set(LIB_PUBLIC_HDRS
   include/mp2p_icp_filters/FilterByRange.h
   include/mp2p_icp_filters/FilterByRing.h
   include/mp2p_icp_filters/FilterCurvature.h
+  include/mp2p_icp_filters/FilterDecimate.h
   include/mp2p_icp_filters/FilterDecimateAdaptive.h
   include/mp2p_icp_filters/FilterDecimateVoxels.h
   include/mp2p_icp_filters/FilterDeleteLayer.h

--- a/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimate.h
+++ b/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimate.h
@@ -1,0 +1,78 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file   FilterDecimate.h
+ * @brief  Naive point cloud downsampling (every N-th point).
+ * @author Jose Luis Blanco Claraco
+ * @date   Jan 12, 2026
+ */
+
+#pragma once
+
+#include <mp2p_icp/metricmap.h>
+#include <mp2p_icp_filters/FilterBase.h>
+
+namespace mp2p_icp_filters
+{
+/**
+ * @brief Naive point cloud downsampling.
+ *
+ * This filter reduces the number of points by keeping only one out of every N
+ * points. It can be configured either with a fixed decimation factor or by
+ * providing a target maximum size (in which case the decimation factor is
+ * computed automatically).
+ *
+ * If the output layer exists, new points are accumulated on it: previous contents are not cleared.
+ *
+ * Note: This filter is non-deterministic regarding the spatial distribution
+ * of points, as it relies purely on the internal storage order.
+ *
+ * \ingroup mp2p_icp_filters_grp
+ */
+class FilterDecimate : public mp2p_icp_filters::FilterBase
+{
+    DEFINE_MRPT_OBJECT(FilterDecimate, mp2p_icp_filters)
+   public:
+    FilterDecimate();
+
+    // See docs in FilterBase
+    void filter(mp2p_icp::metric_map_t& inOut) const override;
+
+    struct Parameters
+    {
+        void load_from_yaml(const mrpt::containers::yaml& c);
+
+        /** Input layer name (must be a point cloud) */
+        std::string input_layer = mp2p_icp::metric_map_t::PT_LAYER_RAW;
+
+        /** Output layer name */
+        std::string output_layer;
+
+        /** Keep one out of every 'decimation' points. If > 0, this takes
+         * precedence over target_max_size. */
+        uint32_t decimation = 0;
+
+        /** Target maximum number of points in the output cloud.
+         * Used only if decimation == 0. */
+        uint64_t target_max_size = 0;
+    };
+
+    /** Algorithm parameters */
+    Parameters params;
+
+   protected:
+    void initialize_filter(const mrpt::containers::yaml& c) override;
+};
+
+}  // namespace mp2p_icp_filters

--- a/mp2p_icp_filters/src/FilterDecimate.cpp
+++ b/mp2p_icp_filters/src/FilterDecimate.cpp
@@ -1,0 +1,102 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file   FilterDecimate.cpp
+ * @brief  Naive point cloud downsampling (every N-th point).
+ * @author Jose Luis Blanco Claraco
+ * @date   Jan 12, 2026
+ */
+
+#include <mp2p_icp_filters/FilterDecimate.h>
+#include <mp2p_icp_filters/GetOrCreatePointLayer.h>
+#include <mrpt/containers/yaml.h>
+#include <mrpt/maps/CPointsMap.h>
+#include <mrpt/version.h>
+
+IMPLEMENTS_MRPT_OBJECT(FilterDecimate, mp2p_icp_filters::FilterBase, mp2p_icp_filters)
+
+using namespace mp2p_icp_filters;
+
+FilterDecimate::FilterDecimate() = default;
+
+void FilterDecimate::Parameters::load_from_yaml(const mrpt::containers::yaml& c)
+{
+    MCP_LOAD_REQ(c, input_layer);
+    MCP_LOAD_REQ(c, output_layer);
+    MCP_LOAD_OPT(c, decimation);
+    MCP_LOAD_OPT(c, target_max_size);
+}
+
+void FilterDecimate::initialize_filter(const mrpt::containers::yaml& c)
+{
+    params.load_from_yaml(c);
+}
+
+void FilterDecimate::filter(mp2p_icp::metric_map_t& inOut) const
+{
+    auto pcIn = inOut.layer<mrpt::maps::CPointsMap>(params.input_layer);
+    if (!pcIn || pcIn->empty())
+    {
+        return;
+    }
+
+    const size_t nIn = pcIn->size();
+
+    // 1. Determine decimation factor N
+    size_t N = 1;
+    if (params.decimation > 0)
+    {
+        N = params.decimation;
+    }
+    else if (params.target_max_size > 0 && nIn > params.target_max_size)
+    {
+        N = nIn / params.target_max_size;
+    }
+
+    // Shortcut if no decimation is needed and layers are different
+    if (N <= 1)
+    {
+        if (params.input_layer != params.output_layer)
+        {
+            // warning: this makes a shallow copy... more efficient but users should be aware of
+            // side effects.
+            inOut.layers[params.output_layer] = pcIn;
+        }
+        return;
+    }
+
+    // 2. Prepare output layer
+    auto outPc = GetOrCreatePointLayer(
+        inOut, params.output_layer, false /*don't allow move if same name*/,
+        pcIn->GetRuntimeClass()->className);
+
+    // Efficiently copy points including all extra fields
+#if MRPT_VERSION >= 0x020f00
+    outPc->registerPointFieldsFrom(*pcIn);
+    auto ctx = outPc->prepareForInsertPointsFrom(*pcIn);
+#endif
+
+    outPc->reserve(outPc->size() + (nIn / N));
+
+    for (size_t i = 0; i < nIn; i += N)
+    {
+#if MRPT_VERSION >= 0x020f03
+        outPc->insertPointFrom(i, ctx);
+#elif MRPT_VERSION >= 0x020f00
+        outPc->insertPointFrom(*pcIn, i, ctx);
+#else
+        outPc->insertPointFrom(*pcIn, i);
+#endif
+    }
+}

--- a/mp2p_icp_filters/src/register.cpp
+++ b/mp2p_icp_filters/src/register.cpp
@@ -31,6 +31,7 @@
 #include <mp2p_icp_filters/FilterByRange.h>
 #include <mp2p_icp_filters/FilterByRing.h>
 #include <mp2p_icp_filters/FilterCurvature.h>
+#include <mp2p_icp_filters/FilterDecimate.h>
 #include <mp2p_icp_filters/FilterDecimateAdaptive.h>
 #include <mp2p_icp_filters/FilterDecimateVoxels.h>
 #include <mp2p_icp_filters/FilterDeleteLayer.h>
@@ -69,6 +70,7 @@ MRPT_INITIALIZER(register_mola_lidar_segmentation)
     registerClass(CLASS_ID(mp2p_icp_filters::FilterByRange));
     registerClass(CLASS_ID(mp2p_icp_filters::FilterByRing));
     registerClass(CLASS_ID(mp2p_icp_filters::FilterCurvature));
+    registerClass(CLASS_ID(mp2p_icp_filters::FilterDecimate));
     registerClass(CLASS_ID(mp2p_icp_filters::FilterDecimateAdaptive));
     registerClass(CLASS_ID(mp2p_icp_filters::FilterDecimateVoxels));
     registerClass(CLASS_ID(mp2p_icp_filters::FilterDeleteLayer));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ mp2p_add_test(mp2p_quality_reproject_ranges)
 
 mp2p_add_test(mp2p_FilterAbsoluteTimestamp EXTRA_LIBS mp2p_icp_filters)
 mp2p_add_test(mp2p_FilterByExpression EXTRA_LIBS mp2p_icp_filters)
+mp2p_add_test(mp2p_FilterDecimate EXTRA_LIBS mp2p_icp_filters)
 mp2p_add_test(mp2p_FilterDecimateVoxels EXTRA_LIBS mp2p_icp_filters)
 mp2p_add_test(mp2p_FilterEdgesPlanes EXTRA_LIBS mp2p_icp_filters)
 mp2p_add_test(mp2p_FilterPoleDetector EXTRA_LIBS mp2p_icp_filters)

--- a/tests/test-mp2p_FilterDecimate.cpp
+++ b/tests/test-mp2p_FilterDecimate.cpp
@@ -1,0 +1,104 @@
+/* _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \\ / _ \\| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\\___/|_|\\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file   test_FilterDecimate.cpp
+ * @brief  Unit test for FilterDecimate
+ * @author Jose Luis Blanco Claraco, Google Gemini
+ * @date   Jan 12, 2026
+ */
+
+#include <mp2p_icp/metricmap.h>
+#include <mp2p_icp_filters/FilterDecimate.h>
+#include <mrpt/core/exceptions.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+
+#include <iostream>
+
+using namespace mp2p_icp_filters;
+
+int main()
+{
+    try
+    {
+        // 1. Setup cloud with 100 points
+        auto pc = mrpt::maps::CSimplePointsMap::Create();
+        for (int i = 0; i < 100; ++i)
+        {
+            pc->insertPoint(static_cast<float>(i), 0, 0);
+        }
+
+        mp2p_icp::metric_map_t map;
+        map.layers["raw"] = pc;
+
+        // ---------------------------------------------------------
+        // Case A: Fixed Decimation (1 out of 4 -> 25 points)
+        // ---------------------------------------------------------
+        {
+            FilterDecimate         filter;
+            mrpt::containers::yaml p;
+            p["input_layer"]  = "raw";
+            p["output_layer"] = "decimated_fixed";
+            p["decimation"]   = 4;
+            filter.initialize(p);
+
+            filter.filter(map);
+            auto out = map.layer<mrpt::maps::CPointsMap>("decimated_fixed");
+            ASSERT_EQUAL_(out->size(), 25ULL);
+            std::cout << "[Test Passed] Fixed decimation factor of 4" << std::endl;
+        }
+
+        // ---------------------------------------------------------
+        // Case B: Target Maximum Size (Target 10 -> factor 10 -> 10 points)
+        // ---------------------------------------------------------
+        {
+            FilterDecimate         filter;
+            mrpt::containers::yaml p;
+            p["input_layer"]     = "raw";
+            p["output_layer"]    = "decimated_target";
+            p["target_max_size"] = 10;
+            filter.initialize(p);
+
+            filter.filter(map);
+            auto out = map.layer<mrpt::maps::CPointsMap>("decimated_target");
+            // 100 / 10 = 10 factor. 100 / 10 points.
+            ASSERT_EQUAL_(out->size(), 10ULL);
+            std::cout << "[Test Passed] Target maximum size of 10" << std::endl;
+        }
+
+        // ---------------------------------------------------------
+        // Case C: Target size larger than input (No-op)
+        // ---------------------------------------------------------
+        {
+            FilterDecimate         filter;
+            mrpt::containers::yaml p;
+            p["input_layer"]     = "raw";
+            p["output_layer"]    = "no_decimation";
+            p["target_max_size"] = 500;
+            filter.initialize(p);
+
+            filter.filter(map);
+            auto out = map.layer<mrpt::maps::CPointsMap>("no_decimation");
+            ASSERT_EQUAL_(out->size(), 100ULL);
+            std::cout << "[Test Passed] Target size larger than input" << std::endl;
+        }
+
+        std::cout << "\nFilterDecimate Unit Tests Passed!" << std::endl;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Test failed: " << e.what() << std::endl;
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FilterDecimate — point-cloud downsampling with fixed decimation and automatic target-size based decimation.

* **Documentation**
  * Added usage docs and configuration examples for FilterDecimate.

* **Tests**
  * Added unit tests validating fixed, target-size, and no-op decimation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->