### PR TITLE
Exploit the maximum float32/float64 precision in exported txt formats

### DIFF
--- a/apps/mm2ply/main.cpp
+++ b/apps/mm2ply/main.cpp
@@ -271,7 +271,7 @@ void saveToPly(
     }
 
     // 4. Data Loop
-    auto write_val = [&](auto val)
+    auto write_val = [&](auto val, const char* fmt)
     {
         if (binary)
         {
@@ -279,7 +279,7 @@ void saveToPly(
         }
         else
         {
-            f << +val << " ";
+            f << mrpt::format(fmt, val) << " ";
         }
     };
 
@@ -296,7 +296,7 @@ void saveToPly(
                 {
                     const auto& buf =
                         *static_cast<const mrpt::aligned_std_vector<float>*>(acc.bufPtr);
-                    write_val(buf[i]);
+                    write_val(buf[i], "%.8e");
                     break;
                 }
 #if MRPT_VERSION >= 0x020f03  // 2.15.3
@@ -304,21 +304,21 @@ void saveToPly(
                 {
                     const auto& buf =
                         *static_cast<const mrpt::aligned_std_vector<double>*>(acc.bufPtr);
-                    write_val(buf[i]);
+                    write_val(buf[i], "%.16le");
                     break;
                 }
                 case FieldAccessor::UINT16:
                 {
                     const auto& buf =
                         *static_cast<const mrpt::aligned_std_vector<uint16_t>*>(acc.bufPtr);
-                    write_val(buf[i]);
+                    write_val(buf[i], "%u");
                     break;
                 }
                 case FieldAccessor::UINT8:
                 {
                     const auto& buf =
                         *static_cast<const mrpt::aligned_std_vector<uint8_t>*>(acc.bufPtr);
-                    write_val(buf[i]);
+                    write_val(buf[i], "%i");
                     break;
                 }
 #endif

--- a/apps/mm2txt/main.cpp
+++ b/apps/mm2txt/main.cpp
@@ -141,20 +141,20 @@ bool saveToTxt(
             // Check coordinate fields
             if (fieldName == "x")
             {
-                mrpt::system::os::fprintf(f, "%f", xs.at(i));
+                mrpt::system::os::fprintf(f, "%.8f", xs.at(i));
             }
             else if (fieldName == "y")
             {
-                mrpt::system::os::fprintf(f, "%f", ys.at(i));
+                mrpt::system::os::fprintf(f, "%.8f", ys.at(i));
             }
             else if (fieldName == "z")
             {
-                mrpt::system::os::fprintf(f, "%f", zs.at(i));
+                mrpt::system::os::fprintf(f, "%.8f", zs.at(i));
             }
             // Check float fields
             else if (floatFields.count(fieldName))
             {
-                mrpt::system::os::fprintf(f, "%f", floatFields.at(fieldName).at(i));
+                mrpt::system::os::fprintf(f, "%.8e", floatFields.at(fieldName).at(i));
             }
             // Check uint16 fields
             else if (uint16Fields.count(fieldName))
@@ -165,7 +165,7 @@ bool saveToTxt(
             // Check double fields
             else if (doubleFields.count(fieldName))
             {
-                mrpt::system::os::fprintf(f, "%lf", doubleFields.at(fieldName).at(i));
+                mrpt::system::os::fprintf(f, "%.16le", doubleFields.at(fieldName).at(i));
             }
             // Check uint8 fields
             else if (uint8Fields.count(fieldName))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Corrected numeric formatting precision in PLY file exports with type-specific decimal and scientific notation
  - Updated TXT file exports with consistent formatting: 8 decimal places for coordinates and scientific notation for floating-point values

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->