### PR TITLE
mm2txt and mm2ply: Add new option --ignore-missing-fields

### DIFF
--- a/apps/mm2ply/main.cpp
+++ b/apps/mm2ply/main.cpp
@@ -46,12 +46,18 @@ TCLAP::ValueArg<std::string> argExportFields(
     "the specified order.",
     false, "", "field1,field2,...", cmd);
 
+TCLAP::SwitchArg argIgnoreMissingFields(
+    "", "ignore-missing-fields",
+    "If defined, the lack of any of the --export-fields in the map will be considered a warning "
+    "instead of an error, and that column will be padded with zeros.",
+    cmd);
+
 // ----------------------------------------------------------------
 // PLY Export Logic using CPointsMap field-generic API
 // ----------------------------------------------------------------
 void saveToPly(
     const mrpt::maps::CPointsMap& pc, const std::string& filename, bool binary,
-    const std::vector<std::string>& selectedFields = {})
+    const std::vector<std::string>& selectedFields = {}, bool ignoreMissingFields = false)
 {
     std::ofstream f;
     f.open(filename, binary ? std::ios::binary : std::ios::out);
@@ -264,7 +270,12 @@ void saveToPly(
 #endif
             if (!found)
             {
-                throw std::runtime_error("Field not found: " + fieldName);
+                if (!ignoreMissingFields)
+                {
+                    throw std::runtime_error("Field not found: " + fieldName);
+                }
+                // Mark this accessor as invalid (nullptr) - will output zeros
+                acc.bufPtr = nullptr;
             }
         }
         accessors.push_back(acc);
@@ -287,6 +298,33 @@ void saveToPly(
     {
         for (const auto& acc : accessors)
         {
+            // Handle missing fields (when ignoreMissingFields is true)
+            if (acc.bufPtr == nullptr)
+            {
+                // Output zero for missing fields
+                switch (acc.type)
+                {
+                    case FieldAccessor::FLOAT:
+                        write_val(0.0f, "%.8e");
+                        break;
+#if MRPT_VERSION >= 0x020f03
+                    case FieldAccessor::DOUBLE:
+                        write_val(0.0, "%.16le");
+                        break;
+                    case FieldAccessor::UINT16:
+                        write_val(static_cast<uint16_t>(0), "%u");
+                        break;
+                    case FieldAccessor::UINT8:
+                        write_val(static_cast<uint8_t>(0), "%i");
+                        break;
+#endif
+                    default:
+                        write_val(0.0f, "%.8e");
+                        break;
+                }
+                continue;
+            }
+
             switch (acc.type)
             {
                 default:
@@ -472,16 +510,20 @@ int main(int argc, char** argv)
                         }
 #endif
                         std::cerr << std::endl;
-                        throw std::runtime_error(
-                            "Field '" + field +
-                            "' specified in --export-fields not found in layer '" + name + "'");
+                        if (!argIgnoreMissingFields.isSet())
+                        {
+                            throw std::runtime_error(
+                                "Field '" + field +
+                                "' specified in --export-fields not found in layer '" + name + "'");
+                        }
                     }
                 }
             }
 
             std::string out = prefix + "_" + name + ".ply";
             std::cout << "Exporting '" << name << "' to " << out << "..." << std::endl;
-            saveToPly(*pts, out, arg_binary.getValue(), selectedFields);
+            saveToPly(
+                *pts, out, arg_binary.getValue(), selectedFields, argIgnoreMissingFields.isSet());
         }
     }
     catch (const std::exception& e)

--- a/apps/mm2txt/main.cpp
+++ b/apps/mm2txt/main.cpp
@@ -54,6 +54,12 @@ TCLAP::ValueArg<std::string> argExportFields(
     "the specified order.",
     false, "", "field1,field2,...", cmd);
 
+TCLAP::SwitchArg argIgnoreMissingFields(
+    "", "ignore-missing-fields",
+    "If defined, the lack of any of the --export-fields in the map will be considered a warning "
+    "instead of an error, and that column will be padded with zeros.",
+    cmd);
+
 bool saveToTxt(
     const mrpt::maps::CGenericPointsMap& pts, const std::string& fileName, bool printHeader,
     const std::vector<std::string>& selectedFields = {})
@@ -332,9 +338,12 @@ void run_mm2txt()
                         }
 #endif
                         std::cerr << std::endl;
-                        THROW_EXCEPTION_FMT(
-                            "Field '%s' specified in --export-fields not found in layer '%s'",
-                            field.c_str(), name.c_str());
+                        if (!argIgnoreMissingFields.isSet())
+                        {
+                            THROW_EXCEPTION_FMT(
+                                "Field '%s' specified in --export-fields not found in layer '%s'",
+                                field.c_str(), name.c_str());
+                        }
                     }
                 }
             }

--- a/docs/source/app_mm2ply.rst
+++ b/docs/source/app_mm2ply.rst
@@ -24,7 +24,7 @@ Usage
 
 .. code-block:: bash
 
-   mm2ply -i <input.mm> [-o <output_prefix>] [-b] [--export-fields <field1,field2,...>]
+   mm2ply -i <input.mm> [-o <output_prefix>] [-b] [--export-fields <field1,field2,...>] [--ignore-missing-fields]
 
 Arguments
 ^^^^^^^^^
@@ -33,6 +33,7 @@ Arguments
 - ``-o, --output <prefix>`` (optional): Prefix for output PLY files. If not specified, uses the input filename without extension
 - ``-b, --binary`` (optional): Export in binary format instead of ASCII (default: ASCII)
 - ``--export-fields <field1,field2,...>`` (optional): Comma-separated list of fields to export in the specified order. If not provided, all available fields will be exported. Spaces around commas are allowed
+- ``--ignore-missing-fields`` (optional): If defined, the lack of any of the ``--export-fields`` in the map will be considered a warning instead of an error, and that column will be padded with zeros.
 
 Examples
 ^^^^^^^^

--- a/docs/source/app_mm2txt.rst
+++ b/docs/source/app_mm2txt.rst
@@ -25,7 +25,7 @@ Usage
 
 .. code-block:: bash
 
-   mm2txt <input.mm> [-l <layer_name>] [--export-fields <field1,field2,...>]
+   mm2txt <input.mm> [-l <layer_name>] [--export-fields <field1,field2,...>] [--ignore-missing-fields]
 
 Arguments
 ^^^^^^^^^
@@ -33,6 +33,7 @@ Arguments
 - ``input`` (required): Input metric map file (\*.mm)
 - ``-l, --layer <name>`` (optional): Layer to export. If not provided, all layers will be exported. This argument can appear multiple times to export specific layers
 - ``--export-fields <field1,field2,...>`` (optional): Comma-separated list of fields to export in the specified order. If not provided, all available fields will be exported. Spaces around commas are allowed
+- ``--ignore-missing-fields`` (optional): If defined, the lack of any of the ``--export-fields`` in the map will be considered a warning instead of an error, and that column will be padded with zeros.
 
 Examples
 ^^^^^^^^


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new --ignore-missing-fields option for mm2ply and mm2txt: when set, missing fields listed in --export-fields produce warnings and those output columns are zero-padded instead of causing errors.

* **Documentation**
  * Updated mm2ply and mm2txt usage docs to describe the new flag and its behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->