### PR TITLE
mm2txt, mm2ply: don't emit columns of zeros for missing user-given fields

### DIFF
--- a/apps/mm2ply/main.cpp
+++ b/apps/mm2ply/main.cpp
@@ -49,7 +49,7 @@ TCLAP::ValueArg<std::string> argExportFields(
 TCLAP::SwitchArg argIgnoreMissingFields(
     "", "ignore-missing-fields",
     "If defined, the lack of any of the --export-fields in the map will be considered a warning "
-    "instead of an error, and that column will be padded with zeros.",
+    "instead of an error; missing fields are skipped.",
     cmd);
 
 // ----------------------------------------------------------------
@@ -425,6 +425,7 @@ int main(int argc, char** argv)
             {
                 continue;
             }
+            std::vector<std::string> validFields;
 
             // Validate selected fields exist in this point cloud
             if (!selectedFields.empty())
@@ -436,6 +437,7 @@ int main(int argc, char** argv)
                 const auto u8_names  = pts->getPointFieldNames_uint8();
 #endif
 
+                // Filter selectedFields to only include fields that exist
                 for (const auto& field : selectedFields)
                 {
                     bool found = (field == "x" || field == "y" || field == "z");
@@ -509,7 +511,7 @@ int main(int argc, char** argv)
                             std::cerr << ", " << fn;
                         }
 #endif
-                        std::cerr << std::endl;
+                        std::cerr << " - skipping this field." << std::endl;
                         if (!argIgnoreMissingFields.isSet())
                         {
                             throw std::runtime_error(
@@ -517,13 +519,22 @@ int main(int argc, char** argv)
                                 "' specified in --export-fields not found in layer '" + name + "'");
                         }
                     }
+                    else
+                    {
+                        validFields.push_back(field);
+                    }
+                }
+                if (validFields.empty())
+                {
+                    std::cerr << "Warning: None of the requested fields exist in layer '" << name
+                              << "'. Skipping export for this layer." << std::endl;
+                    continue;
                 }
             }
 
             std::string out = prefix + "_" + name + ".ply";
             std::cout << "Exporting '" << name << "' to " << out << "..." << std::endl;
-            saveToPly(
-                *pts, out, arg_binary.getValue(), selectedFields, argIgnoreMissingFields.isSet());
+            saveToPly(*pts, out, arg_binary.getValue(), validFields);
         }
     }
     catch (const std::exception& e)

--- a/apps/mm2txt/main.cpp
+++ b/apps/mm2txt/main.cpp
@@ -57,7 +57,7 @@ TCLAP::ValueArg<std::string> argExportFields(
 TCLAP::SwitchArg argIgnoreMissingFields(
     "", "ignore-missing-fields",
     "If defined, the lack of any of the --export-fields in the map will be considered a warning "
-    "instead of an error, and that column will be padded with zeros.",
+    "instead of an error; missing fields are skipped.",
     cmd);
 
 bool saveToTxt(
@@ -297,6 +297,7 @@ void run_mm2txt()
         if (auto* genxyz = dynamic_cast<const mrpt::maps::CGenericPointsMap*>(pts); genxyz)
         {
             // Validate selected fields exist in this point cloud
+            std::vector<std::string> validFields;
             if (!selectedFields.empty())
             {
                 const auto& floatFields  = genxyz->float_fields();
@@ -337,7 +338,7 @@ void run_mm2txt()
                             std::cerr << ", " << fname;
                         }
 #endif
-                        std::cerr << std::endl;
+                        std::cerr << " - skipping this field." << std::endl;
                         if (!argIgnoreMissingFields.isSet())
                         {
                             THROW_EXCEPTION_FMT(
@@ -345,11 +346,25 @@ void run_mm2txt()
                                 field.c_str(), name.c_str());
                         }
                     }
+                    else
+                    {
+                        validFields.push_back(field);
+                    }
                 }
+                if (validFields.empty())
+                {
+                    std::cerr << "Warning: None of the requested fields exist in layer '" << name
+                              << "'. Skipping export for this layer." << std::endl;
+                    continue;
+                }
+            }
+            else
+            {
+                validFields = selectedFields;
             }
 
             bool printHeader = true;
-            saveToTxt(*genxyz, filName, printHeader, selectedFields);
+            saveToTxt(*genxyz, filName, printHeader, validFields);
         }
 #if MRPT_VERSION < 0x030000  // <3.0.0
         else

--- a/docs/source/app_mm2ply.rst
+++ b/docs/source/app_mm2ply.rst
@@ -33,7 +33,7 @@ Arguments
 - ``-o, --output <prefix>`` (optional): Prefix for output PLY files. If not specified, uses the input filename without extension
 - ``-b, --binary`` (optional): Export in binary format instead of ASCII (default: ASCII)
 - ``--export-fields <field1,field2,...>`` (optional): Comma-separated list of fields to export in the specified order. If not provided, all available fields will be exported. Spaces around commas are allowed
-- ``--ignore-missing-fields`` (optional): If defined, the lack of any of the ``--export-fields`` in the map will be considered a warning instead of an error, and that column will be padded with zeros.
+- ``--ignore-missing-fields`` (optional): If defined, the lack of any of the ``--export-fields`` in the map will be considered a warning instead of an error.
 
 Examples
 ^^^^^^^^
@@ -102,7 +102,7 @@ When using the ``--export-fields`` option:
 - Fields must be specified as a comma-separated list
 - Spaces around commas are allowed (e.g., ``"x, y, z"`` or ``"x,y,z"``)
 - Fields will be exported in the exact order specified
-- All specified fields must exist in the point cloud, or an error will be raised
+- All specified fields must exist in the point cloud, or an error will be raised (unless ``--ignore-missing-fields`` is added)
 - The tool validates field availability and reports available fields if a requested field is not found
 - Color fields (``color_r``, ``color_g``, ``color_b``) are automatically mapped to PLY standard names (``red``, ``green``, ``blue``) in the output file, even when using field selection
 

--- a/docs/source/app_mm2txt.rst
+++ b/docs/source/app_mm2txt.rst
@@ -33,7 +33,7 @@ Arguments
 - ``input`` (required): Input metric map file (\*.mm)
 - ``-l, --layer <name>`` (optional): Layer to export. If not provided, all layers will be exported. This argument can appear multiple times to export specific layers
 - ``--export-fields <field1,field2,...>`` (optional): Comma-separated list of fields to export in the specified order. If not provided, all available fields will be exported. Spaces around commas are allowed
-- ``--ignore-missing-fields`` (optional): If defined, the lack of any of the ``--export-fields`` in the map will be considered a warning instead of an error, and that column will be padded with zeros.
+- ``--ignore-missing-fields`` (optional): If defined, the lack of any of the ``--export-fields`` in the map will be considered a warning instead of an error.
 
 Examples
 ^^^^^^^^
@@ -122,7 +122,7 @@ When using the ``--export-fields`` option:
 - Fields must be specified as a comma-separated list
 - Spaces around commas are allowed (e.g., ``"x, y, z"`` or ``"x,y,z"``)
 - Fields will be exported in the exact order specified
-- All specified fields must exist in the point cloud, or an error will be raised
+- All specified fields must exist in the point cloud, or an error will be raised (unless ``--ignore-missing-fields`` is added)
 - The tool validates field availability and reports available fields if a requested field is not found
 - This option is only supported for **CGenericPointsMap** point clouds; for legacy types (CPointsMapXYZI, CPointsMapXYZIRT), all fields are exported with a warning
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Per-layer field validation for exports to ensure only existing fields are written.
  * If a layer has no valid fields, that layer is skipped and a warning is emitted.
  * Improved missing-field warnings now list available fields and note when a field is skipped.

* **Documentation**
  * Updated PLY/TXT export docs: missing fields produce warnings (no zero-padding) and errors are suppressed when the ignore-missing option is used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->