### PR TITLE
Add functor_should_generate_debug_file to override the decision of whether to write .icplog files

### DIFF
--- a/mp2p_icp/include/mp2p_icp/Parameters.h
+++ b/mp2p_icp/include/mp2p_icp/Parameters.h
@@ -26,6 +26,7 @@
 namespace mp2p_icp
 {
 class metric_map_t;  // Frwd decl
+class LogRecord;  // Frwd decl
 
 /** ICP parameters.
  * \sa ICP_Base
@@ -89,8 +90,12 @@ struct Parameters : public mrpt::serialization::CSerializable
     /** Function to apply to the local and global maps before saving the map to
      * a log file. Useful to apply deletion filters to save space and time.
      */
-    std::function<void(mp2p_icp::metric_map_t&)> functor_before_logging_local,
-        functor_before_logging_global;
+    std::function<void(mp2p_icp::metric_map_t&)> functor_before_logging_local;
+    std::function<void(mp2p_icp::metric_map_t&)> functor_before_logging_global;
+
+    /** Optional function to override `generateDebugFiles`: If the function is provided, and it
+     * returns a valid value, it will override `generateDebugFiles` and `decimationDebugFiles`  */
+    std::function<std::optional<bool>(const LogRecord&)> functor_should_generate_debug_file;
 
     bool debugPrintIterationProgress = false;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a conditional override to control whether debug files are generated at runtime.
  * Log filenames can include a unique per-record identifier for easier tracking.

* **Bug Fixes / Improvements**
  * Log writing now respects a decimation policy to reduce file volume.
  * Error and directory messages adjusted for cleaner output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->