### PR TITLE
Use ZStd compression by default (for MRPT>=2.15.7)

### DIFF
--- a/apps/icp-log-viewer/main.cpp
+++ b/apps/icp-log-viewer/main.cpp
@@ -28,6 +28,7 @@
 #include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/config.h>
 #include <mrpt/config/CConfigFile.h>
+#include <mrpt/core/Clock.h>
 #include <mrpt/core/round.h>
 #include <mrpt/opengl/CEllipsoid3D.h>
 #include <mrpt/opengl/CGridPlaneXY.h>

--- a/apps/icp-log-viewer/main.cpp
+++ b/apps/icp-log-viewer/main.cpp
@@ -470,7 +470,10 @@ void main_show_gui()
         {
             return;
         }
-        m.save_to_file(outFile);
+        if (bool ok = m.save_to_file(outFile); !ok)
+        {
+            std::cerr << "Error saving file: " << outFile << "\n";
+        }
     };
 
     // tab 2: variables

--- a/apps/kitti2mm/main.cpp
+++ b/apps/kitti2mm/main.cpp
@@ -48,7 +48,10 @@ int main(int argc, char** argv)
     try
     {
         // Parse arguments:
-        if (!cmd.parse(argc, argv)) return 1;  // should exit.
+        if (!cmd.parse(argc, argv))
+        {
+            return 1;  // should exit.
+        }
 
         const auto& f = argInput.getValue();
 
@@ -62,11 +65,19 @@ int main(int argc, char** argv)
         mp2p_icp::metric_map_t mm;
         mm.layers["raw"] = std::move(obs->pointcloud);
 
-        if (argID.isSet()) mm.id = argID.getValue();
-        if (argLabel.isSet()) mm.label = argLabel.getValue();
+        if (argID.isSet())
+        {
+            mm.id = argID.getValue();
+        }
+        if (argLabel.isSet())
+        {
+            mm.label = argLabel.getValue();
+        }
 
         if (!mm.save_to_file(argOutput.getValue()))
+        {
             THROW_EXCEPTION_FMT("Error writing to target file '%s'", argOutput.getValue().c_str());
+        }
     }
     catch (const std::exception& e)
     {

--- a/apps/mm-filter/main.cpp
+++ b/apps/mm-filter/main.cpp
@@ -169,7 +169,7 @@ int main(int argc, char** argv)
     }
     catch (const std::exception& e)
     {
-        std::cerr << e.what();
+        std::cerr << e.what() << std::endl;
         return 1;
     }
     return 0;

--- a/apps/mm-georef/main.cpp
+++ b/apps/mm-georef/main.cpp
@@ -200,7 +200,7 @@ int main(int argc, char** argv)
     }
     catch (const std::exception& e)
     {
-        std::cerr << e.what();
+        std::cerr << e.what() << std::endl;
         return 1;
     }
     return 0;

--- a/apps/mm-georef/main.cpp
+++ b/apps/mm-georef/main.cpp
@@ -148,7 +148,11 @@ void run_mm_inject(Cli& cli)
 
     std::cout << "[mm-georef] Saving updated map to: '" << filMap << "'..." << std::endl;
 
-    mm.save_to_file(filMap);
+    bool ok = mm.save_to_file(filMap);
+    if (!ok)
+    {
+        THROW_EXCEPTION_FMT("Error saving updated map to file: '%s'", filMap.c_str());
+    }
 }
 
 void run_mm_georef(Cli& cli)

--- a/apps/mm-info/main.cpp
+++ b/apps/mm-info/main.cpp
@@ -22,6 +22,7 @@
 #include <mp2p_icp/metricmap.h>
 #include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/containers/yaml.h>
+#include <mrpt/core/Clock.h>
 #include <mrpt/system/filesystem.h>
 
 // CLI flags:

--- a/apps/mm-info/main.cpp
+++ b/apps/mm-info/main.cpp
@@ -40,11 +40,14 @@ void run_mm_info()
     ASSERT_FILE_EXISTS_(argMapFile.getValue());
 
     std::cout << "[mm-info] Reading input map from: '" << filInput << "'..." << std::endl;
+    const double mm_t0 = mrpt::Clock::nowDouble();
 
     mp2p_icp::metric_map_t mm;
     mm.load_from_file(filInput);
 
-    std::cout << "[mm-info] Done read map. Contents:\n" << mm.contents_summary() << std::endl;
+    const double mm_t1 = mrpt::Clock::nowDouble();
+    std::cout << "[mm-info] Done read map in " << (mm_t1 - mm_t0) << " sec. Contents:\n"
+              << mm.contents_summary() << std::endl;
 }
 
 int main(int argc, char** argv)

--- a/apps/mm-info/main.cpp
+++ b/apps/mm-info/main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char** argv)
     }
     catch (const std::exception& e)
     {
-        std::cerr << e.what();
+        std::cerr << e.what() << std::endl;
         return 1;
     }
     return 0;

--- a/apps/mm2txt/main.cpp
+++ b/apps/mm2txt/main.cpp
@@ -207,11 +207,14 @@ void run_mm2txt()
     ASSERT_FILE_EXISTS_(argMapFile.getValue());
 
     std::cout << "[mm-info] Reading input map from: '" << filInput << "'..." << std::endl;
+    const double mm_t0 = mrpt::Clock::nowDouble();
 
     mp2p_icp::metric_map_t mm;
     mm.load_from_file(filInput);
 
-    std::cout << "[mm-info] Done read map. Contents:\n" << mm.contents_summary() << std::endl;
+    const double mm_t1 = mrpt::Clock::nowDouble();
+    std::cout << "[mm-info] Done read map in " << (mm_t1 - mm_t0) << " sec. Contents:\n"
+              << mm.contents_summary() << "\n";
 
     std::vector<std::string> layers;
     if (argLayers.isSet())

--- a/apps/mm2txt/main.cpp
+++ b/apps/mm2txt/main.cpp
@@ -416,7 +416,7 @@ int main(int argc, char** argv)
     }
     catch (const std::exception& e)
     {
-        std::cerr << e.what();
+        std::cerr << e.what() << std::endl;
         return 1;
     }
     return 0;

--- a/apps/mm2txt/main.cpp
+++ b/apps/mm2txt/main.cpp
@@ -22,6 +22,7 @@
 #include <mp2p_icp/metricmap.h>
 #include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/containers/yaml.h>
+#include <mrpt/core/Clock.h>
 #include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/system/os.h>

--- a/apps/rawlog-filter/main.cpp
+++ b/apps/rawlog-filter/main.cpp
@@ -23,6 +23,7 @@
 #include <mp2p_icp_filters/Generator.h>
 #include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/containers/yaml.h>
+#include <mrpt/core/Clock.h>
 #include <mrpt/io/lazy_load_path.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CRawlog.h>

--- a/apps/rawlog-filter/main.cpp
+++ b/apps/rawlog-filter/main.cpp
@@ -23,7 +23,6 @@
 #include <mp2p_icp_filters/Generator.h>
 #include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/containers/yaml.h>
-#include <mrpt/io/CFileGZOutputStream.h>
 #include <mrpt/io/lazy_load_path.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CRawlog.h>
@@ -31,6 +30,13 @@
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/system/progress.h>
+#include <mrpt/version.h>
+
+#if MRPT_VERSION >= 0x020f07
+#include <mrpt/io/CCompressedOutputStream.h>
+#else
+#include <mrpt/io/CFileGZOutputStream.h>
+#endif
 
 // CLI flags:
 struct Cli
@@ -174,8 +180,14 @@ void run_mm_filter(Cli& cli)
     const auto filOut = cli.argOutput.getValue();
     std::cout << "[rawlog-filter] Creating output rawlog file: '" << filOut << "'..." << std::endl;
 
+#if MRPT_VERSION >= 0x020f07
+    mrpt::io::CCompressedOutputStream fo(
+        filOut, mrpt::io::OpenMode::TRUNCATE, {mrpt::io::CompressionType::Zstd});
+#else
     mrpt::io::CFileGZOutputStream fo(filOut);
-    auto                          outArch = mrpt::serialization::archiveFrom(fo);
+#endif
+
+    auto outArch = mrpt::serialization::archiveFrom(fo);
 
     if (cli.arg_lazy_load_base_dir.isSet())
     {

--- a/apps/rawlog-filter/main.cpp
+++ b/apps/rawlog-filter/main.cpp
@@ -272,7 +272,7 @@ int main(int argc, char** argv)
     }
     catch (const std::exception& e)
     {
-        std::cerr << e.what();
+        std::cerr << e.what() << std::endl;
         return 1;
     }
     return 0;

--- a/apps/sm2mm/main.cpp
+++ b/apps/sm2mm/main.cpp
@@ -251,7 +251,7 @@ int main(int argc, char** argv)
     }
     catch (const std::exception& e)
     {
-        std::cerr << e.what();
+        std::cerr << e.what() << std::endl;
         return 1;
     }
     return 0;

--- a/apps/sm2mm/main.cpp
+++ b/apps/sm2mm/main.cpp
@@ -26,6 +26,11 @@
 #include <mrpt/io/lazy_load_path.h>
 #include <mrpt/system/COutputLogger.h>
 #include <mrpt/system/filesystem.h>
+#include <mrpt/version.h>
+
+#if MRPT_VERSION >= 0x020f07
+#include <mrpt/io/compression_options.h>
+#endif
 
 // CLI flags:
 struct CLI
@@ -65,6 +70,19 @@ struct CLI
     TCLAP::ValueArg<std::string> arg_verbosity_level{
         "v",    "verbosity", "Verbosity level: ERROR|WARN|INFO|DEBUG (Default: INFO)", false, "",
         "INFO", cmd};
+
+#if MRPT_VERSION >= 0x020f07
+    TCLAP::ValueArg<std::string> arg_compression_method{
+        "",
+        "compression-method",
+        "Compression method to use in the output metric map .mm file. "
+        "Options: CompressionType::None|CompressionType::Gzip|CompressionType::Zstd. (Default: "
+        "CompressionType::Zstd)",
+        false,
+        "CompressionType::Zstd",
+        "METHOD",
+        cmd};
+#endif
 
     TCLAP::ValueArg<std::string> arg_lazy_load_base_dir{
         "",
@@ -117,10 +135,14 @@ void run_sm_to_mm(CLI& cli)
     mrpt::maps::CSimpleMap sm;
 
     std::cout << "[sm2mm] Reading simplemap from: '" << filSM << "'..." << std::endl;
+    const double sm_t0 = mrpt::Clock::nowDouble();
 
     sm.loadFromFile(filSM);
 
-    std::cout << "[sm2mm] Done read simplemap with " << sm.size() << " keyframes." << std::endl;
+    const double sm_t1 = mrpt::Clock::nowDouble();
+    std::cout << "[sm2mm] Done read simplemap with " << sm.size() << " keyframes in "
+              << (sm_t1 - sm_t0) << " sec.\n";
+
     ASSERT_(!sm.empty());
 
     // Load pipeline from YAML file:
@@ -194,7 +216,20 @@ void run_sm_to_mm(CLI& cli)
     const auto filOut = cli.argOutput.getValue();
     std::cout << "[sm2mm] Writing metric map to: '" << filOut << "'..." << std::endl;
 
+#if MRPT_VERSION >= 0x020f07
+    mrpt::io::CompressionOptions compOpts{mrpt::io::CompressionType::Zstd, 3 /*default level*/};
+    if (cli.arg_compression_method.isSet())
+    {
+        using ct      = mrpt::typemeta::TEnumType<mrpt::io::CompressionType>;
+        compOpts.type = ct::name2value(cli.arg_compression_method.getValue());
+    }
+#endif
+
+#if MRPT_VERSION >= 0x020f07
+    if (!mm.save_to_file(filOut, compOpts))
+#else
     if (!mm.save_to_file(filOut))
+#endif
     {
         THROW_EXCEPTION_FMT("Error writing to target file '%s'", filOut.c_str());
     }

--- a/apps/sm2mm/main.cpp
+++ b/apps/sm2mm/main.cpp
@@ -23,6 +23,7 @@
 #include <mp2p_icp_filters/sm2mm.h>
 #include <mrpt/3rdparty/tclap/CmdLine.h>
 #include <mrpt/containers/yaml.h>
+#include <mrpt/core/Clock.h>
 #include <mrpt/io/lazy_load_path.h>
 #include <mrpt/system/COutputLogger.h>
 #include <mrpt/system/filesystem.h>

--- a/docs/source/app_sm2mm.rst
+++ b/docs/source/app_sm2mm.rst
@@ -33,9 +33,9 @@ CLI Reference
 
     sm2mm  [--decimate-max <N>] [--decimate-nth <N>] [--to-index <0>]
             [--from-index <0>] [--profiler] [--no-progress-bar]
-            [--externals-dir <<ExternalsDirectory>>] [-v <INFO>] [-p
-            <pipeline.yaml>] [-l <foobar.so>] -o <out.mm> -i <map.simplemap>
-            [--] [--version] [-h]
+            [--externals-dir <<ExternalsDirectory>>] [--compression-method
+            <METHOD>] [-v <INFO>] [-p <pipeline.yaml>] [-l <foobar.so>] -o
+            <out.mm> -i <map.simplemap> [--] [--version] [-h]
 
 
     Where:
@@ -64,6 +64,11 @@ CLI Reference
     --externals-dir <<ExternalsDirectory>>
         Lazy-load base directory for datasets with externally-stored
         observations
+
+    --compression-method <METHOD>
+        Compression method to use in the output metric map .mm file. Options:
+        CompressionType::None|CompressionType::Gzip|CompressionType::Zstd.
+        (Default: CompressionType::Zstd)
 
     -v <INFO>,  --verbosity <INFO>
         Verbosity level: ERROR|WARN|INFO|DEBUG (Default: INFO)

--- a/mp2p_icp/include/mp2p_icp/LogRecord.h
+++ b/mp2p_icp/include/mp2p_icp/LogRecord.h
@@ -24,6 +24,9 @@
 #include <mp2p_icp/Results.h>
 #include <mp2p_icp/metricmap.h>
 #include <mrpt/serialization/CSerializable.h>
+#if MRPT_VERSION >= 0x020f07
+#include <mrpt/io/compression_options.h>
+#endif
 
 #include <optional>
 
@@ -40,8 +43,7 @@ class LogRecord : public mrpt::serialization::CSerializable
     DEFINE_SERIALIZABLE(LogRecord, mp2p_icp)
 
    public:
-    LogRecord()  = default;
-    ~LogRecord() = default;
+    LogRecord() = default;
 
     /** @name Data fields
      * @{ */
@@ -79,7 +81,13 @@ class LogRecord : public mrpt::serialization::CSerializable
      *  using on-the-fly GZIP compression.
      * \return true on success.
      */
-    bool save_to_file(const std::string& fileName) const;
+#if MRPT_VERSION >= 0x020f07
+    [[nodiscard]] bool save_to_file(
+        const std::string&                  fileName,
+        const mrpt::io::CompressionOptions& co = {mrpt::io::CompressionType::Zstd}) const;
+#else
+    [[nodiscard]] bool save_to_file(const std::string& fileName) const;
+#endif
 
     /** Loads the record object from a file. See \save_to_file()
      * \return true on success.

--- a/mp2p_icp/src/LogRecord.cpp
+++ b/mp2p_icp/src/LogRecord.cpp
@@ -13,11 +13,18 @@
 */
 
 #include <mp2p_icp/LogRecord.h>
-#include <mrpt/io/CFileGZInputStream.h>
-#include <mrpt/io/CFileGZOutputStream.h>
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/serialization/optional_serialization.h>
 #include <mrpt/serialization/stl_serialization.h>
+#include <mrpt/version.h>
+
+#if MRPT_VERSION >= 0x020f07
+#include <mrpt/io/CCompressedInputStream.h>
+#include <mrpt/io/CCompressedOutputStream.h>
+#else
+#include <mrpt/io/CFileGZInputStream.h>
+#include <mrpt/io/CFileGZOutputStream.h>
+#endif
 
 IMPLEMENTS_MRPT_OBJECT(LogRecord, mrpt::serialization::CSerializable, mp2p_icp)
 
@@ -74,9 +81,13 @@ void LogRecord::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version
             in >> initialGuessLocalWrtGlobal >> icpParameters >> icpResult >> iterationsDetails;
 
             if (version >= 1)
+            {
                 in >> dynamicVariables;
+            }
             else
+            {
                 dynamicVariables.clear();
+            }
         }
         break;
         default:
@@ -84,12 +95,25 @@ void LogRecord::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version
     };
 }
 
-bool LogRecord::save_to_file(const std::string& fileName) const
+bool LogRecord::save_to_file(
+#if MRPT_VERSION >= 0x020f07
+    const std::string& fileName, const mrpt::io::CompressionOptions& co
+#else
+    const std::string& fileName
+#endif
+) const
 {
     try
     {
+#if MRPT_VERSION >= 0x020f07
+        auto f = mrpt::io::CCompressedOutputStream(fileName, mrpt::io::OpenMode::TRUNCATE, co);
+#else
         auto f = mrpt::io::CFileGZOutputStream(fileName);
-        if (!f.is_open()) return false;
+#endif
+        if (!f.is_open())
+        {
+            return false;
+        }
 
         auto arch = mrpt::serialization::archiveFrom(f);
         arch << *this;
@@ -107,8 +131,15 @@ bool LogRecord::load_from_file(const std::string& fileName)
 {
     try
     {
+#if MRPT_VERSION >= 0x020f07
+        auto f = mrpt::io::CCompressedInputStream(fileName);
+#else
         auto f = mrpt::io::CFileGZInputStream(fileName);
-        if (!f.is_open()) return false;
+#endif
+        if (!f.is_open())
+        {
+            return false;
+        }
 
         auto arch = mrpt::serialization::archiveFrom(f);
         arch >> *this;

--- a/mp2p_icp/src/LogRecord.cpp
+++ b/mp2p_icp/src/LogRecord.cpp
@@ -148,7 +148,7 @@ bool LogRecord::load_from_file(const std::string& fileName)
     }
     catch (const std::exception& e)
     {
-        std::cerr << "[LogRecord::save_to_file] Error: " << e.what();
+        std::cerr << "[LogRecord::load_from_file] Error: " << e.what();
         return false;
     }
 }

--- a/mp2p_icp_filters/src/FilterDeskew.cpp
+++ b/mp2p_icp_filters/src/FilterDeskew.cpp
@@ -27,6 +27,7 @@
 #include <mp2p_icp_filters/FilterDeskew.h>
 #include <mp2p_icp_filters/GetOrCreatePointLayer.h>
 #include <mrpt/containers/yaml.h>
+#include <mrpt/core/Clock.h>
 #include <mrpt/core/exceptions.h>
 #include <mrpt/maps/CPointsMapXYZIRT.h>
 #include <mrpt/maps/CSimplePointsMap.h>

--- a/mp2p_icp_map/include/mp2p_icp/metricmap.h
+++ b/mp2p_icp_map/include/mp2p_icp/metricmap.h
@@ -33,6 +33,10 @@
 #include <mrpt/poses/CPose3DPDFGaussian.h>
 #include <mrpt/serialization/CSerializable.h>
 #include <mrpt/topography/data_types.h>
+#include <mrpt/version.h>
+#if MRPT_VERSION >= 0x020f07
+#include <mrpt/io/compression_options.h>
+#endif
 
 #include <map>
 #include <memory>
@@ -175,7 +179,13 @@ class metric_map_t : public mrpt::serialization::CSerializable,
      *  using on-the-fly GZIP compression.
      * \return true on success.
      */
-    bool save_to_file(const std::string& fileName) const;
+#if MRPT_VERSION >= 0x020f07
+    [[nodiscard]] bool save_to_file(
+        const std::string&                  fileName,
+        const mrpt::io::CompressionOptions& co = {mrpt::io::CompressionType::Zstd}) const;
+#else
+    [[nodiscard]] bool save_to_file(const std::string& fileName) const;
+#endif
 
     /** Loads the metric_map_t object from a file. See \save_to_file()
      * \return true on success.

--- a/mp2p_icp_map/src/load_xyz_file.cpp
+++ b/mp2p_icp_map/src/load_xyz_file.cpp
@@ -20,8 +20,14 @@
  */
 
 #include <mp2p_icp/load_xyz_file.h>
-#include <mrpt/io/CFileGZInputStream.h>
 #include <mrpt/system/filesystem.h>
+#include <mrpt/version.h>
+
+#if MRPT_VERSION >= 0x020f07
+#include <mrpt/io/CCompressedInputStream.h>
+#else
+#include <mrpt/io/CFileGZInputStream.h>
+#endif
 
 #include <fstream>
 
@@ -34,8 +40,13 @@ mrpt::maps::CSimplePointsMap::Ptr mp2p_icp::load_xyz_file(const std::string& fil
 
     if (mrpt::system::extractFileExtension(fil) == "gz")
     {
+#if MRPT_VERSION >= 0x020f07
+        mrpt::io::CCompressedInputStream f(fil);
+#else
         mrpt::io::CFileGZInputStream f(fil);
-        std::string                  buf;
+#endif
+
+        std::string buf;
         while (!f.checkEOF())
         {
             const size_t N = 10000;

--- a/mp2p_icp_map/src/metricmap.cpp
+++ b/mp2p_icp_map/src/metricmap.cpp
@@ -644,11 +644,18 @@ bool metric_map_t::save_to_file(
     {
         return false;
     }
+    try
+    {
+        auto arch = mrpt::serialization::archiveFrom(f);
+        arch << *this;
 
-    auto arch = mrpt::serialization::archiveFrom(f);
-    arch << *this;
-
-    return true;
+        return true;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "[metric_map_t::save_to_file] Error: " << e.what();
+        return false;
+    }
 }
 
 bool metric_map_t::load_from_file(

--- a/mp2p_icp_map/src/metricmap.cpp
+++ b/mp2p_icp_map/src/metricmap.cpp
@@ -21,8 +21,6 @@
 #include <mp2p_icp/MetricMapMergeCapable.h>
 #include <mp2p_icp/metricmap.h>
 #include <mrpt/containers/yaml.h>
-#include <mrpt/io/CFileGZInputStream.h>
-#include <mrpt/io/CFileGZOutputStream.h>
 #include <mrpt/maps/CVoxelMap.h>
 #include <mrpt/maps/CVoxelMapRGB.h>
 #include <mrpt/obs/customizable_obs_viz.h>
@@ -36,6 +34,14 @@
 #include <mrpt/serialization/stl_serialization.h>
 #include <mrpt/system/string_utils.h>  // unitsFormat()
 #include <mrpt/version.h>
+
+#if MRPT_VERSION >= 0x020f07
+#include <mrpt/io/CCompressedInputStream.h>
+#include <mrpt/io/CCompressedOutputStream.h>
+#else
+#include <mrpt/io/CFileGZInputStream.h>
+#include <mrpt/io/CFileGZOutputStream.h>
+#endif
 
 #include <algorithm>
 #include <iterator>
@@ -621,9 +627,19 @@ std::string metric_map_t::contents_summary() const
     return ret;
 }
 
-bool metric_map_t::save_to_file(const std::string& fileName) const
+bool metric_map_t::save_to_file(
+#if MRPT_VERSION >= 0x020f07
+    const std::string& fileName, const mrpt::io::CompressionOptions& co
+#else
+    const std::string& fileName
+#endif
+) const
 {
+#if MRPT_VERSION >= 0x020f07
+    auto f = mrpt::io::CCompressedOutputStream(fileName, mrpt::io::OpenMode::TRUNCATE, co);
+#else
     auto f = mrpt::io::CFileGZOutputStream(fileName);
+#endif
     if (!f.is_open())
     {
         return false;
@@ -640,7 +656,11 @@ bool metric_map_t::load_from_file(
 {
     using namespace std::string_literals;
 
+#if MRPT_VERSION >= 0x020f07
+    auto f = mrpt::io::CCompressedInputStream(fileName);
+#else
     auto f = mrpt::io::CFileGZInputStream(fileName);
+#endif
     if (!f.is_open())
     {
         if (outErrorMsg)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added error validation for file save operations; failures are now reported with error messages instead of silently failing.

* **New Features**
  * Added timing measurements for map loading and reading operations, displayed in output.
  * Added compression method configuration option for saving metric map files (supported in newer MRPT versions).

* **Chores**
  * Updated codebase for compatibility with newer MRPT library versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->