### PR TITLE
mm2las: export flag '--frame geodetic' for georeferenced clouds

### DIFF
--- a/apps/mm2las/CMakeLists.txt
+++ b/apps/mm2las/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(mm2las)
 
 find_package(mrpt-tclap REQUIRED)
+find_package(mrpt-topography REQUIRED)
 
 mola_add_executable(
   TARGET ${PROJECT_NAME}
@@ -9,5 +10,6 @@ mola_add_executable(
   LINK_LIBRARIES
     mp2p_icp_map
     mrpt::tclap
+    mrpt::topography
 )
 

--- a/apps/mm2las/main.cpp
+++ b/apps/mm2las/main.cpp
@@ -25,9 +25,12 @@
 #include <mrpt/poses/CPose3D.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/system/string_utils.h>
+#include <mrpt/topography/conversions.h>
+#include <mrpt/topography/data_types.h>
 #include <mrpt/version.h>
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -59,8 +62,11 @@ TCLAP::ValueArg<std::string> argGeneratingSoftware(
 TCLAP::ValueArg<std::string> argFrame(
     "", "frame",
     "Coordinate frame for exported points: 'map' (default) uses the map local frame; "
-    "'enu' transforms points to the East-North-Up frame (requires georeferencing data in the map).",
-    false, "map", "map|enu", cmd);
+    "'enu' transforms points to the East-North-Up frame (requires georeferencing data in the map); "
+    "'geodetic' exports as WGS-84 lon/lat/alt with EPSG:4979 CRS embedded in the LAS file "
+    "(requires georeferencing data). If per-point latitude/longitude/altitude fields already exist "
+    "in the map, they are used directly; otherwise, the conversion is computed on the fly.",
+    false, "map", "map|enu|geodetic", cmd);
 
 // ----------------------------------------------------------------
 // LAS 1.4 Format Structures
@@ -172,14 +178,39 @@ struct FieldInfo
     size_t      size   = 0;  // size in bytes for serialization
 };
 
+// WKT string for EPSG:4979 (WGS 84 geographic 3D)
+// X=Longitude, Y=Latitude, Z=Ellipsoidal height
+static const char* const kWKT_EPSG4979 =
+    "GEOGCRS[\"WGS 84\","
+    "ENSEMBLE[\"World Geodetic System 1984 ensemble\","
+    "MEMBER[\"World Geodetic System 1984 (Transit)\"],"
+    "MEMBER[\"World Geodetic System 1984 (G730)\"],"
+    "MEMBER[\"World Geodetic System 1984 (G873)\"],"
+    "MEMBER[\"World Geodetic System 1984 (G1150)\"],"
+    "MEMBER[\"World Geodetic System 1984 (G1674)\"],"
+    "MEMBER[\"World Geodetic System 1984 (G1762)\"],"
+    "MEMBER[\"World Geodetic System 1984 (G2139)\"],"
+    "ELLIPSOID[\"WGS 84\",6378137,298.257223563,"
+    "LENGTHUNIT[\"metre\",1]],"
+    "ENSEMBLEACCURACY[2.0]],"
+    "PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],"
+    "CS[ellipsoidal,3],"
+    "AXIS[\"geodetic latitude (Lat)\",north,ORDER[1],ANGLEUNIT[\"degree\",0.0174532925199433]],"
+    "AXIS[\"geodetic longitude (Lon)\",east,ORDER[2],ANGLEUNIT[\"degree\",0.0174532925199433]],"
+    "AXIS[\"ellipsoidal height (h)\",up,ORDER[3],LENGTHUNIT[\"metre\",1]],"
+    "USAGE[SCOPE[\"Geodesy.\"],AREA[\"World.\"],"
+    "BBOX[-90,-180,90,180]],"
+    "ID[\"EPSG\",4979]]";
+
 // ----------------------------------------------------------------
 // LAS 1.4 Export Logic with Extra Dimensions
 // ----------------------------------------------------------------
 void saveToLas(
     const mrpt::maps::CPointsMap& pc, const std::string& filename,
     const std::vector<std::string>& selectedFields, const std::string& systemId,
-    const std::string&                         generatingSoftware,
-    const std::optional<mrpt::poses::CPose3D>& T_enu_to_map = std::nullopt)
+    const std::string&                                           generatingSoftware,
+    const std::optional<mrpt::poses::CPose3D>&                   T_enu_to_map = std::nullopt,
+    const std::optional<mp2p_icp::metric_map_t::Georeferencing>& geodetic     = std::nullopt)
 {
     const size_t N = pc.size();
     if (N == 0)
@@ -225,6 +256,55 @@ void saveToLas(
 
     const auto &xs = pc.getPointsBufferRef_x(), &ys = pc.getPointsBufferRef_y(),
                &zs = pc.getPointsBufferRef_z();
+
+    // Detect pre-existing per-point geodetic fields
+    bool hasPerPointGeodetic = false;
+
+    [[maybe_unused]] const mrpt::aligned_std_vector<double>* latBuf = nullptr;
+    [[maybe_unused]] const mrpt::aligned_std_vector<double>* lonBuf = nullptr;
+    [[maybe_unused]] const mrpt::aligned_std_vector<double>* altBuf = nullptr;
+
+#if MRPT_VERSION >= 0x020f03
+    if (geodetic.has_value())
+    {
+        const auto d_names_check = pc.getPointFieldNames_double();
+        bool       hasLat = false, hasLon = false, hasAlt = false;
+        for (const auto& n : d_names_check)
+        {
+            if (n == "latitude")
+            {
+                hasLat = true;
+            }
+            if (n == "longitude")
+            {
+                hasLon = true;
+            }
+            if (n == "altitude")
+            {
+                hasAlt = true;
+            }
+        }
+        if (hasLat && hasLon && hasAlt)
+        {
+            latBuf = pc.getPointsBufferRef_double_field("latitude");
+            lonBuf = pc.getPointsBufferRef_double_field("longitude");
+            altBuf = pc.getPointsBufferRef_double_field("altitude");
+            if (latBuf && lonBuf && altBuf && !latBuf->empty())
+            {
+                hasPerPointGeodetic = true;
+                std::cout
+                    << "  [geodetic] Using pre-existing per-point latitude/longitude/altitude "
+                       "fields."
+                    << std::endl;
+            }
+        }
+        if (!hasPerPointGeodetic)
+        {
+            std::cout << "  [geodetic] Per-point geodetic fields not found; computing on the fly."
+                      << std::endl;
+        }
+    }
+#endif
 
     // 2. Collect all fields to export
     std::vector<std::string> fieldsToExport;
@@ -596,12 +676,50 @@ void saveToLas(
     double min_z = std::numeric_limits<double>::max();
     double max_z = std::numeric_limits<double>::lowest();
 
+    // Helper lambda: compute geodetic coords for a point
+    // Returns {longitude, latitude, altitude} (LAS X=lon, Y=lat, Z=alt)
+    auto pointToGeodetic = [&](size_t i) -> std::array<double, 3>
+    {
+        if (hasPerPointGeodetic)
+        {
+            return {(*lonBuf)[i], (*latBuf)[i], (*altBuf)[i]};
+        }
+        // On-the-fly conversion: map -> ENU -> geocentric -> geodetic
+        const mrpt::math::TPoint3D ptENU =
+            geodetic->T_enu_to_map.mean.composePoint({xs[i], ys[i], zs[i]});
+
+        mrpt::topography::TGeocentricCoords geocentric;
+        mrpt::topography::ENUToGeocentric(
+            ptENU, geodetic->geo_coord, geocentric,
+            mrpt::topography::TEllipsoid::Ellipsoid_WGS84());
+
+        mrpt::topography::TGeodeticCoords geod;
+        mrpt::topography::geocentricToGeodetic(
+            geocentric, geod, mrpt::topography::TEllipsoid::Ellipsoid_WGS84());
+
+        return {geod.lon.getDecimalValue(), geod.lat.getDecimalValue(), geod.height};
+    };
+
     for (size_t i = 0; i < N; ++i)
     {
-        double px = xs[i], py = ys[i], pz = zs[i];
-        if (T_enu_to_map.has_value())
+        double px, py, pz;
+        if (geodetic.has_value())
         {
-            T_enu_to_map->composePoint(xs[i], ys[i], zs[i], px, py, pz);
+            // In geodetic mode: X=longitude, Y=latitude, Z=altitude
+            auto g = pointToGeodetic(i);
+            px     = g[0];
+            py     = g[1];
+            pz     = g[2];
+        }
+        else
+        {
+            px = xs[i];
+            py = ys[i];
+            pz = zs[i];
+            if (T_enu_to_map.has_value())
+            {
+                T_enu_to_map->composePoint(xs[i], ys[i], zs[i], px, py, pz);
+            }
         }
         min_x = std::min(min_x, px);
         max_x = std::max(max_x, px);
@@ -644,16 +762,48 @@ void saveToLas(
     header.y_offset = min_y;
     header.z_offset = min_z;
 
-    // If we have extra dimensions, we need VLR for "Extra Bytes"
+    // In geodetic mode, use finer scale for degrees and set appropriate offsets
+    if (geodetic.has_value())
+    {
+        // Scale factor tradeoffs for geodetic coordinates:
+        // LAS stores coordinates as int32, so the usable range from the offset
+        // is ±(2^31 * scale) ≈ ±2.147e9 * scale.
+        //
+        // At 1e-8 degrees: ~1.1mm precision at equator (cos(lat) shrinks this
+        // towards poles). Range: ±21.47 degrees from offset — more than enough
+        // for any single point cloud extent.
+        //
+        // At 1e-7 degrees: ~1.1cm precision, ±214.7 deg range (exceeds globe).
+        // At 1e-9 degrees: ~0.11mm precision, but only ±2.15 deg range (~239km
+        // at equator), which could overflow for very large-area datasets.
+        //
+        // 1e-8 is the sweet spot: mm-level precision with ample range (~2,388km).
+        header.x_scale_factor = 1e-8;  // longitude
+        header.y_scale_factor = 1e-8;  // latitude
+        header.z_scale_factor = 0.001;  // altitude in meters, 1mm precision
+    }
+
+    // Calculate VLR sizes
+    uint32_t numVLRs       = 0;
+    uint32_t vlrTotalBytes = 0;
+
+    // WKT CRS VLR (geodetic mode)
+    const size_t wktLen = geodetic.has_value() ? (std::strlen(kWKT_EPSG4979) + 1) : 0;  // +1 null
+    if (geodetic.has_value())
+    {
+        numVLRs++;
+        vlrTotalBytes += sizeof(VLRHeader) + wktLen;
+    }
+
+    // Extra Bytes VLR
     if (extraBytesPerPoint > 0)
     {
-        header.number_of_variable_length_records = 1;
-        header.offset_to_point_data = 375 + sizeof(VLRHeader) + (extraFields.size() * 192);
+        numVLRs++;
+        vlrTotalBytes += sizeof(VLRHeader) + (extraFields.size() * 192);
     }
-    else
-    {
-        header.offset_to_point_data = 375;
-    }
+
+    header.number_of_variable_length_records = numVLRs;
+    header.offset_to_point_data              = 375 + vlrTotalBytes;
 
     std::cout << "LAS 1.4 Point Format 8:" << std::endl;
     std::cout << "  Base size: 38 bytes" << std::endl;
@@ -665,7 +815,22 @@ void saveToLas(
     // Write header
     f.write(reinterpret_cast<const char*>(&header), sizeof(LASHeader_1_4));
 
-    // 7. Write VLR for Extra Bytes if needed
+    // 7a. Write WKT CRS VLR (geodetic mode)
+    if (geodetic.has_value())
+    {
+        VLRHeader wktVlr;
+        std::strncpy(wktVlr.user_id, "LASF_Projection", 16);
+        wktVlr.record_id     = 2112;  // OGC WKT CRS
+        wktVlr.record_length = static_cast<uint16_t>(wktLen);
+        std::strncpy(wktVlr.description, "OGC WKT CRS (EPSG:4979)", 31);
+
+        f.write(reinterpret_cast<const char*>(&wktVlr), sizeof(VLRHeader));
+        f.write(kWKT_EPSG4979, static_cast<std::streamsize>(wktLen));
+
+        std::cout << "  [geodetic] Embedded EPSG:4979 WKT CRS in LAS file." << std::endl;
+    }
+
+    // 7b. Write VLR for Extra Bytes if needed
     if (extraBytesPerPoint > 0)
     {
         VLRHeader vlr;
@@ -759,11 +924,24 @@ void saveToLas(
     {
         LASPointFormat8 pt = {};
 
-        // On-the-fly coordinate transform if exporting in ENU frame
-        double px = xs[i], py = ys[i], pz = zs[i];
-        if (T_enu_to_map.has_value())
+        // Coordinate transform depending on export mode
+        double px, py, pz;
+        if (geodetic.has_value())
         {
-            T_enu_to_map->composePoint(xs[i], ys[i], zs[i], px, py, pz);
+            auto g = pointToGeodetic(i);
+            px     = g[0];  // longitude
+            py     = g[1];  // latitude
+            pz     = g[2];  // altitude
+        }
+        else
+        {
+            px = xs[i];
+            py = ys[i];
+            pz = zs[i];
+            if (T_enu_to_map.has_value())
+            {
+                T_enu_to_map->composePoint(xs[i], ys[i], zs[i], px, py, pz);
+            }
         }
 
         // Scale coordinates
@@ -951,7 +1129,8 @@ int main(int argc, char** argv)
         mm.load_from_file(arg_input.getValue());
 
         // Handle --frame option
-        std::optional<mrpt::poses::CPose3D> T_enu_to_map;
+        std::optional<mrpt::poses::CPose3D>                   T_enu_to_map;
+        std::optional<mp2p_icp::metric_map_t::Georeferencing> geodeticExport;
         {
             const auto frame = argFrame.getValue();
             if (frame == "enu")
@@ -965,9 +1144,33 @@ int main(int argc, char** argv)
                 T_enu_to_map = mm.georeferencing->T_enu_to_map.mean;
                 std::cout << "[mm2las] Exporting points in ENU frame." << std::endl;
             }
+            else if (frame == "geodetic")
+            {
+                if (!mm.georeferencing.has_value())
+                {
+                    throw std::runtime_error(
+                        "Cannot use --frame geodetic: the input map does not contain "
+                        "georeferencing information.");
+                }
+                if (mm.georeferencing->geo_coord.isClear())
+                {
+                    throw std::runtime_error(
+                        "Cannot use --frame geodetic: georeferencing exists but geodetic "
+                        "coordinates (lat/lon/alt) are not defined.");
+                }
+                geodeticExport = mm.georeferencing;
+                std::cout << "[mm2las] Exporting points in geodetic WGS-84 coordinates "
+                             "(EPSG:4979)."
+                          << std::endl;
+                std::cout << "[mm2las] Reference: lat="
+                          << mm.georeferencing->geo_coord.lat.getDecimalValue()
+                          << " lon=" << mm.georeferencing->geo_coord.lon.getDecimalValue()
+                          << " alt=" << mm.georeferencing->geo_coord.height << " m" << std::endl;
+            }
             else if (frame != "map")
             {
-                throw std::runtime_error("Invalid --frame value. Must be 'map' or 'enu'.");
+                throw std::runtime_error(
+                    "Invalid --frame value. Must be 'map', 'enu', or 'geodetic'.");
             }
         }
 
@@ -1029,7 +1232,9 @@ int main(int argc, char** argv)
             std::string out = prefix + "_" + name + ".las";
             std::cout << "Exporting '" << name << "' to " << out << " (" << pts->size()
                       << " points)..." << std::endl;
-            saveToLas(*pts, out, selectedFields, systemId, generatingSoftware, T_enu_to_map);
+            saveToLas(
+                *pts, out, selectedFields, systemId, generatingSoftware, T_enu_to_map,
+                geodeticExport);
         }
 
         std::cout << "Done." << std::endl;

--- a/apps/mm2las/main.cpp
+++ b/apps/mm2las/main.cpp
@@ -36,6 +36,7 @@
 #include <iostream>
 #include <limits>
 #include <map>
+#include <stdexcept>
 
 // CLI flags
 TCLAP::CmdLine cmd("mm2las");
@@ -292,7 +293,8 @@ void saveToLas(
             latBuf = pc.getPointsBufferRef_double_field("latitude");
             lonBuf = pc.getPointsBufferRef_double_field("longitude");
             altBuf = pc.getPointsBufferRef_double_field("altitude");
-            if (latBuf && lonBuf && altBuf && !latBuf->empty())
+            if (latBuf && lonBuf && altBuf && latBuf->size() >= N && lonBuf->size() >= N &&
+                altBuf->size() >= N)
             {
                 hasPerPointGeodetic = true;
                 std::cout
@@ -784,6 +786,30 @@ void saveToLas(
         header.x_scale_factor = 1e-8;  // longitude
         header.y_scale_factor = 1e-8;  // latitude
         header.z_scale_factor = 0.001;  // altitude in meters, 1mm precision
+    }
+
+    // Verify that the coordinate range fits in int32 with the chosen scale.
+    // LAS stores coordinates as (coord - offset) / scale cast to int32, so the
+    // maximum representable span from the offset is INT32_MAX * scale.
+    {
+        const double int32_max     = static_cast<double>(std::numeric_limits<int32_t>::max());
+        const double max_span_x    = int32_max * header.x_scale_factor;
+        const double max_span_y    = int32_max * header.y_scale_factor;
+        const double max_span_z    = int32_max * header.z_scale_factor;
+        const double actual_span_x = max_x - min_x;
+        const double actual_span_y = max_y - min_y;
+        const double actual_span_z = max_z - min_z;
+        if (actual_span_x > max_span_x || actual_span_y > max_span_y || actual_span_z > max_span_z)
+        {
+            throw std::runtime_error(
+                "Point cloud extent overflows int32 with the chosen LAS scale factors.\n"
+                "  X span: " +
+                std::to_string(actual_span_x) + " (max " + std::to_string(max_span_x) + ")\n" +
+                "  Y span: " + std::to_string(actual_span_y) + " (max " +
+                std::to_string(max_span_y) + ")\n" + "  Z span: " + std::to_string(actual_span_z) +
+                " (max " + std::to_string(max_span_z) + ")\n" +
+                "Use a coarser scale factor or split the point cloud into smaller tiles.");
+        }
     }
 
     // Calculate VLR sizes

--- a/apps/mm2las/main.cpp
+++ b/apps/mm2las/main.cpp
@@ -30,7 +30,6 @@
 #include <mrpt/version.h>
 
 #include <algorithm>
-#include <array>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -213,9 +212,9 @@ void saveToLas(
     const mrpt::maps::CPointsMap& pc, const std::string& filename,
     const std::vector<std::string>& selectedFields, const std::string& systemId,
     const std::string&                                           generatingSoftware,
-    const std::optional<mrpt::poses::CPose3D>&                   T_enu_to_map    = std::nullopt,
-    bool                                                         exportGeodetic  = false,
-    const std::optional<mp2p_icp::metric_map_t::Georeferencing>& geodetic        = std::nullopt)
+    const std::optional<mrpt::poses::CPose3D>&                   T_enu_to_map   = std::nullopt,
+    bool                                                         exportGeodetic = false,
+    const std::optional<mp2p_icp::metric_map_t::Georeferencing>& geodetic       = std::nullopt)
 {
     const size_t N = pc.size();
     if (N == 0)
@@ -693,7 +692,7 @@ void saveToLas(
 
     // Helper lambda: compute geodetic coords for a point
     // Returns {longitude, latitude, altitude} (LAS X=lon, Y=lat, Z=alt)
-    auto pointToGeodetic = [&](size_t i) -> std::array<double, 3>
+    auto pointToGeodetic = [&](size_t i) -> mrpt::math::TPoint3D
     {
         if (hasPerPointGeodetic)
         {
@@ -715,16 +714,33 @@ void saveToLas(
         return {geod.lon.getDecimalValue(), geod.lat.getDecimalValue(), geod.height};
     };
 
+    // Cache on-the-fly geodetic results so the write loop does not recompute them.
+    // The fast-path (hasPerPointGeodetic) reads existing buffers cheaply and needs no cache.
+    std::vector<mrpt::math::TPoint3D> geodeticCache;
+    if (exportGeodetic && !hasPerPointGeodetic)
+    {
+        geodeticCache.resize(N);
+    }
+
     for (size_t i = 0; i < N; ++i)
     {
         double px, py, pz;
         if (exportGeodetic)
         {
             // In geodetic mode: X=longitude, Y=latitude, Z=altitude
-            auto g = pointToGeodetic(i);
-            px     = g[0];
-            py     = g[1];
-            pz     = g[2];
+            mrpt::math::TPoint3D g;
+            if (!hasPerPointGeodetic)
+            {
+                g                = pointToGeodetic(i);
+                geodeticCache[i] = g;
+            }
+            else
+            {
+                g = pointToGeodetic(i);
+            }
+            px = g.x;
+            py = g.y;
+            pz = g.z;
         }
         else
         {
@@ -759,6 +775,12 @@ void saveToLas(
     header.system_identifier[31] = '\0';
     std::strncpy(header.generating_software, generatingSoftware.c_str(), 31);
     header.generating_software[31] = '\0';
+
+    // Bit 4 (0x10) signals a WKT CRS VLR is present; only set it when we actually write one.
+    if (!exportGeodetic)
+    {
+        header.global_encoding &= ~static_cast<uint16_t>(0x10);
+    }
 
     header.point_data_format_id     = 8;  // Always use Format 8
     header.point_data_record_length = 38 + static_cast<uint16_t>(extraBytesPerPoint);
@@ -967,10 +989,11 @@ void saveToLas(
         double px, py, pz;
         if (exportGeodetic)
         {
-            auto g = pointToGeodetic(i);
-            px     = g[0];  // longitude
-            py     = g[1];  // latitude
-            pz     = g[2];  // altitude
+            const mrpt::math::TPoint3D g =
+                !hasPerPointGeodetic ? geodeticCache[i] : pointToGeodetic(i);
+            px = g.x;  // longitude
+            py = g.y;  // latitude
+            pz = g.z;  // altitude
         }
         else
         {

--- a/apps/mm2las/main.cpp
+++ b/apps/mm2las/main.cpp
@@ -213,8 +213,9 @@ void saveToLas(
     const mrpt::maps::CPointsMap& pc, const std::string& filename,
     const std::vector<std::string>& selectedFields, const std::string& systemId,
     const std::string&                                           generatingSoftware,
-    const std::optional<mrpt::poses::CPose3D>&                   T_enu_to_map = std::nullopt,
-    const std::optional<mp2p_icp::metric_map_t::Georeferencing>& geodetic     = std::nullopt)
+    const std::optional<mrpt::poses::CPose3D>&                   T_enu_to_map    = std::nullopt,
+    bool                                                         exportGeodetic  = false,
+    const std::optional<mp2p_icp::metric_map_t::Georeferencing>& geodetic        = std::nullopt)
 {
     const size_t N = pc.size();
     if (N == 0)
@@ -269,7 +270,7 @@ void saveToLas(
     [[maybe_unused]] const mrpt::aligned_std_vector<double>* altBuf = nullptr;
 
 #if MRPT_VERSION >= 0x020f03
-    if (geodetic.has_value())
+    if (exportGeodetic)
     {
         const auto d_names_check = pc.getPointFieldNames_double();
         bool       hasLat = false, hasLon = false, hasAlt = false;
@@ -310,6 +311,15 @@ void saveToLas(
         }
     }
 #endif
+
+    // Preflight: geodetic mode requires either per-point buffers or a georeferencing context
+    // for on-the-fly conversion. Fail early with a clear message instead of a null deref later.
+    if (exportGeodetic && !hasPerPointGeodetic && !geodetic.has_value())
+    {
+        throw std::runtime_error(
+            "Cannot export in geodetic mode: no per-point latitude/longitude/altitude fields "
+            "found and no georeferencing context was provided for on-the-fly conversion.");
+    }
 
     // 2. Collect all fields to export
     std::vector<std::string> fieldsToExport;
@@ -708,7 +718,7 @@ void saveToLas(
     for (size_t i = 0; i < N; ++i)
     {
         double px, py, pz;
-        if (geodetic.has_value())
+        if (exportGeodetic)
         {
             // In geodetic mode: X=longitude, Y=latitude, Z=altitude
             auto g = pointToGeodetic(i);
@@ -768,7 +778,7 @@ void saveToLas(
     header.z_offset = min_z;
 
     // In geodetic mode, use finer scale for degrees and set appropriate offsets
-    if (geodetic.has_value())
+    if (exportGeodetic)
     {
         // Scale factor tradeoffs for geodetic coordinates:
         // LAS stores coordinates as int32, so the usable range from the offset
@@ -817,8 +827,8 @@ void saveToLas(
     uint32_t vlrTotalBytes = 0;
 
     // WKT CRS VLR (geodetic mode)
-    const size_t wktLen = geodetic.has_value() ? (std::strlen(kWKT_EPSG4979) + 1) : 0;  // +1 null
-    if (geodetic.has_value())
+    const size_t wktLen = exportGeodetic ? (std::strlen(kWKT_EPSG4979) + 1) : 0;  // +1 null
+    if (exportGeodetic)
     {
         numVLRs++;
         vlrTotalBytes += sizeof(VLRHeader) + wktLen;
@@ -845,7 +855,7 @@ void saveToLas(
     f.write(reinterpret_cast<const char*>(&header), sizeof(LASHeader_1_4));
 
     // 7a. Write WKT CRS VLR (geodetic mode)
-    if (geodetic.has_value())
+    if (exportGeodetic)
     {
         VLRHeader wktVlr;
         std::strncpy(wktVlr.user_id, "LASF_Projection", 16);
@@ -955,7 +965,7 @@ void saveToLas(
 
         // Coordinate transform depending on export mode
         double px, py, pz;
-        if (geodetic.has_value())
+        if (exportGeodetic)
         {
             auto g = pointToGeodetic(i);
             px     = g[0];  // longitude
@@ -1159,6 +1169,7 @@ int main(int argc, char** argv)
 
         // Handle --frame option
         std::optional<mrpt::poses::CPose3D>                   T_enu_to_map;
+        bool                                                  exportGeodetic = false;
         std::optional<mp2p_icp::metric_map_t::Georeferencing> geodeticExport;
         {
             const auto frame = argFrame.getValue();
@@ -1175,26 +1186,29 @@ int main(int argc, char** argv)
             }
             else if (frame == "geodetic")
             {
-                if (!mm.georeferencing.has_value())
+                exportGeodetic = true;
+                // Provide georeferencing context when available (needed for on-the-fly
+                // conversion). If absent, saveToLas will use per-point lat/lon/alt fields
+                // directly, or fail with a clear error if those are also absent.
+                if (mm.georeferencing.has_value() && !mm.georeferencing->geo_coord.isClear())
                 {
-                    throw std::runtime_error(
-                        "Cannot use --frame geodetic: the input map does not contain "
-                        "georeferencing information.");
+                    geodeticExport = mm.georeferencing;
+                    std::cout << "[mm2las] Exporting points in geodetic WGS-84 coordinates "
+                                 "(EPSG:4979)."
+                              << std::endl;
+                    std::cout << "[mm2las] Reference: lat="
+                              << mm.georeferencing->geo_coord.lat.getDecimalValue()
+                              << " lon=" << mm.georeferencing->geo_coord.lon.getDecimalValue()
+                              << " alt=" << mm.georeferencing->geo_coord.height << " m"
+                              << std::endl;
                 }
-                if (mm.georeferencing->geo_coord.isClear())
+                else
                 {
-                    throw std::runtime_error(
-                        "Cannot use --frame geodetic: georeferencing exists but geodetic "
-                        "coordinates (lat/lon/alt) are not defined.");
+                    std::cout
+                        << "[mm2las] Exporting points in geodetic WGS-84 coordinates (EPSG:4979) "
+                           "using per-point latitude/longitude/altitude fields."
+                        << std::endl;
                 }
-                geodeticExport = mm.georeferencing;
-                std::cout << "[mm2las] Exporting points in geodetic WGS-84 coordinates "
-                             "(EPSG:4979)."
-                          << std::endl;
-                std::cout << "[mm2las] Reference: lat="
-                          << mm.georeferencing->geo_coord.lat.getDecimalValue()
-                          << " lon=" << mm.georeferencing->geo_coord.lon.getDecimalValue()
-                          << " alt=" << mm.georeferencing->geo_coord.height << " m" << std::endl;
             }
             else if (frame != "map")
             {
@@ -1263,7 +1277,7 @@ int main(int argc, char** argv)
                       << " points)..." << std::endl;
             saveToLas(
                 *pts, out, selectedFields, systemId, generatingSoftware, T_enu_to_map,
-                geodeticExport);
+                exportGeodetic, geodeticExport);
         }
 
         std::cout << "Done." << std::endl;

--- a/apps/mm2las/main.cpp
+++ b/apps/mm2las/main.cpp
@@ -178,8 +178,11 @@ struct FieldInfo
     size_t      size   = 0;  // size in bytes for serialization
 };
 
-// WKT string for EPSG:4979 (WGS 84 geographic 3D)
-// X=Longitude, Y=Latitude, Z=Ellipsoidal height
+// WKT2:2019 string for EPSG:4979 (WGS 84 geographic 3D).
+// IMPORTANT: Axis order is longitude-first (ORDER[1]) to match LAS point data
+// layout where X=longitude, Y=latitude, Z=ellipsoidal height. The canonical
+// EPSG:4979 definition uses lat-first, but that would cause CRS-aware readers
+// to swap X/Y. WKT1 cannot represent 3D geographic CRS, so WKT2 is required.
 static const char* const kWKT_EPSG4979 =
     "GEOGCRS[\"WGS 84\","
     "ENSEMBLE[\"World Geodetic System 1984 ensemble\","
@@ -195,8 +198,8 @@ static const char* const kWKT_EPSG4979 =
     "ENSEMBLEACCURACY[2.0]],"
     "PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],"
     "CS[ellipsoidal,3],"
-    "AXIS[\"geodetic latitude (Lat)\",north,ORDER[1],ANGLEUNIT[\"degree\",0.0174532925199433]],"
-    "AXIS[\"geodetic longitude (Lon)\",east,ORDER[2],ANGLEUNIT[\"degree\",0.0174532925199433]],"
+    "AXIS[\"geodetic longitude (Lon)\",east,ORDER[1],ANGLEUNIT[\"degree\",0.0174532925199433]],"
+    "AXIS[\"geodetic latitude (Lat)\",north,ORDER[2],ANGLEUNIT[\"degree\",0.0174532925199433]],"
     "AXIS[\"ellipsoidal height (h)\",up,ORDER[3],LENGTHUNIT[\"metre\",1]],"
     "USAGE[SCOPE[\"Geodesy.\"],AREA[\"World.\"],"
     "BBOX[-90,-180,90,180]],"

--- a/docs/source/app_mm2las.rst
+++ b/docs/source/app_mm2las.rst
@@ -26,7 +26,7 @@ Usage
 
 .. code-block:: bash
 
-   mm2las -i <input.mm> [-o <output_prefix>] [--export-fields <field1,field2,...>] [--frame map|enu]
+   mm2las -i <input.mm> [-o <output_prefix>] [--export-fields <field1,field2,...>] [--frame map|enu|geodetic]
 
 Arguments
 ^^^^^^^^^
@@ -36,7 +36,7 @@ Arguments
 - ``--export-fields <field1,field2,...>`` (optional): Comma-separated list of fields to export. If omitted, all available fields are exported, with non-standard fields becoming Extra Dimensions.
 - ``--system-id <string>``: Sets the System Identifier in the LAS header (default: "mm2las").
 - ``--generating-software <string>``: Sets the Generating Software in the LAS header (default: "MOLA mm2las").
-- ``--frame <map|enu>`` (optional): Coordinate frame for exported points. ``map`` (default) exports coordinates in the map local frame. ``enu`` transforms all point coordinates to the East-North-Up frame using the georeferencing information stored in the map. Requires that the input map contains georeferencing data; otherwise, an error is raised.
+- ``--frame <map|enu|geodetic>`` (optional): Coordinate frame for exported points. ``map`` (default) exports coordinates in the map local frame. ``enu`` transforms all point coordinates to the East-North-Up frame using the georeferencing information stored in the map. ``geodetic`` exports points as WGS-84 geographic coordinates (EPSG:4979) with longitude as X, latitude as Y, and ellipsoidal height as Z, embedding the CRS as a WKT VLR in the LAS file for full georeferencing support in GIS software. Requires that the input map contains georeferencing data with valid geodetic coordinates. If per-point ``latitude``/``longitude``/``altitude`` double fields already exist in the map (e.g., from ``mola-mm-add-geodetic``), they are used directly; otherwise, the conversion from map coordinates is computed on the fly.
 
 
 Examples
@@ -72,6 +72,12 @@ Export points in the ENU (East-North-Up) frame:
 
    mm2las -i mymap.mm --frame enu
 
+Export as georeferenced WGS-84 coordinates (EPSG:4979) for GIS software:
+
+.. code-block:: bash
+
+   mm2las -i mymap.mm --frame geodetic
+
 
 Field Selection
 ---------------
@@ -105,8 +111,8 @@ LAS Format Details
 
 - **LAS Version**: 1.4.
 - **Point Format**: 8 (Base size: 38 bytes + Extra Dimensions).
-- **WKT Support**: Uses LAS 1.4 Global Encoding to signal coordinate reference system compatibility.
-- **Coordinate precision**: 0.001 (1mm scale).
+- **WKT CRS Support**: When using ``--frame geodetic``, embeds an OGC WKT string for EPSG:4979 (WGS 84 3D) as a VLR, following the LAS 1.4 specification for CRS encoding.
+- **Coordinate precision**: 0.001 (1mm scale) for metric frames; 1e-8 degrees (~1mm at equator) for geodetic latitude/longitude.
 - **Maximum points**: Supports >4.3 billion points via 64-bit Extended Point Counters.
 
 Compression
@@ -133,13 +139,18 @@ LAZ files typically achieve 7-20× compression ratios while maintaining lossless
 Coordinate Frames
 -----------------
 
-By default, points are exported in the **map** local frame (the native coordinate system of the metric map). If the map contains georeferencing metadata (see :ref:`app_mm-georef`), you can use ``--frame enu`` to export all point coordinates transformed to the **ENU (East-North-Up)** frame. The transformation uses the ``T_enu_to_map`` SE(3) pose stored in the map's georeferencing data. Non-coordinate fields (intensity, RGB, etc.) are not affected by this transformation.
+By default, points are exported in the **map** local frame (the native coordinate system of the metric map). If the map contains georeferencing metadata (see :ref:`app_mm-georef`), you can use:
+
+- ``--frame enu``: Exports all point coordinates transformed to the **ENU (East-North-Up)** frame. The transformation uses the ``T_enu_to_map`` SE(3) pose stored in the map's georeferencing data.
+- ``--frame geodetic``: Exports points as **WGS-84 geographic coordinates (EPSG:4979)**, with X=longitude, Y=latitude, Z=ellipsoidal height. A WKT Coordinate Reference System record is embedded as a VLR in the LAS file, enabling commercial GIS software (CloudCompare, QGIS, Global Mapper, ArcGIS, etc.) to correctly geolocate the point cloud on the globe. The coordinate precision is ~1mm (scale factor 1e-8 degrees for lat/lon, 0.001m for altitude), with a usable range of ~2,388km from the offset origin — more than sufficient for any single point cloud. If the map already contains per-point ``latitude``/``longitude``/``altitude`` fields (e.g., added by the ``mola-mm-add-geodetic`` tool), those values are used directly. Otherwise, the geodetic coordinates are computed on the fly from the map coordinates using the georeferencing origin and the ENU-to-geodetic conversion via WGS-84 ellipsoid parameters.
+
+Non-coordinate fields (intensity, RGB, etc.) are not affected by these transformations.
 
 Limitations
 -----------
 
 - **Waveform Data**: Not supported in the current export logic.
 - **Direct LAZ**: Compressed LAZ files are not written directly; use ``laszip`` or ``pdal`` for post-compression.
-- **Coordinate Systems**: While the file is LAS 1.4 compliant, specific CRS WKT strings are not yet automatically embedded in the VLRs.
+- **Coordinate Systems**: CRS WKT embedding is only available with ``--frame geodetic`` (EPSG:4979). Other projected CRS (e.g., UTM) are not currently supported.
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added geodetic coordinate export (EPSG:4979/WGS‑84) for LAS output with CRS embedded as a WKT VLR.
  * New "geodetic" frame mode alongside "map" and "enu"; CLI validates presence of georeferencing data for geodetic exports.
  * Uses per-point lat/lon/alt when present; otherwise converts map/ENU coordinates on the fly.
  * LAS 1.4 adjustments: finer scales for geodetic coords and added VLRs/extra-dimension support.

* **Documentation**
  * Updated mm2las docs and examples covering geodetic workflow, CRS embedding, precision, and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->