### PR TITLE
Update to build against mrpt >=2.15.13

### DIFF
--- a/apps/txt2mm/main.cpp
+++ b/apps/txt2mm/main.cpp
@@ -38,9 +38,9 @@
 const char* VALID_FORMATS = "(xyz|xyzi|xyzirt|xyzrgb|xyzrgb_normalized)";
 
 // Replicated here from CGenericPointsMap until MRPT 2.15.3 is minimum required version:
-constexpr static std::string_view POINT_FIELD_INTENSITY = "intensity";
-constexpr static std::string_view POINT_FIELD_RING_ID   = "ring";
-constexpr static std::string_view POINT_FIELD_TIMESTAMP = "t";
+constexpr static const char* POINT_FIELD_INTENSITY = "intensity";
+constexpr static const char* POINT_FIELD_RING_ID   = "ring";
+constexpr static const char* POINT_FIELD_TIMESTAMP = "t";
 
 using namespace std::string_literals;
 

--- a/mp2p_icp_filters/include/mp2p_icp_filters/FilterBase.h
+++ b/mp2p_icp_filters/include/mp2p_icp_filters/FilterBase.h
@@ -125,9 +125,9 @@ constexpr auto POINT_FIELD_RING_ID   = mrpt::maps::CPointsMap::POINT_FIELD_RING_
 constexpr auto POINT_FIELD_TIMESTAMP = mrpt::maps::CPointsMap::POINT_FIELD_TIMESTAMP;
 #else
 // Define here locally, until MRPT 2.15.3 is the minimum required version:
-constexpr static std::string_view POINT_FIELD_INTENSITY = "intensity";
-constexpr static std::string_view POINT_FIELD_RING_ID   = "ring";
-constexpr static std::string_view POINT_FIELD_TIMESTAMP = "t";
+constexpr static const char* POINT_FIELD_INTENSITY = "intensity";
+constexpr static const char* POINT_FIELD_RING_ID   = "ring";
+constexpr static const char* POINT_FIELD_TIMESTAMP = "t";
 #endif
 
 /** @} */

--- a/mp2p_icp_filters/src/Generator.cpp
+++ b/mp2p_icp_filters/src/Generator.cpp
@@ -406,7 +406,7 @@ void Generator::addViewVectorField(
     // Exit now if we are not generating view vectors, not without first checking consistency:
     if (!params.generate_view_vector)
     {
-        for (const std::string_view fname : {"view_x", "view_y", "view_z"})
+        for (const char* const fname : {"view_x", "view_y", "view_z"})
         {
             if (genPc->hasPointField(fname))
             {
@@ -430,7 +430,7 @@ void Generator::addViewVectorField(
     // Register each field if absent; if already present, resize to cover nTotal.
     // registerField_float() initialises the new vector to size() zeros, so registering
     // after insertAnotherMap() gives us correctly-sized storage for all points.
-    for (const std::string_view fname : {"view_x", "view_y", "view_z"})
+    for (const char* const fname : {"view_x", "view_y", "view_z"})
     {
         if (!genPc->hasPointField(fname))
         {

--- a/tests/test-mp2p_Filters.cpp
+++ b/tests/test-mp2p_Filters.cpp
@@ -38,7 +38,7 @@ using namespace mp2p_icp;
 namespace
 {
 
-constexpr std::string_view INTENSITY = POINT_FIELD_INTENSITY;
+constexpr auto INTENSITY = POINT_FIELD_INTENSITY;
 
 // Helper to create a test point cloud with known positions and intensities
 mrpt::maps::CPointsMap::Ptr createTestPointsWithIntensity(


### PR DESCRIPTION
(pointcloud field names as std::string instead of string_view)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal type definitions for point-field identifiers across multiple modules to improve compatibility and consistency. No user-facing functionality has been modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->