### PR TITLE
sm2mm: Add optional flag --permit-missing-externals

### DIFF
--- a/apps/sm2mm/main.cpp
+++ b/apps/sm2mm/main.cpp
@@ -102,6 +102,12 @@ struct CLI
 
     TCLAP::SwitchArg argProfiler{"", "profiler", "Enables profiler.", cmd};
 
+    TCLAP::SwitchArg argDontThrowOnMissingExternals{
+        "", "permit-missing-externals",
+        "If set, missing external files will generate a warning instead of an exception stopping "
+        "the processing.",
+        cmd};
+
     TCLAP::ValueArg<size_t> argIndexFrom{
         "",
         "from-index",
@@ -206,6 +212,11 @@ void run_sm_to_mm(CLI& cli)
     {
         profiler.emplace();
         opts.profiler = *profiler;
+    }
+
+    if (cli.argDontThrowOnMissingExternals.isSet())
+    {
+        opts.throw_on_missing_external_files = false;
     }
 
     // Create the map:

--- a/docs/source/app_sm2mm.rst
+++ b/docs/source/app_sm2mm.rst
@@ -32,10 +32,11 @@ CLI Reference
     USAGE:
 
     sm2mm  [--decimate-max <N>] [--decimate-nth <N>] [--to-index <0>]
-            [--from-index <0>] [--profiler] [--no-progress-bar]
-            [--externals-dir <<ExternalsDirectory>>] [--compression-method
-            <METHOD>] [-v <INFO>] [-p <pipeline.yaml>] [-l <foobar.so>] -o
-            <out.mm> -i <map.simplemap> [--] [--version] [-h]
+            [--from-index <0>] [--permit-missing-externals] [--profiler]
+            [--no-progress-bar] [--externals-dir <<ExternalsDirectory>>]
+            [--compression-method <METHOD>] [-v <INFO>] [-p <pipeline.yaml>]
+            [-l <foobar.so>] -o <out.mm> -i <map.simplemap> [--] [--version]
+            [-h]
 
 
     Where:
@@ -53,6 +54,10 @@ CLI Reference
     --from-index <0>
         If provided, the simplemap keyframes until this index will be
         discarded and it will start at this point.
+
+    --permit-missing-externals
+        If set, missing external files will generate a warning instead of an
+        exception stopping the processing.
 
     --profiler
         Enables profiler.

--- a/mp2p_icp_filters/include/mp2p_icp_filters/sm2mm.h
+++ b/mp2p_icp_filters/include/mp2p_icp_filters/sm2mm.h
@@ -43,7 +43,8 @@ struct sm2mm_options_t
 
     mrpt::system::VerbosityLevel                  verbosity       = mrpt::system::LVL_INFO;
     bool                                          showProgressBar = false;
-    std::vector<std::pair<std::string, double>>   customVariables = {};
+    bool                                          throw_on_missing_external_files = true;
+    std::vector<std::pair<std::string, double>>   customVariables                 = {};
     std::optional<size_t>                         start_index;
     std::optional<size_t>                         end_index;
     mrpt::optional_ref<mrpt::system::CTimeLogger> profiler;

--- a/mp2p_icp_filters/src/sm2mm.cpp
+++ b/mp2p_icp_filters/src/sm2mm.cpp
@@ -34,6 +34,34 @@
 #include <cmath>
 #include <iostream>
 
+namespace
+{
+std::string first_n_lines(const std::string& input, std::size_t n)
+{
+    if (n == 0)
+    {
+        return {};
+    }
+
+    std::size_t pos   = 0;
+    std::size_t lines = 0;
+
+    while (lines < n)
+    {
+        pos = input.find('\n', pos);
+        if (pos == std::string::npos)
+        {
+            // Fewer than n lines: return entire string
+            return input;
+        }
+        ++pos;  // move past '\n'
+        ++lines;
+    }
+
+    return input.substr(0, pos);
+}
+}  // namespace
+
 void mp2p_icp_filters::simplemap_to_metricmap(
     const mrpt::maps::CSimpleMap& sm, mp2p_icp::metric_map_t& mm,
     const mrpt::containers::yaml& yamlData, const sm2mm_options_t& options)
@@ -206,22 +234,41 @@ void mp2p_icp_filters::simplemap_to_metricmap(
 #endif
         }
 
-        // Next, do the actual sensor data processing:
-        for (const auto& obs : *sf)
+        try
         {
-            ASSERT_(obs);
-            obs->load();
-
-            bool handled = mp2p_icp_filters::apply_generators(generators, *obs, mm, robotPose);
-
-            if (!handled)
+            // Next, do the actual sensor data processing:
+            for (const auto& obs : *sf)
             {
+                ASSERT_(obs);
+                obs->load();
+
+                bool handled = mp2p_icp_filters::apply_generators(generators, *obs, mm, robotPose);
+
+                if (!handled)
+                {
+                    obs->unload();
+                    continue;
+                }
+
+                // process it:
+                mp2p_icp_filters::apply_filter_pipeline(filters, mm, options.profiler);
+                obs->unload();
+            }
+        }
+        catch (const std::exception& e)
+        {
+            // If the exception msg contains "Assert file existence failed", it's due to missing
+            // external files.
+            const std::string errMsg = e.what();
+            if (errMsg.find("Assert file existence failed") != std::string::npos &&
+                !options.throw_on_missing_external_files)
+            {
+                std::cerr << "[sm2mm] Keyframe #" << curKF
+                          << ": skipping observation due to missing external files: "
+                          << first_n_lines(errMsg, 3) << "\n";
                 continue;
             }
-
-            // process it:
-            mp2p_icp_filters::apply_filter_pipeline(filters, mm, options.profiler);
-            obs->unload();
+            throw;  // Rethrow other exceptions
         }
 
 #if 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag (--permit-missing-externals) that, when enabled, treats missing external files as warnings and continues processing.

* **Behavior**
  * Processing now catches missing-external errors and logs a warning (showing brief context) instead of aborting when the new flag is set.

* **Documentation**
  * Updated command usage and help text to document the new option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->