### PR TITLE
Generator: creates CGenericPointsMap by default; add sanity checks in most filters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 add_subdirectory(3rdparty)
 
 # find dependencies:
-find_package(MRPT 2.15.0 REQUIRED COMPONENTS
+find_package(MRPT 2.15.4 REQUIRED COMPONENTS
   containers
   tfest
   maps

--- a/agents.md
+++ b/agents.md
@@ -9,7 +9,7 @@ Quick-start reference for AI agents and new contributors.
 - **Version**: 2.7.1 (March 2026)
 - **License**: BSD-3-Clause
 - **Maintainer**: Jose Luis Blanco-Claraco
-- **Minimum MRPT**: 2.15.0
+- **Minimum MRPT**: 2.15.4
 
 ---
 
@@ -172,7 +172,7 @@ SIMD-optimized translation units are compiled separately with `-mavx` / `-msse2`
 
 | Dependency | Notes |
 |-----------|-------|
-| MRPT ≥ 2.15.0 | containers, tfest, maps, gui, topography — mandatory |
+| MRPT ≥ 2.15.4 | containers, tfest, maps, gui, topography — mandatory |
 | TBB | Optional; enables parallel ICP iterations |
 | mola_common | CMake scripts; fetched as git submodule |
 | mola_imu_preintegration | Optional; advanced deskew in FilterDeskew |

--- a/apps/txt2mm/main.cpp
+++ b/apps/txt2mm/main.cpp
@@ -21,19 +21,12 @@
 
 #include <mp2p_icp/metricmap.h>
 #include <mrpt/3rdparty/tclap/CmdLine.h>
+#include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/math/CMatrixDynamic.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/version.h>
-
-#if MRPT_VERSION >= 0x20f00  // 2.15.0
-#include <mrpt/maps/CGenericPointsMap.h>
-#else
-#include <mrpt/maps/CColouredPointsMap.h>
-#include <mrpt/maps/CPointsMapXYZI.h>
-#include <mrpt/maps/CPointsMapXYZIRT.h>
-#endif
 
 const char* VALID_FORMATS = "(xyz|xyzi|xyzirt|xyzrgb|xyzrgb_normalized)";
 
@@ -214,14 +207,10 @@ int main(int argc, char** argv)
         {
             ASSERT_GE_(nCols, 6U);
             const bool rgb_normalized = (format == "xyzrgb_normalized");
-#if MRPT_VERSION >= 0x20f00  // 2.15.0
-            auto pts = mrpt::maps::CGenericPointsMap::Create();
+            auto       pts            = mrpt::maps::CGenericPointsMap::Create();
             pts->registerField_float("color_r");
             pts->registerField_float("color_g");
             pts->registerField_float("color_b");
-#else
-            auto pts = mrpt::maps::CColouredPointsMap::Create();
-#endif
             pts->reserve(nRows);
             if (nCols > 6)
             {
@@ -250,15 +239,9 @@ int main(int argc, char** argv)
                     b_val = mrpt::u8tof(static_cast<uint8_t>(data(i, idxBlue)));
                 }
 
-#if MRPT_VERSION >= 0x20f00  // 2.15.0
                 pts->insertPointField_float("color_r", r_val);
                 pts->insertPointField_float("color_g", g_val);
                 pts->insertPointField_float("color_b", b_val);
-#else
-                pts->insertPointField_color_R(r_val);
-                pts->insertPointField_color_G(g_val);
-                pts->insertPointField_color_B(b_val);
-#endif
             }
 
             pc = pts;

--- a/demos/sm2mm_bonxai_voxelmap.yaml
+++ b/demos/sm2mm_bonxai_voxelmap.yaml
@@ -43,6 +43,7 @@ generators:
       throw_on_unhandled_observation_class: true
       process_class_names_regex: ".*"
       #process_sensor_labels_regex: '.*'
+      filterOutPointsAtZero: true # Remove invalid points in 'organized' LiDAR scans
 
 # --------------------------------------------------------
 # 2) Per local frame filtering

--- a/demos/sm2mm_bonxai_voxelmap_gridmap.yaml
+++ b/demos/sm2mm_bonxai_voxelmap_gridmap.yaml
@@ -43,6 +43,7 @@ generators:
       throw_on_unhandled_observation_class: true
       process_class_names_regex: ".*"
       #process_sensor_labels_regex: '.*'
+      filterOutPointsAtZero: true # Remove invalid points in 'organized' LiDAR scans
 
 # --------------------------------------------------------
 # 2) Per local frame filtering

--- a/demos/sm2mm_bonxai_voxelmap_gridmap_no_deskew.yaml
+++ b/demos/sm2mm_bonxai_voxelmap_gridmap_no_deskew.yaml
@@ -43,6 +43,7 @@ generators:
       throw_on_unhandled_observation_class: true
       process_class_names_regex: ".*"
       #process_sensor_labels_regex: '.*'
+      filterOutPointsAtZero: true # Remove invalid points in 'organized' LiDAR scans
 
 # --------------------------------------------------------
 # 2) Per local frame filtering

--- a/demos/sm2mm_no_decim_imu.yaml
+++ b/demos/sm2mm_no_decim_imu.yaml
@@ -13,9 +13,10 @@
 # --------------------------------------------------------
 # 1) Generator (observation -> local frame metric maps)
 # --------------------------------------------------------
-#generators:
-#  - class_name: mp2p_icp_filters::Generator
-#    params: ~
+generators:
+  - class_name: mp2p_icp_filters::Generator
+    params:
+      filterOutPointsAtZero: true # Remove invalid points in 'organized' LiDAR scans
 
 # --------------------------------------------------------
 # 2) Per local frame filtering

--- a/demos/sm2mm_no_decim_imu.yaml
+++ b/demos/sm2mm_no_decim_imu.yaml
@@ -4,8 +4,7 @@
 # See: https://github.com/MOLAorg/mp2p_icp/tree/develop/apps/sm2mm
 #
 # Explanation of this particular pipeline:
-#  - Generators: empty, so the default generator is used (everything in one
-#                layer named 'raw' with all points).
+#  - Generators: default generator is used (creates an 'raw' layer).
 #  - Filters: Deskew using IMU, remove close points.
 #  - Final filters: intensity normalization.
 # -----------------------------------------------------------------------------

--- a/demos/sm2mm_no_decim_imu_mls.yaml
+++ b/demos/sm2mm_no_decim_imu_mls.yaml
@@ -17,6 +17,7 @@ generators:
   - class_name: mp2p_icp_filters::Generator
     params:
       generate_view_vector: true # Generate "view" vectors for advanced normals handling (Default=true)
+      filterOutPointsAtZero: true # Remove invalid points in 'organized' LiDAR scans
 
 # --------------------------------------------------------
 # 2) Per local frame filtering

--- a/demos/sm2mm_no_decim_imu_mls.yaml
+++ b/demos/sm2mm_no_decim_imu_mls.yaml
@@ -4,8 +4,7 @@
 # See: https://github.com/MOLAorg/mp2p_icp/tree/develop/apps/sm2mm
 #
 # Explanation of this particular pipeline:
-#  - Generators: empty, so the default generator is used (everything in one
-#                layer named 'raw' with all points).
+#  - Generators: default generator is used (creates an 'raw' layer).
 #  - Filters: Deskew using IMU, remove close points.
 #  - Final filters: intensity normalization, MLS filtering.
 # -----------------------------------------------------------------------------

--- a/demos/sm2mm_no_decim_imu_mls_keyframe_map.yaml
+++ b/demos/sm2mm_no_decim_imu_mls_keyframe_map.yaml
@@ -18,6 +18,7 @@ generators:
   - class_name: mp2p_icp_filters::Generator
     params:
       name: "generator_default"
+      filterOutPointsAtZero: true # Remove invalid points in 'organized' LiDAR scans
 
   # This one will just create the layer "localmap", expected by the GICP LIO algorithm for localization
   - class_name: mp2p_icp_filters::Generator

--- a/demos/sm2mm_pointcloud_voxelize.yaml
+++ b/demos/sm2mm_pointcloud_voxelize.yaml
@@ -4,8 +4,7 @@
 # See: https://github.com/MOLAorg/mp2p_icp/tree/develop/apps/sm2mm
 #
 # Explanation of this particular pipeline:
-#  - Generators: empty, so the default generator is used (everything in one
-#                layer named 'raw' with all points).
+#  - Generators: default generator is used (creates an 'raw' layer).
 #  - Filters: Just one downsampling filter, with an additional removal of close
 #             points (e.g. the robot body)
 # -----------------------------------------------------------------------------

--- a/demos/sm2mm_pointcloud_voxelize.yaml
+++ b/demos/sm2mm_pointcloud_voxelize.yaml
@@ -13,9 +13,10 @@
 # --------------------------------------------------------
 # 1) Generator (observation -> local frame metric maps)
 # --------------------------------------------------------
-#generators:
-#  - class_name: mp2p_icp_filters::Generator
-#    params: ~
+generators:
+  - class_name: mp2p_icp_filters::Generator
+    params:
+      filterOutPointsAtZero: true # Remove invalid points in 'organized' LiDAR scans
 
 # --------------------------------------------------------
 # 2) Per local frame filtering

--- a/demos/sm2mm_pointcloud_voxelize_no_deskew.yaml
+++ b/demos/sm2mm_pointcloud_voxelize_no_deskew.yaml
@@ -4,8 +4,7 @@
 # See: https://github.com/MOLAorg/mp2p_icp/tree/develop/apps/sm2mm
 #
 # Explanation of this particular pipeline:
-#  - Generators: empty, so the default generator is used (everything in one
-#                layer named 'raw' with all points).
+#  - Generators: default generator is used (creates an 'raw' layer).
 #  - Filters: Just one downsampling filter, with an additional removal of close
 #             points (e.g. the robot body)
 # -----------------------------------------------------------------------------

--- a/demos/sm2mm_pointcloud_voxelize_no_deskew.yaml
+++ b/demos/sm2mm_pointcloud_voxelize_no_deskew.yaml
@@ -13,9 +13,10 @@
 # --------------------------------------------------------
 # 1) Generator (observation -> local frame metric maps)
 # --------------------------------------------------------
-#generators:
-#  - class_name: mp2p_icp_filters::Generator
-#    params: ~
+generators:
+  - class_name: mp2p_icp_filters::Generator
+    params:
+      filterOutPointsAtZero: true # Remove invalid points in 'organized' LiDAR scans
 
 # --------------------------------------------------------
 # 2) Per local frame filtering

--- a/demos/sm2mm_voxels_static_dynamic_points.yaml
+++ b/demos/sm2mm_voxels_static_dynamic_points.yaml
@@ -69,6 +69,7 @@ generators:
       throw_on_unhandled_observation_class: true
       process_class_names_regex: "(mrpt::obs::CObservationPointCloud|mrpt::obs::CObservation3DRangeScan|mrpt::obs::CObservation2DRangeScan)"
       process_sensor_labels_regex: ".*"
+      filterOutPointsAtZero: true # Remove invalid points in 'organized' LiDAR scans
       metric_map_definition:
         # Any class derived from mrpt::maps::CMetricMap https://docs.mrpt.org/reference/latest/group_mrpt_maps_grp.html
         class: mrpt::maps::CGenericPointsMap

--- a/mp2p_icp_filters/include/mp2p_icp_filters/FilterDeskew.h
+++ b/mp2p_icp_filters/include/mp2p_icp_filters/FilterDeskew.h
@@ -61,8 +61,8 @@ enum class MotionCompensationMethod : uint8_t
  *   reference time point, which can be the start or middle point of the scan. This can be
  *   controlled by adding a FilterAdjustTimestamps before this block.
  *
- * - The input layer must contain a point cloud in the format
- *   mrpt::maps::CPointsMapXYZIRT or mrpt::maps::CGenericPointsMap so timestamps are present.
+ * - The input layer must contain a point cloud of type mrpt::maps::CGenericPointsMap
+ *   so timestamps are present.
  *
  * - If the input layer is of a different type, or the `t` field is missing,
  *   an exception will be thrown by default, unless the option

--- a/mp2p_icp_filters/include/mp2p_icp_filters/Generator.h
+++ b/mp2p_icp_filters/include/mp2p_icp_filters/Generator.h
@@ -169,6 +169,12 @@ class Generator : public mrpt::rtti::CObject,  // RTTI support
          */
         std::string default_pointcloud_class = "mrpt::maps::CGenericPointsMap";
 
+        /** When processing mrpt::obs::CObservationPointCloud as inputs, this controls whether
+         *  points with (x,y,z)=(0,0,0) should be discarded as invalid ones; e.g. typical in
+         *  organized clouds from LiDAR sensors.
+         */
+        bool filterOutPointsAtZero = false;
+
         /** If not empty, it will be used instead of class name in Logger and Profiler.
          *  This is loaded from the `name` key in the YAML configuration block.
          */

--- a/mp2p_icp_filters/include/mp2p_icp_filters/Generator.h
+++ b/mp2p_icp_filters/include/mp2p_icp_filters/Generator.h
@@ -161,6 +161,14 @@ class Generator : public mrpt::rtti::CObject,  // RTTI support
          */
         bool generate_view_vector = true;
 
+        /** When processing mrpt::obs::CObservationPointCloud as inputs, this will be the class of
+         * the generated layer, in which the cloud will be later inserted.
+         * Set to empty means use the same class as the original cloud in the observation.
+         * Default is to use the modern CGenericPointsMap which is capable of arbitrary point cloud
+         * fields.
+         */
+        std::string default_pointcloud_class = "mrpt::maps::CGenericPointsMap";
+
         /** If not empty, it will be used instead of class name in Logger and Profiler.
          *  This is loaded from the `name` key in the YAML configuration block.
          */

--- a/mp2p_icp_filters/src/FilterAdjustTimestamps.cpp
+++ b/mp2p_icp_filters/src/FilterAdjustTimestamps.cpp
@@ -82,11 +82,7 @@ void FilterAdjustTimestamps::filter(mp2p_icp::metric_map_t& inOut) const
         return;
     }
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
     auto* TsPtr = pc.getPointsBufferRef_float_field("t");
-#else
-    auto* TsPtr = pc.getPointsBufferRef_timestamp();
-#endif
 
     if (TsPtr == nullptr || (TsPtr->empty() && !pc.empty()))
     {

--- a/mp2p_icp_filters/src/FilterBoundingBox.cpp
+++ b/mp2p_icp_filters/src/FilterBoundingBox.cpp
@@ -106,7 +106,6 @@ void FilterBoundingBox::filter(mp2p_icp::metric_map_t& inOut) const
         outsidePc->reserve(outsidePc->size() + pc.size() / 10);
     }
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
     mrpt::maps::CPointsMap::InsertCtx ctxOutside, ctxInside;
     if (insidePc)
     {
@@ -118,7 +117,6 @@ void FilterBoundingBox::filter(mp2p_icp::metric_map_t& inOut) const
         outsidePc->registerPointFieldsFrom(pc);
         ctxOutside = outsidePc->prepareForInsertPointsFrom(pc);
     }
-#endif
 
     const auto& xs = pc.getPointsBufferRef_x();
     const auto& ys = pc.getPointsBufferRef_y();
@@ -129,18 +127,10 @@ void FilterBoundingBox::filter(mp2p_icp::metric_map_t& inOut) const
         const bool isInside = params.bounding_box.containsPoint({xs[i], ys[i], zs[i]});
 
         auto* targetPc = isInside ? insidePc.get() : outsidePc.get();
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
-        auto* ctx = isInside ? &ctxInside : &ctxOutside;
-#endif
+        auto* ctx      = isInside ? &ctxInside : &ctxOutside;
         if (targetPc)
         {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
             targetPc->insertPointFrom(i, *ctx);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-            targetPc->insertPointFrom(pc, i, *ctx);
-#else
-            targetPc->insertPointFrom(pc, i);
-#endif
         }
     }
 

--- a/mp2p_icp_filters/src/FilterBoundingBox.cpp
+++ b/mp2p_icp_filters/src/FilterBoundingBox.cpp
@@ -18,6 +18,7 @@
  * @date   Sep 10, 2021
  */
 
+#include <mp2p_icp/pointcloud_field_utils.h>
 #include <mp2p_icp_filters/FilterBoundingBox.h>
 #include <mp2p_icp_filters/GetOrCreatePointLayer.h>
 #include <mrpt/containers/yaml.h>
@@ -111,11 +112,13 @@ void FilterBoundingBox::filter(mp2p_icp::metric_map_t& inOut) const
     {
         insidePc->registerPointFieldsFrom(pc);
         ctxInside = insidePc->prepareForInsertPointsFrom(pc);
+        mp2p_icp::warn_on_field_padding_mismatch(pc, *insidePc, *this);
     }
     if (outsidePc)
     {
         outsidePc->registerPointFieldsFrom(pc);
         ctxOutside = outsidePc->prepareForInsertPointsFrom(pc);
+        mp2p_icp::warn_on_field_padding_mismatch(pc, *outsidePc, *this);
     }
 
     const auto& xs = pc.getPointsBufferRef_x();

--- a/mp2p_icp_filters/src/FilterByIntensity.cpp
+++ b/mp2p_icp_filters/src/FilterByIntensity.cpp
@@ -126,7 +126,6 @@ void FilterByIntensity::filter(mp2p_icp::metric_map_t& inOut) const
     ASSERT_EQUAL_(Is.size(), xs.size());
     const size_t N = xs.size();
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
     mrpt::maps::CPointsMap::InsertCtx ctxLow, ctxHigh, ctxMid;
     if (outLow)
     {
@@ -143,7 +142,6 @@ void FilterByIntensity::filter(mp2p_icp::metric_map_t& inOut) const
         outMid->registerPointFieldsFrom(pc);
         ctxMid = outMid->prepareForInsertPointsFrom(pc);
     }
-#endif
 
     size_t countLow = 0, countMid = 0, countHigh = 0;
 
@@ -153,43 +151,29 @@ void FilterByIntensity::filter(mp2p_icp::metric_map_t& inOut) const
 
         mrpt::maps::CPointsMap* trg = nullptr;
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
         mrpt::maps::CPointsMap::InsertCtx* ctx = nullptr;
-#endif
         if (I < params.low_threshold)
         {
             trg = outLow.get();
             ++countLow;
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
             ctx = &ctxLow;
-#endif
         }
         else if (I > params.high_threshold)
         {
             trg = outHigh.get();
             ++countHigh;
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
             ctx = &ctxHigh;
-#endif
         }
         else
         {
             trg = outMid.get();
             ++countMid;
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
             ctx = &ctxMid;
-#endif
         }
 
         if (trg)
         {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
             trg->insertPointFrom(i, *ctx);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-            trg->insertPointFrom(pc, i, *ctx);
-#else
-            trg->insertPointFrom(pc, i);
-#endif
         }
     }
 

--- a/mp2p_icp_filters/src/FilterByRange.cpp
+++ b/mp2p_icp_filters/src/FilterByRange.cpp
@@ -18,6 +18,7 @@
  * @date   Nov 14, 2023
  */
 
+#include <mp2p_icp/pointcloud_sanity_check.h>
 #include <mp2p_icp_filters/FilterByRange.h>
 #include <mp2p_icp_filters/GetOrCreatePointLayer.h>
 #include <mrpt/containers/yaml.h>
@@ -162,6 +163,17 @@ void FilterByRange::filter(mp2p_icp::metric_map_t& inOut) const
         << pc.asString()
         << " outputBetween: " << (outBetween ? outBetween->asString().c_str() : "(none)")
         << " outputOutside: " << (outOutside ? outOutside->asString().c_str() : "(none)"));
+
+    if (outBetween)
+    {
+        const bool sanityPassed = mp2p_icp::pointcloud_sanity_check(*outBetween);
+        ASSERT_(sanityPassed);
+    }
+    if (outOutside)
+    {
+        const bool sanityPassed = mp2p_icp::pointcloud_sanity_check(*outOutside);
+        ASSERT_(sanityPassed);
+    }
 
     MRPT_END
 }

--- a/mp2p_icp_filters/src/FilterByRange.cpp
+++ b/mp2p_icp_filters/src/FilterByRange.cpp
@@ -115,7 +115,6 @@ void FilterByRange::filter(mp2p_icp::metric_map_t& inOut) const
     const float sqrMin = mrpt::square(params.range_min);
     const float sqrMax = mrpt::square(params.range_max);
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
     std::optional<mrpt::maps::CPointsMap::InsertCtx> ctxBetween;
     std::optional<mrpt::maps::CPointsMap::InsertCtx> ctxOutside;
     if (outBetween)
@@ -128,7 +127,6 @@ void FilterByRange::filter(mp2p_icp::metric_map_t& inOut) const
         outOutside->registerPointFieldsFrom(pc);
         ctxOutside = outOutside->prepareForInsertPointsFrom(pc);
     }
-#endif
 
     for (size_t i = 0; i < xs.size(); i++)
     {
@@ -154,15 +152,8 @@ void FilterByRange::filter(mp2p_icp::metric_map_t& inOut) const
 
         if (targetPc)
         {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
             const auto& ctx = isInside ? ctxBetween : ctxOutside;
             targetPc->insertPointFrom(i, ctx.value());
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-            const auto& ctx = isInside ? ctxBetween : ctxOutside;
-            targetPc->insertPointFrom(pc, i, ctx.value());
-#else
-            targetPc->insertPointFrom(pc, i);
-#endif
         }
     }
 

--- a/mp2p_icp_filters/src/FilterByRange.cpp
+++ b/mp2p_icp_filters/src/FilterByRange.cpp
@@ -18,6 +18,7 @@
  * @date   Nov 14, 2023
  */
 
+#include <mp2p_icp/pointcloud_field_utils.h>
 #include <mp2p_icp/pointcloud_sanity_check.h>
 #include <mp2p_icp_filters/FilterByRange.h>
 #include <mp2p_icp_filters/GetOrCreatePointLayer.h>
@@ -122,11 +123,13 @@ void FilterByRange::filter(mp2p_icp::metric_map_t& inOut) const
     {
         outBetween->registerPointFieldsFrom(pc);
         ctxBetween = outBetween->prepareForInsertPointsFrom(pc);
+        mp2p_icp::warn_on_field_padding_mismatch(pc, *outBetween, *this);
     }
     if (outOutside)
     {
         outOutside->registerPointFieldsFrom(pc);
         ctxOutside = outOutside->prepareForInsertPointsFrom(pc);
+        mp2p_icp::warn_on_field_padding_mismatch(pc, *outOutside, *this);
     }
 
     for (size_t i = 0; i < xs.size(); i++)

--- a/mp2p_icp_filters/src/FilterByRing.cpp
+++ b/mp2p_icp_filters/src/FilterByRing.cpp
@@ -111,13 +111,7 @@ void FilterByRing::filter(mp2p_icp::metric_map_t& inOut) const
 
     const auto& xs = pc.getPointsBufferRef_x();
 
-#if MRPT_VERSION >= 0x020f04  // 2.15.4
     const auto* ptrR = pc.getPointsBufferRef_uint16_field("ring");
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-    const auto* ptrR = pc.getPointsBufferRef_uint_field("ring");
-#else
-    const auto* ptrR = pc.getPointsBufferRef_ring();
-#endif
 
     if (!ptrR || ptrR->empty())
     {
@@ -127,7 +121,6 @@ void FilterByRing::filter(mp2p_icp::metric_map_t& inOut) const
             params.input_pointcloud_layer.c_str());
     }
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
     mrpt::maps::CPointsMap::InsertCtx ctxSelected;
     if (outSelected)
     {
@@ -140,7 +133,6 @@ void FilterByRing::filter(mp2p_icp::metric_map_t& inOut) const
         outNonSel->registerPointFieldsFrom(pc);
         ctxNotSelected = outNonSel->prepareForInsertPointsFrom(pc);
     }
-#endif
 
     const auto& Rs = *ptrR;
     ASSERT_EQUAL_(Rs.size(), xs.size());
@@ -152,37 +144,25 @@ void FilterByRing::filter(mp2p_icp::metric_map_t& inOut) const
     {
         const auto R = Rs[i];
 
-        mrpt::maps::CPointsMap* trg = nullptr;
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
+        mrpt::maps::CPointsMap*            trg = nullptr;
         mrpt::maps::CPointsMap::InsertCtx* ctx = nullptr;
-#endif
 
         if (params.selected_ring_ids.count(R) != 0)
         {
             trg = outSelected.get();
             ++countSel;
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
             ctx = &ctxSelected;
-#endif
         }
         else
         {
             trg = outNonSel.get();
             ++countNon;
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
             ctx = &ctxNotSelected;
-#endif
         }
 
         if (trg)
         {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
             trg->insertPointFrom(i, *ctx);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-            trg->insertPointFrom(pc, i, *ctx);
-#else
-            trg->insertPointFrom(pc, i);
-#endif
         }
     }
 

--- a/mp2p_icp_filters/src/FilterCurvature.cpp
+++ b/mp2p_icp_filters/src/FilterCurvature.cpp
@@ -113,11 +113,7 @@ void FilterCurvature::filter(mp2p_icp::metric_map_t& inOut) const
     const auto& ys = pc.getPointsBufferRef_y();
     const auto& zs = pc.getPointsBufferRef_z();
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
     const auto* ptrRings = pc.getPointsBufferRef_float_field("ring");
-#else
-    const auto* ptrRings = pc.getPointsBufferRef_ring();
-#endif
     if (!ptrRings || ptrRings->empty())
     {
         THROW_EXCEPTION_FMT(
@@ -131,7 +127,6 @@ void FilterCurvature::filter(mp2p_icp::metric_map_t& inOut) const
 
     const size_t N = xs.size();
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
     mrpt::maps::CPointsMap::InsertCtx ctxLarger;
     if (outPcLarger)
     {
@@ -150,7 +145,6 @@ void FilterCurvature::filter(mp2p_icp::metric_map_t& inOut) const
         outPcOther->registerPointFieldsFrom(pc);
         ctxOther = outPcOther->prepareForInsertPointsFrom(pc);
     }
-#endif
 
     const uint16_t nRings = 1 + *std::max_element(ringPerPt.begin(), ringPerPt.end());
 
@@ -230,13 +224,7 @@ void FilterCurvature::filter(mp2p_icp::metric_map_t& inOut) const
                 counterLarger++;
                 if (outPcLarger)
                 {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
                     outPcLarger->insertPointFrom(i, ctxLarger);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-                    outPcLarger->insertPointFrom(pc, i, ctxLarger);
-#else
-                    outPcLarger->insertPointFrom(pc, i);
-#endif
                 }
             }
             continue;
@@ -263,26 +251,14 @@ void FilterCurvature::filter(mp2p_icp::metric_map_t& inOut) const
                     counterLarger++;
                     if (outPcLarger)
                     {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
                         outPcLarger->insertPointFrom(i, ctxLarger);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-                        outPcLarger->insertPointFrom(pc, i, ctxLarger);
-#else
-                        outPcLarger->insertPointFrom(pc, i);
-#endif
                     }
                 }
                 else
                 {
                     if (outPcOther)
                     {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
                         outPcOther->insertPointFrom(i, ctxOther);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-                        outPcOther->insertPointFrom(pc, i, ctxOther);
-#else
-                        outPcOther->insertPointFrom(pc, i);
-#endif
                     }
                 }
                 continue;
@@ -300,13 +276,7 @@ void FilterCurvature::filter(mp2p_icp::metric_map_t& inOut) const
                 counterLarger++;
                 if (outPcLarger)
                 {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
                     outPcLarger->insertPointFrom(i, ctxLarger);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-                    outPcLarger->insertPointFrom(pc, i, ctxLarger);
-#else
-                    outPcLarger->insertPointFrom(pc, i);
-#endif
                 }
             }
             else
@@ -314,13 +284,7 @@ void FilterCurvature::filter(mp2p_icp::metric_map_t& inOut) const
                 counterLess++;
                 if (outPcSmaller)
                 {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
                     outPcSmaller->insertPointFrom(i, ctxSmaller);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-                    outPcSmaller->insertPointFrom(pc, i, ctxSmaller);
-#else
-                    outPcSmaller->insertPointFrom(pc, i);
-#endif
                 }
             }
         }

--- a/mp2p_icp_filters/src/FilterDecimate.cpp
+++ b/mp2p_icp_filters/src/FilterDecimate.cpp
@@ -18,6 +18,7 @@
  * @date   Jan 12, 2026
  */
 
+#include <mp2p_icp/pointcloud_field_utils.h>
 #include <mp2p_icp_filters/FilterDecimate.h>
 #include <mp2p_icp_filters/GetOrCreatePointLayer.h>
 #include <mrpt/containers/yaml.h>
@@ -82,21 +83,14 @@ void FilterDecimate::filter(mp2p_icp::metric_map_t& inOut) const
         pcIn->GetRuntimeClass()->className);
 
     // Efficiently copy points including all extra fields
-#if MRPT_VERSION >= 0x020f00
     outPc->registerPointFieldsFrom(*pcIn);
     auto ctx = outPc->prepareForInsertPointsFrom(*pcIn);
-#endif
+    mp2p_icp::warn_on_field_padding_mismatch(*pcIn, *outPc, *this);
 
     outPc->reserve(outPc->size() + (nIn / N));
 
     for (size_t i = 0; i < nIn; i += N)
     {
-#if MRPT_VERSION >= 0x020f03
         outPc->insertPointFrom(i, ctx);
-#elif MRPT_VERSION >= 0x020f00
-        outPc->insertPointFrom(*pcIn, i, ctx);
-#else
-        outPc->insertPointFrom(*pcIn, i);
-#endif
     }
 }

--- a/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
@@ -18,6 +18,7 @@
  * @date   Nov 24, 2023
  */
 
+#include <mp2p_icp/pointcloud_field_utils.h>
 #include <mp2p_icp_filters/FilterDecimateAdaptive.h>
 #include <mp2p_icp_filters/GetOrCreatePointLayer.h>
 #include <mrpt/containers/yaml.h>
@@ -183,6 +184,7 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
 
     outPc->registerPointFieldsFrom(pc);
     mrpt::maps::CPointsMap::InsertCtx ctx = outPc->prepareForInsertPointsFrom(pc);
+    mp2p_icp::warn_on_field_padding_mismatch(pc, *outPc, *this);
 
     // Perform resampling:
     // -------------------

--- a/mp2p_icp_filters/src/FilterDecimateVoxels.cpp
+++ b/mp2p_icp_filters/src/FilterDecimateVoxels.cpp
@@ -429,5 +429,8 @@ void FilterDecimateVoxels::filter(mp2p_icp::metric_map_t& inOut) const
                        << " type=" << outPc->GetRuntimeClass()->className
                        << " useSingleGrid=" << (useSingleGrid() ? "Yes" : "No"));
 
+    const bool sanityPassed = mp2p_icp::pointcloud_sanity_check(*outPc);
+    ASSERT_(sanityPassed);
+
     MRPT_END
 }

--- a/mp2p_icp_filters/src/FilterDecimateVoxels.cpp
+++ b/mp2p_icp_filters/src/FilterDecimateVoxels.cpp
@@ -25,11 +25,6 @@
 #include <mrpt/math/ops_containers.h>  // dotProduct
 #include <mrpt/random/RandomGenerators.h>
 
-//
-#include <mrpt/maps/CPointsMapXYZI.h>
-#include <mrpt/maps/CPointsMapXYZIRT.h>
-#include <mrpt/version.h>
-
 IMPLEMENTS_MRPT_OBJECT(FilterDecimateVoxels, mp2p_icp_filters::FilterBase, mp2p_icp_filters)
 
 using namespace mp2p_icp_filters;
@@ -174,11 +169,9 @@ void FilterDecimateVoxels::filter(mp2p_icp::metric_map_t& inOut) const
             const auto& xs = pcPtrs[mapIdx]->getPointsBufferRef_x();
             const auto& ys = pcPtrs[mapIdx]->getPointsBufferRef_y();
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
             outPc->registerPointFieldsFrom(*pcPtrs[mapIdx]);
             mrpt::maps::CPointsMap::InsertCtx ctxOut =
                 outPc->prepareForInsertPointsFrom(*pcPtrs[mapIdx]);
-#endif
 
             for (size_t i = 0; i < xs.size(); i++)
             {
@@ -188,13 +181,7 @@ void FilterDecimateVoxels::filter(mp2p_icp::metric_map_t& inOut) const
                 }
                 else
                 {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
                     outPc->insertPointFrom(i, ctxOut);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-                    outPc->insertPointFrom(*pcPtrs[mapIdx], i, ctxOut);
-#else
-                    outPc->insertPointFrom(*pcPtrs[mapIdx], i);
-#endif
                 }
             }
         }
@@ -233,9 +220,7 @@ void FilterDecimateVoxels::filter(mp2p_icp::metric_map_t& inOut) const
         std::set<PointCloudToVoxelGridSingle::indices_t, PointCloudToVoxelGridSingle::IndicesHash>
             flattenUsedBins;
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
         std::map<const mrpt::maps::CPointsMap*, mrpt::maps::CPointsMap::InsertCtx> ctxs;
-#endif
 
         grid.visit_voxels(
             [&](const PointCloudToVoxelGridSingle::indices_t& idx,
@@ -269,11 +254,7 @@ void FilterDecimateVoxels::filter(mp2p_icp::metric_map_t& inOut) const
                         outPc->registerPointFieldsFrom(*pc);
                         ctx = outPc->prepareForInsertPointsFrom(*pc);
                     }
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
                     outPc->insertPointFrom(*vxl.pointIdx, ctx);
-#else
-                    outPc->insertPointFrom(*pc, *vxl.pointIdx, ctx);
-#endif
                     // Actual flatten in "z":
                     outPc->getPointsBufferRef_float_field("z")->back() =
                         static_cast<float>(*params.flatten_to);
@@ -288,11 +269,7 @@ void FilterDecimateVoxels::filter(mp2p_icp::metric_map_t& inOut) const
                         outPc->registerPointFieldsFrom(*pc);
                         ctx = outPc->prepareForInsertPointsFrom(*pc);
                     }
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
                     outPc->insertPointFrom(*vxl.pointIdx, ctx);
-#else
-                    outPc->insertPointFrom(*pc, *vxl.pointIdx, ctx);
-#endif
                 }
             });
     }
@@ -326,10 +303,8 @@ void FilterDecimateVoxels::filter(mp2p_icp::metric_map_t& inOut) const
         std::set<PointCloudToVoxelGrid::indices_t, PointCloudToVoxelGrid::IndicesHash>
             flattenUsedBins;
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
         outPc->registerPointFieldsFrom(pc);
         auto ctx = outPc->prepareForInsertPointsFrom(pc);
-#endif
 
         grid.visit_voxels(
             [&](const PointCloudToVoxelGrid::indices_t& idx,
@@ -440,13 +415,7 @@ void FilterDecimateVoxels::filter(mp2p_icp::metric_map_t& inOut) const
                     }
                     else
                     {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
                         outPc->insertPointFrom(insertPtIdx, ctx);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-                        outPc->insertPointFrom(pc, insertPtIdx, ctx);
-#else
-                        outPc->insertPointFrom(pc, insertPtIdx);
-#endif
                     }
                 }
             });

--- a/mp2p_icp_filters/src/FilterDecimateVoxels.cpp
+++ b/mp2p_icp_filters/src/FilterDecimateVoxels.cpp
@@ -18,6 +18,7 @@
  * @date   Sep 10, 2021
  */
 
+#include <mp2p_icp/pointcloud_field_utils.h>
 #include <mp2p_icp/pointcloud_sanity_check.h>
 #include <mp2p_icp_filters/FilterDecimateVoxels.h>
 #include <mp2p_icp_filters/GetOrCreatePointLayer.h>
@@ -172,6 +173,7 @@ void FilterDecimateVoxels::filter(mp2p_icp::metric_map_t& inOut) const
             outPc->registerPointFieldsFrom(*pcPtrs[mapIdx]);
             mrpt::maps::CPointsMap::InsertCtx ctxOut =
                 outPc->prepareForInsertPointsFrom(*pcPtrs[mapIdx]);
+            mp2p_icp::warn_on_field_padding_mismatch(*pcPtrs[mapIdx], *outPc, *this);
 
             for (size_t i = 0; i < xs.size(); i++)
             {

--- a/mp2p_icp_filters/src/FilterDeskew.cpp
+++ b/mp2p_icp_filters/src/FilterDeskew.cpp
@@ -152,10 +152,6 @@ auto findBeforeAfter(const mola::imu::Trajectory& trajectory, const double t)
 }
 #endif  // MP2P_ICP_HAS_MOLA_IMU_PREINTEGRATION
 
-#if MRPT_VERSION < 0x020f00  // 2.15.0
-#error "MRPT >= 2.15.0 is required to compile FilterDeskew"
-#endif
-
 struct CorrectPointsArguments
 {
     mrpt::aligned_std_vector<float>&       xs;

--- a/mp2p_icp_filters/src/FilterDeskew.cpp
+++ b/mp2p_icp_filters/src/FilterDeskew.cpp
@@ -29,8 +29,6 @@
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/Clock.h>
 #include <mrpt/core/exceptions.h>
-#include <mrpt/maps/CPointsMapXYZIRT.h>
-#include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/poses/Lie/SO.h>
 #include <mrpt/version.h>
 

--- a/mp2p_icp_filters/src/FilterDeskew.cpp
+++ b/mp2p_icp_filters/src/FilterDeskew.cpp
@@ -24,6 +24,7 @@
 #include <mola_imu_preintegration/trajectory_from_buffer.h>
 #endif
 
+#include <mp2p_icp/pointcloud_field_utils.h>
 #include <mp2p_icp_filters/FilterDeskew.h>
 #include <mp2p_icp_filters/GetOrCreatePointLayer.h>
 #include <mrpt/containers/yaml.h>
@@ -430,6 +431,7 @@ void FilterDeskew::filter(mp2p_icp::metric_map_t& inOut) const
 
         // and then, prepare structures for fast copying:
         insert_ctx = outPc->prepareForInsertPointsFrom(*inPc);
+        mp2p_icp::warn_on_field_padding_mismatch(*inPc, *outPc, *this);
     }
 
     // If the input is empty, just move on:

--- a/mp2p_icp_filters/src/FilterDeskew.cpp
+++ b/mp2p_icp_filters/src/FilterDeskew.cpp
@@ -354,26 +354,22 @@ void correctPointsLoop(const CorrectPointsArguments& args)
             {
                 outPc->setPointFast(n0 + i, corrPt.x, corrPt.y, corrPt.z);
 
-            // Copy additional fields using the insertion context:
-#if MRPT_VERSION >= 0x020f02  // >=2.15.2
+                // Copy additional fields using the insertion context:
                 for (auto& [src, dst] : ctxCopyPointFields->double_fields)
                 {
-                    (*dst)[n0 + i] = (*src)[i];
+                    (*dst)[n0 + i] = src ? (*src)[i] : 0.0;
                 }
-#endif
-#if MRPT_VERSION >= 0x020f03  // >=2.15.3
                 for (auto& [src, dst] : ctxCopyPointFields->uint8_fields)
                 {
-                    (*dst)[n0 + i] = (*src)[i];
+                    (*dst)[n0 + i] = src ? (*src)[i] : uint8_t{0};
                 }
-#endif
                 for (auto& [src, dst] : ctxCopyPointFields->float_fields)
                 {
-                    (*dst)[n0 + i] = (*src)[i];
+                    (*dst)[n0 + i] = src ? (*src)[i] : 0.0f;
                 }
                 for (auto& [src, dst] : ctxCopyPointFields->uint16_fields)
                 {
-                    (*dst)[n0 + i] = (*src)[i];
+                    (*dst)[n0 + i] = src ? (*src)[i] : uint16_t{0};
                 }
             }
         }

--- a/mp2p_icp_filters/src/FilterFartherPointSampling.cpp
+++ b/mp2p_icp_filters/src/FilterFartherPointSampling.cpp
@@ -104,10 +104,8 @@ void FilterFartherPointSampling::filter(mp2p_icp::metric_map_t& inOut) const
 
     outPc->reserve(outPc->size() + params.desired_output_point_count);
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
     outPc->registerPointFieldsFrom(pc);
     mrpt::maps::CPointsMap::InsertCtx ctx = outPc->prepareForInsertPointsFrom(pc);
-#endif
 
     const auto input_size = pc.size();
     if (params.desired_output_point_count > input_size)
@@ -124,13 +122,7 @@ void FilterFartherPointSampling::filter(mp2p_icp::metric_map_t& inOut) const
     srand((unsigned)time(NULL));
     std::size_t idx = rand() % input_size;
 
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
     outPc->insertPointFrom(idx, ctx);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-    outPc->insertPointFrom(pc, idx, ctx);
-#else
-    outPc->insertPointFrom(pc, idx);
-#endif
 
     // Initialize distances to first point
     const auto& xs = pc.getPointsBufferRef_x();
@@ -162,13 +154,7 @@ void FilterFartherPointSampling::filter(mp2p_icp::metric_map_t& inOut) const
         } while (top.dist != minDist[top.idx] && !heap.empty());
 
         const auto farthestIdx = top.idx;
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
         outPc->insertPointFrom(farthestIdx, ctx);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-        outPc->insertPointFrom(pc, farthestIdx, ctx);
-#else
-        outPc->insertPointFrom(pc, farthestIdx);
-#endif
         // Update distances relative to new point
         for (std::size_t j = 0; j < input_size; j++)
         {

--- a/mp2p_icp_filters/src/FilterMLS.cpp
+++ b/mp2p_icp_filters/src/FilterMLS.cpp
@@ -616,13 +616,22 @@ void FilterMLS::filter(mp2p_icp::metric_map_t& inOut) const
         return;
     }
 
-    // Register the normal fields in the output map.
+    // Register query_pc fields first, then build the InsertCtx from that
+    // snapshot. Normal fields are intentionally registered AFTER this call so
+    // that they are absent from ctx: insertPointFrom() must not touch them,
+    // because the loop below is the sole writer of normals via push_back().
+    // Registering normals before prepareForInsertPointsFrom() would cause
+    // insertPointFrom() (MRPT >= 0x020f0d) to zero-pad them on every call,
+    // resulting in double-length normal vectors and a sanity-check failure.
+    outPc->registerPointFieldsFrom(*query_pc);
+
+    const auto ctx = outPc->prepareForInsertPointsFrom(*query_pc);
+    mp2p_icp::warn_on_field_padding_mismatch(*query_pc, *outPc, *this);
+
+    // Register the normal fields in the output map only after the ctx is built.
     outPc->registerField_float("normal_x");
     outPc->registerField_float("normal_y");
     outPc->registerField_float("normal_z");
-
-    // and the ones at origin cloud:
-    outPc->registerPointFieldsFrom(*query_pc);
 
     auto* normals_x = outPc->getPointsBufferRef_float_field("normal_x");
     auto* normals_y = outPc->getPointsBufferRef_float_field("normal_y");
@@ -630,9 +639,6 @@ void FilterMLS::filter(mp2p_icp::metric_map_t& inOut) const
     ASSERT_(normals_x);
     ASSERT_(normals_y);
     ASSERT_(normals_z);
-
-    const auto ctx = outPc->prepareForInsertPointsFrom(*query_pc);
-    mp2p_icp::warn_on_field_padding_mismatch(*query_pc, *outPc, *this);
 
     const size_t firstIdx = outPc->size();
     outPc->reserve(firstIdx + nNewPoints);

--- a/mp2p_icp_filters/src/FilterMLS.cpp
+++ b/mp2p_icp_filters/src/FilterMLS.cpp
@@ -19,6 +19,8 @@
  * @date   Oct 26, 2025
  */
 
+#include <mp2p_icp/pointcloud_field_utils.h>
+#include <mp2p_icp/pointcloud_sanity_check.h>
 #include <mp2p_icp_filters/FilterMLS.h>
 #include <mp2p_icp_filters/GetOrCreatePointLayer.h>
 #include <mrpt/containers/NonCopiableData.h>
@@ -630,6 +632,7 @@ void FilterMLS::filter(mp2p_icp::metric_map_t& inOut) const
     ASSERT_(normals_z);
 
     const auto ctx = outPc->prepareForInsertPointsFrom(*query_pc);
+    mp2p_icp::warn_on_field_padding_mismatch(*query_pc, *outPc, *this);
 
     const size_t firstIdx = outPc->size();
     outPc->reserve(firstIdx + nNewPoints);

--- a/mp2p_icp_filters/src/FilterPoleDetector.cpp
+++ b/mp2p_icp_filters/src/FilterPoleDetector.cpp
@@ -179,7 +179,6 @@ void FilterPoleDetector::filter(mp2p_icp::metric_map_t& inOut) const
         outNoPoles->reserve(outNoPoles->size() + pc.size() / 10);
     }
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
     mrpt::maps::CPointsMap::InsertCtx ctxPoles;
     if (outPoles)
     {
@@ -192,7 +191,6 @@ void FilterPoleDetector::filter(mp2p_icp::metric_map_t& inOut) const
         outNoPoles->registerPointFieldsFrom(pc);
         ctxNoPoles = outNoPoles->prepareForInsertPointsFrom(pc);
     }
-#endif
 
     const auto& xs = pc.getPointsBufferRef_x();
     const auto& ys = pc.getPointsBufferRef_y();
@@ -253,20 +251,12 @@ void FilterPoleDetector::filter(mp2p_icp::metric_map_t& inOut) const
         const bool isPole = check_pass_count >= params.minimum_neighbors_checks_to_pass;
 
         auto* targetPc = isPole ? outPoles.get() : outNoPoles.get();
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
-        auto* ctx = isPole ? &ctxPoles : &ctxNoPoles;
-#endif
+        auto* ctx      = isPole ? &ctxPoles : &ctxNoPoles;
         if (targetPc)
         {
             for (const auto ptIdx : cell.point_indices)
             {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
                 targetPc->insertPointFrom(ptIdx, *ctx);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-                targetPc->insertPointFrom(pc, ptIdx, *ctx);
-#else
-                targetPc->insertPointFrom(pc, ptIdx);
-#endif
             }
         }
     }

--- a/mp2p_icp_filters/src/FilterRemoveByVoxelOccupancy.cpp
+++ b/mp2p_icp_filters/src/FilterRemoveByVoxelOccupancy.cpp
@@ -123,7 +123,6 @@ void FilterRemoveByVoxelOccupancy::filter(mp2p_icp::metric_map_t& inOut) const
         "At least one 'output_layer_static_objects' or "
         "'output_layer_dynamic_objects' output layers must be provided.");
 
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
     mrpt::maps::CPointsMap::InsertCtx ctxStatic;
     if (outPcStatic)
     {
@@ -136,7 +135,6 @@ void FilterRemoveByVoxelOccupancy::filter(mp2p_icp::metric_map_t& inOut) const
         outPcDynamic->registerPointFieldsFrom(*pcPtr);
         ctxDynamic = outPcDynamic->prepareForInsertPointsFrom(*pcPtr);
     }
-#endif
 
     // Process occupancy input value so it lies within [0,0.5]:
     const double occFree  = params.occupancy_threshold > 0.5 ? (1.0 - params.occupancy_threshold)
@@ -160,38 +158,26 @@ void FilterRemoveByVoxelOccupancy::filter(mp2p_icp::metric_map_t& inOut) const
             continue;  // undefined! pt out of voxelmap
         }
 
-        mrpt::maps::CPointsMap* trgMap = nullptr;
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
-        mrpt::maps::CPointsMap::InsertCtx* ctx = nullptr;
-#endif
+        mrpt::maps::CPointsMap*            trgMap = nullptr;
+        mrpt::maps::CPointsMap::InsertCtx* ctx    = nullptr;
         if (prob_occupancy > occThres)
         {
             trgMap = outPcStatic.get();
             nStatic++;
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
             ctx = &ctxStatic;
-#endif
         }
         else if (prob_occupancy < occFree)
         {
             trgMap = outPcDynamic.get();
             nDynamic++;
-#if MRPT_VERSION >= 0x020f00  // 2.15.0
             ctx = &ctxDynamic;
-#endif
         }
 
         if (!trgMap)
         {
             continue;
         }
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
         trgMap->insertPointFrom(i, *ctx);
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-        trgMap->insertPointFrom(*pcPtr, i, *ctx);
-#else
-        trgMap->insertPointFrom(*pcPtr, i);
-#endif
     }
 
     MRPT_LOG_DEBUG_STREAM(

--- a/mp2p_icp_filters/src/FilterSOR.cpp
+++ b/mp2p_icp_filters/src/FilterSOR.cpp
@@ -165,7 +165,6 @@ void FilterSOR::filter(mp2p_icp::metric_map_t& inOut) const
         const bool isInlier = (avg_distances[i] <= threshold);
         if (isInlier)
         {
-#if MRPT_VERSION >= 0x020f03  // 2.15.3
             ++num_inliers;
             if (outInliers)
             {
@@ -179,35 +178,6 @@ void FilterSOR::filter(mp2p_icp::metric_map_t& inOut) const
             {
                 outOutliers->insertPointFrom(i, *ctxO);
             }
-#elif MRPT_VERSION >= 0x020f00  // 2.15.0
-            ++num_inliers;
-            if (outInliers)
-            {
-                outInliers->insertPointFrom(pc, i, *ctxI);
-            }
-        }
-        else
-        {
-            ++num_outliers;
-            if (outOutliers)
-            {
-                outOutliers->insertPointFrom(pc, i, *ctxO);
-            }
-#else
-            ++num_inliers;
-            if (outInliers)
-            {
-                outInliers->insertPointFrom(pc, i);
-            }
-        }
-        else
-        {
-            ++num_outliers;
-            if (outOutliers)
-            {
-                outOutliers->insertPointFrom(pc, i);
-            }
-#endif
         }
     }
 

--- a/mp2p_icp_filters/src/FilterSOR.cpp
+++ b/mp2p_icp_filters/src/FilterSOR.cpp
@@ -19,6 +19,8 @@
  * @date   Dec 28, 2025
  */
 
+#include <mp2p_icp/pointcloud_field_utils.h>
+#include <mp2p_icp/pointcloud_sanity_check.h>
 #include <mp2p_icp_filters/FilterSOR.h>
 #include <mp2p_icp_filters/GetOrCreatePointLayer.h>
 #include <mrpt/containers/yaml.h>
@@ -87,11 +89,13 @@ void FilterSOR::filter(mp2p_icp::metric_map_t& inOut) const
     {
         outInliers->registerPointFieldsFrom(pc);
         ctxI = outInliers->prepareForInsertPointsFrom(pc);
+        mp2p_icp::warn_on_field_padding_mismatch(pc, *outInliers, *this);
     }
     if (outOutliers)
     {
         outOutliers->registerPointFieldsFrom(pc);
         ctxO = outOutliers->prepareForInsertPointsFrom(pc);
+        mp2p_icp::warn_on_field_padding_mismatch(pc, *outOutliers, *this);
     }
 
     if (pcPtr->empty())

--- a/mp2p_icp_filters/src/FilterVoxelSOR.cpp
+++ b/mp2p_icp_filters/src/FilterVoxelSOR.cpp
@@ -19,6 +19,8 @@
  * @date   Jan 21, 2026
  */
 
+#include <mp2p_icp/pointcloud_field_utils.h>
+#include <mp2p_icp/pointcloud_sanity_check.h>
 #include <mp2p_icp_filters/FilterVoxelSOR.h>
 #include <mp2p_icp_filters/GetOrCreatePointLayer.h>
 #include <mp2p_icp_filters/PointCloudToVoxelGrid.h>
@@ -92,16 +94,17 @@ void FilterVoxelSOR::filter(mp2p_icp::metric_map_t& inOut) const
         outOutliers->clear();
     }
 
-#if MRPT_VERSION >= 0x020f00
     outInliers->registerPointFieldsFrom(*pcIn);
     auto ctxI = outInliers->prepareForInsertPointsFrom(*pcIn);
+    mp2p_icp::warn_on_field_padding_mismatch(*pcIn, *outInliers, *this);
+
     std::optional<mrpt::maps::CPointsMap::InsertCtx> ctxO;
     if (outOutliers)
     {
         outOutliers->registerPointFieldsFrom(*pcIn);
         ctxO = outOutliers->prepareForInsertPointsFrom(*pcIn);
+        mp2p_icp::warn_on_field_padding_mismatch(*pcIn, *outOutliers, *this);
     }
-#endif
 
     const auto& xs = pcIn->getPointsBufferRef_x();
     const auto& ys = pcIn->getPointsBufferRef_y();

--- a/mp2p_icp_filters/src/Generator.cpp
+++ b/mp2p_icp_filters/src/Generator.cpp
@@ -63,6 +63,7 @@ void Generator::Parameters::load_from_yaml(const mrpt::containers::yaml& c, Gene
     MCP_LOAD_OPT(c, process_sensor_labels_regex);
     MCP_LOAD_OPT(c, throw_on_unhandled_observation_class);
     MCP_LOAD_OPT(c, generate_view_vector);
+    MCP_LOAD_OPT(c, default_pointcloud_class);
 
     MCP_LOAD_OPT(c, name);
     if (!name.empty())
@@ -336,9 +337,27 @@ bool Generator::filterPointCloud(  //
     }
     else
     {
-        // Make a new layer of the same type than the input cloud:
-        outPc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(
-            pc.GetRuntimeClass()->ptrCreateObject());
+        if (params.default_pointcloud_class.empty())
+        {
+            // Make a new layer of the same type than the input cloud:
+            outPc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(
+                pc.GetRuntimeClass()->ptrCreateObject());
+        }
+        else
+        {
+            auto obj = mrpt::rtti::classFactory(params.default_pointcloud_class);
+            ASSERTMSG_(
+                obj, mrpt::format(
+                         "Error creating class of type '%s'. Is it registered?",
+                         params.default_pointcloud_class.c_str()));
+
+            outPc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(obj);
+            ASSERTMSG_(
+                obj, mrpt::format(
+                         "Error creating class of type '%s': it does not seem to be derived from "
+                         "CPointsMap as expected.",
+                         params.default_pointcloud_class.c_str()));
+        }
         ASSERT_(outPc);
 
         MRPT_LOG_DEBUG_FMT(

--- a/mp2p_icp_filters/src/Generator.cpp
+++ b/mp2p_icp_filters/src/Generator.cpp
@@ -64,6 +64,7 @@ void Generator::Parameters::load_from_yaml(const mrpt::containers::yaml& c, Gene
     MCP_LOAD_OPT(c, throw_on_unhandled_observation_class);
     MCP_LOAD_OPT(c, generate_view_vector);
     MCP_LOAD_OPT(c, default_pointcloud_class);
+    MCP_LOAD_OPT(c, filterOutPointsAtZero);
 
     MCP_LOAD_OPT(c, name);
     if (!name.empty())
@@ -370,7 +371,7 @@ bool Generator::filterPointCloud(  //
     const mrpt::poses::CPose3D p = robotPose ? robotPose.value() + sensorPose : sensorPose;
 
     outPc->registerPointFieldsFrom(pc);
-    outPc->insertAnotherMap(&pc, p);
+    outPc->insertAnotherMap(&pc, p, params.filterOutPointsAtZero);
 
     return true;
 }

--- a/mp2p_icp_filters/src/Generator.cpp
+++ b/mp2p_icp_filters/src/Generator.cpp
@@ -354,10 +354,10 @@ bool Generator::filterPointCloud(  //
 
             outPc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(obj);
             ASSERTMSG_(
-                obj, mrpt::format(
-                         "Error creating class of type '%s': it does not seem to be derived from "
-                         "CPointsMap as expected.",
-                         params.default_pointcloud_class.c_str()));
+                outPc, mrpt::format(
+                           "Error creating class of type '%s': it does not seem to be derived from "
+                           "CPointsMap as expected.",
+                           params.default_pointcloud_class.c_str()));
         }
         ASSERT_(outPc);
 

--- a/mp2p_icp_map/CMakeLists.txt
+++ b/mp2p_icp_map/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIB_SRCS
   src/NearestPlaneCapable.cpp
   src/NearestPointWithCovCapable.cpp
   src/point_with_cov_pair_t.cpp
+  src/pointcloud_field_utils.cpp
   src/pointcloud_sanity_check.cpp
   src/update_velocity_buffer_from_obs.cpp
   #
@@ -30,6 +31,7 @@ set(LIB_PUBLIC_HDRS
   include/mp2p_icp/point_plane_pair_t.h
   include/mp2p_icp/point_with_cov_pair_t.h
   include/mp2p_icp/pointcloud_bitfield.h
+  include/mp2p_icp/pointcloud_field_utils.h
   include/mp2p_icp/pointcloud_sanity_check.h
   include/mp2p_icp/render_params.h
   include/mp2p_icp/update_velocity_buffer_from_obs.h

--- a/mp2p_icp_map/include/mp2p_icp/pointcloud_field_utils.h
+++ b/mp2p_icp_map/include/mp2p_icp/pointcloud_field_utils.h
@@ -1,0 +1,54 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file   pointcloud_field_utils.h
+ * @brief  Raises warnings on missing fields that would be filled with zeros.
+ * @author Jose Luis Blanco Claraco
+ * @date   Apr 9, 2026
+ */
+
+#pragma once
+
+#include <mrpt/maps/CPointsMap.h>
+#include <mrpt/system/COutputLogger.h>
+
+#include <string>
+#include <vector>
+
+namespace mp2p_icp
+{
+
+/** Checks whether copying points from \a src into \a dst via
+ *  CPointsMap::prepareForInsertPointsFrom() + insertPointFrom() would result
+ *  in any destination field being zero-padded (i.e. the field exists in \a dst
+ *  but is absent in \a src).
+ *
+ *  This situation is benign on MRPT < 2.15.13 (those fields were simply
+ *  skipped, which caused sanity-check crashes), and is
+ *  handled correctly from MRPT 2.15.13 onwards by writing explicit zeros.
+ *  However, silent zero-padding may still indicate a configuration problem,
+ *  or sensor drops.
+ *
+ *  One WARN-level message is emitted per mismatched field name.
+ *
+ *  \param src  Source point cloud (the one being inserted FROM).
+ *  \param dst  Destination point cloud (the one being inserted INTO).
+ *  \param logger  Logger used for WARN messages.
+ *  \return True if at least one mismatch was found.
+ */
+bool warn_on_field_padding_mismatch(
+    const mrpt::maps::CPointsMap& src, const mrpt::maps::CPointsMap& dst,
+    const mrpt::system::COutputLogger& logger);
+
+}  // namespace mp2p_icp

--- a/mp2p_icp_map/src/metricmap.cpp
+++ b/mp2p_icp_map/src/metricmap.cpp
@@ -336,12 +336,10 @@ void metric_map_t::get_visualization_map_layer(
         if (auto glPtsCol = o.getByClass<mrpt::opengl::CPointCloudColoured>(); glPtsCol)
         {
             glPtsCol->setPointSize(p.pointSize);
-#if MRPT_VERSION >= 0x20e0c  // v2.14.12
             if (p.force_alpha_channel)
             {
                 glPtsCol->setAllPointsAlpha(p.color.A);
             }
-#endif
         }
         else if (auto glPts = o.getByClass<mrpt::opengl::CPointCloud>(); glPts)
         {
@@ -364,22 +362,17 @@ void metric_map_t::get_visualization_map_layer(
         glPts->loadFromPointsMap(pts.get());
 
         glPts->setPointSize(p.pointSize);
-#if MRPT_VERSION >= 0x20e0c  // v2.14.12
         if (p.force_alpha_channel)
         {
             glPts->setAllPointsAlpha(p.color.A);
         }
-#endif
 
         ASSERT_(p.colorMode->recolorizeByField.has_value());
 
-#if MRPT_VERSION >= 0x020f03  // v2.15.3
         mrpt::obs::PointCloudRecoloringParameters vizParams;
         vizParams.colorMapMinCoord = p.colorMode->colorMapMinCoord;
         vizParams.colorMapMaxCoord = p.colorMode->colorMapMaxCoord;
-#else
-        mrpt::obs::VisualizationParameters vizParams;
-#endif
+
         vizParams.colorizeByField = p.colorMode->recolorizeByField.value();
         vizParams.colorMap        = p.colorMode->colorMap;
 

--- a/mp2p_icp_map/src/pointcloud_field_utils.cpp
+++ b/mp2p_icp_map/src/pointcloud_field_utils.cpp
@@ -1,0 +1,92 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/**
+ * @file   pointcloud_field_utils.cpp
+ * @brief  Raises warnings on missing fields that would be filled with zeros.
+ * @author Jose Luis Blanco Claraco
+ * @date   Apr 9, 2026
+ */
+
+#include <mp2p_icp/pointcloud_field_utils.h>
+
+bool mp2p_icp::warn_on_field_padding_mismatch(
+    const mrpt::maps::CPointsMap& src, const mrpt::maps::CPointsMap& dst,
+    const mrpt::system::COutputLogger& logger)
+{
+    bool any = false;
+
+    // Helper: check one family of fields.
+    // dst_names  – fields registered in dst for this type
+    // src_has_fn – returns true if src carries a non-empty buffer for the name
+    auto check =
+        [&](const std::vector<std::string>& dst_names, auto src_has_fn, const char* type_label)
+    {
+        for (const auto& name : dst_names)
+        {
+            if (!src_has_fn(name))
+            {
+                logger.logFmt(
+                    mrpt::system::LVL_WARN,
+                    "warn_on_field_padding_mismatch: destination map has field '%s' (%s) but "
+                    "source map does not: points inserted from source will be "
+                    "zero-padded for this field.",
+                    name.c_str(), type_label);
+                any = true;
+            }
+        }
+    };
+
+    // float fields (excluding x/y/z which are always present)
+    check(
+        dst.getPointFieldNames_float_except_xyz(),
+        [&](const std::string& name) -> bool
+        {
+            const auto* v = src.getPointsBufferRef_float_field(name);
+            return v && !v->empty();
+        },
+        "float");
+
+    // double fields
+    check(
+        dst.getPointFieldNames_double(),
+        [&](const std::string& name) -> bool
+        {
+            const auto* v = src.getPointsBufferRef_double_field(name);
+            return v && !v->empty();
+        },
+        "double");
+
+    // uint16 fields
+    check(
+        dst.getPointFieldNames_uint16(),
+        [&](const std::string& name) -> bool
+        {
+            const auto* v = src.getPointsBufferRef_uint16_field(name);
+            return v && !v->empty();
+        },
+        "uint16");
+
+    // uint8 fields
+    check(
+        dst.getPointFieldNames_uint8(),
+        [&](const std::string& name) -> bool
+        {
+            const auto* v = src.getPointsBufferRef_uint8_field(name);
+            return v && !v->empty();
+        },
+        "uint8");
+
+    return any;
+}

--- a/mp2p_icp_map/src/pointcloud_field_utils.cpp
+++ b/mp2p_icp_map/src/pointcloud_field_utils.cpp
@@ -28,11 +28,17 @@ bool mp2p_icp::warn_on_field_padding_mismatch(
     bool any = false;
 
     // Helper: check one family of fields.
-    // dst_names  – fields registered in dst for this type
-    // src_has_fn – returns true if src carries a non-empty buffer for the name
-    auto check =
-        [&](const std::vector<std::string>& dst_names, auto src_has_fn, const char* type_label)
+    // dst_names: fields registered in dst for this type
+    // src_has_fn: returns true if src carries a non-empty buffer for the name
+    auto check = [&](const auto& dst_names_org, auto src_has_fn, const char* type_label)
     {
+        // make this compatible with different MRPT versions using std::string_view vs std::string
+        std::vector<std::string> dst_names;
+        for (const auto& mame : dst_names_org)
+        {
+            dst_names.emplace_back(std::string(mame));
+        }
+
         for (const auto& name : dst_names)
         {
             if (!src_has_fn(name))

--- a/mp2p_icp_map/src/pointcloud_sanity_check.cpp
+++ b/mp2p_icp_map/src/pointcloud_sanity_check.cpp
@@ -21,21 +21,14 @@
 
 #include <mp2p_icp/pointcloud_sanity_check.h>
 #include <mrpt/core/exceptions.h>
-#include <mrpt/version.h>
-
-#if MRPT_VERSION >= 0x20f00  // 2.15.0
 #include <mrpt/maps/CPointsMap.h>
-#else
-#include <mrpt/maps/CPointsMapXYZI.h>
-#include <mrpt/maps/CPointsMapXYZIRT.h>
-#endif
+#include <mrpt/version.h>
 
 bool mp2p_icp::pointcloud_sanity_check(const mrpt::maps::CPointsMap& pc, bool printWarnings)
 {
     bool         ok = true;
     const size_t n  = pc.size();
 
-#if MRPT_VERSION >= 0x20f00  // 2.15.0
     for (const auto& field : pc.getPointFieldNames_float())
     {
         const auto& vec = pc.getPointsBufferRef_float_field(field);
@@ -52,11 +45,7 @@ bool mp2p_icp::pointcloud_sanity_check(const mrpt::maps::CPointsMap& pc, bool pr
     }
     for (const auto& field : pc.getPointFieldNames_uint16())
     {
-#if MRPT_VERSION >= 0x20f04  // 2.15.4
         const auto& vec = pc.getPointsBufferRef_uint16_field(field);
-#else
-        const auto& vec = pc.getPointsBufferRef_uint_field(field);
-#endif
         if (vec && !vec->empty() && vec->size() != n)
         {
             ok = false;
@@ -69,7 +58,6 @@ bool mp2p_icp::pointcloud_sanity_check(const mrpt::maps::CPointsMap& pc, bool pr
         }
     }
 
-#if MRPT_VERSION >= 0x20f03  // 2.15.3
     for (const auto& field : pc.getPointFieldNames_double())
     {
         const auto& vec = pc.getPointsBufferRef_double_field(field);
@@ -98,51 +86,6 @@ bool mp2p_icp::pointcloud_sanity_check(const mrpt::maps::CPointsMap& pc, bool pr
             }
         }
     }
-#endif
 
-#else
-    if (auto* pcIRT = dynamic_cast<const mrpt::maps::CPointsMapXYZIRT*>(&pc); pcIRT)
-    {
-        if (pcIRT->hasIntensityField() && pcIRT->getPointsBufferRef_intensity()->size() != n)
-        {
-            ok = false;
-            if (printWarnings)
-                std::cerr << "[mp2p_icp] XYZIRT WARNING: Intensity channel has "
-                             "incorrect length="
-                          << pcIRT->getPointsBufferRef_intensity()->size() << " expected=" << n
-                          << std::endl;
-        }
-        if (pcIRT->hasRingField() && pcIRT->getPointsBufferRef_ring()->size() != n)
-        {
-            ok = false;
-            if (printWarnings)
-                std::cerr << "[mp2p_icp] XYZIRT WARNING: Ring channel has "
-                             "incorrect length="
-                          << pcIRT->getPointsBufferRef_ring()->size() << " expected=" << n
-                          << std::endl;
-        }
-        if (pcIRT->hasTimeField() && pcIRT->getPointsBufferRef_timestamp()->size() != n)
-        {
-            ok = false;
-            if (printWarnings)
-                std::cerr << "[mp2p_icp] XYZIRT WARNING: Timestamp channel has "
-                             "incorrect length="
-                          << pcIRT->getPointsBufferRef_timestamp()->size() << " expected=" << n
-                          << std::endl;
-        }
-    }
-    else if (auto* pcI = dynamic_cast<const mrpt::maps::CPointsMapXYZI*>(&pc); pcI)
-    {
-        if (pcI->getPointsBufferRef_intensity() && pcI->getPointsBufferRef_intensity()->size() != n)
-        {
-            ok = false;
-            if (printWarnings)
-                std::cerr << "[mp2p_icp] XYZI WARNING: Intensity channel has "
-                             "incorrect length="
-                          << pcI->getPointsBufferRef_intensity()->size() << " expected=" << n
-                          << std::endl;
-        }
-    }
-#endif
     return ok;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generator gains options to choose the output point‑cloud class and to discard invalid zero-valued points; demo pipelines enable this filtering.

* **Documentation**
  * Clarified required input point‑cloud type for timestamps and updated the documented minimum MRPT version.

* **Chores**
  * Removed legacy version-dependent branches, added runtime field-padding warnings and point-cloud sanity checks, and simplified insertion workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->