### PR TITLE
mm-viewer: add CLI flags to load overlaid 3D scenes for visualization

### DIFF
--- a/docs/source/app_mm-viewer.rst
+++ b/docs/source/app_mm-viewer.rst
@@ -5,3 +5,37 @@ Application: ``mm-viewer``
 ===============================
 
 Write me!
+
+.. code-block:: bash
+
+    USAGE: 
+
+    mm-viewer  [-s <scene.3dscene>] ...  [-t <trajectory.tum>] [-l
+                <foobar.so>] [--] [--version] [-h] <myMap.mm>
+
+
+    Where: 
+
+    -s <scene.3dscene>,  --add-3d-scene <scene.3dscene>  (accepted multiple
+        times)
+        Adds an extra 3D scene file (*.3dscene) for visualization.
+
+    -t <trajectory.tum>,  --trajectory <trajectory.tum>
+        Also draw a trajectory, given by a TUM file trajectory.
+
+    -l <foobar.so>,  --load-plugins <foobar.so>
+        One or more (comma separated) *.so files to load as plugins
+
+    --,  --ignore_rest
+        Ignores the rest of the labeled arguments following this flag.
+
+    --version
+        Displays version information and exits.
+
+    -h,  --help
+        Displays usage information and exits.
+
+    <myMap.mm>
+        Load this metric map file (*.mm)
+
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line option to load and display additional 3D scene files at application startup.
  * Added per-file UI toggles to independently control the visibility of each loaded 3D scene.

* **Documentation**
  * Added documentation for mm-viewer command-line options and usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->