### PR TITLE
mm-info, mm2grid, mm2las, mm2ply, mm2txt now have a --load-plugins flag

### DIFF
--- a/apps/mm-filter/main.cpp
+++ b/apps/mm-filter/main.cpp
@@ -24,6 +24,8 @@
 #include <mrpt/containers/yaml.h>
 #include <mrpt/system/filesystem.h>
 
+#include <stdexcept>
+
 namespace
 {
 

--- a/apps/mm-georef/main.cpp
+++ b/apps/mm-georef/main.cpp
@@ -29,6 +29,7 @@
 #include <mrpt/system/os.h>
 
 #include <fstream>
+#include <stdexcept>
 
 namespace
 {

--- a/apps/mm-info/main.cpp
+++ b/apps/mm-info/main.cpp
@@ -26,6 +26,8 @@
 #include <mrpt/system/filesystem.h>
 #include <mrpt/system/os.h>
 
+#include <stdexcept>
+
 // CLI flags:
 namespace
 {

--- a/apps/mm-info/main.cpp
+++ b/apps/mm-info/main.cpp
@@ -24,18 +24,35 @@
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/Clock.h>
 #include <mrpt/system/filesystem.h>
+#include <mrpt/system/os.h>
 
 // CLI flags:
 namespace
 {
-TCLAP::CmdLine cmd("mm-filter");
+TCLAP::CmdLine cmd("mm-info");
 
 TCLAP::UnlabeledValueArg<std::string> argMapFile(
     "input", "Load this metric map file (*.mm)", true, "myMap.mm", "myMap.mm", cmd);
+
+TCLAP::ValueArg<std::string> arg_plugins(
+    "l", "load-plugins", "One or more (comma separated) *.so files to load as plugins", false,
+    "foobar.so", "foobar.so", cmd);
 }  // namespace
 
 void run_mm_info()
 {
+    // Load plugins:
+    if (arg_plugins.isSet())
+    {
+        std::string errMsg;
+        const auto  plugins = arg_plugins.getValue();
+        std::cout << "Loading plugin(s): " << plugins << std::endl;
+        if (!mrpt::system::loadPluginModules(plugins, errMsg))
+        {
+            throw std::runtime_error(errMsg);
+        }
+    }
+
     const auto& filInput = argMapFile.getValue();
 
     ASSERT_FILE_EXISTS_(argMapFile.getValue());

--- a/apps/mm2grid/main.cpp
+++ b/apps/mm2grid/main.cpp
@@ -30,6 +30,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
 
 // ---------------------------------------------------------------------------
 // CLI flags

--- a/apps/mm2grid/main.cpp
+++ b/apps/mm2grid/main.cpp
@@ -79,6 +79,10 @@ TCLAP::SwitchArg argNegate(
     "occupied (negate: true in the YAML).",
     cmd);
 
+TCLAP::ValueArg<std::string> arg_plugins(
+    "", "load-plugins", "One or more (comma separated) *.so files to load as plugins", false,
+    "foobar.so", "foobar.so", cmd);
+
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -86,6 +90,18 @@ TCLAP::SwitchArg argNegate(
 void run_mm2grid()
 {
     using namespace std::string_literals;
+
+    // Load plugins:
+    if (arg_plugins.isSet())
+    {
+        std::string errMsg;
+        const auto  plugins = arg_plugins.getValue();
+        std::cout << "Loading plugin(s): " << plugins << std::endl;
+        if (!mrpt::system::loadPluginModules(plugins, errMsg))
+        {
+            throw std::runtime_error(errMsg);
+        }
+    }
 
     const auto& filInput = argMapFile.getValue();
     ASSERT_FILE_EXISTS_(filInput);

--- a/apps/mm2las/main.cpp
+++ b/apps/mm2las/main.cpp
@@ -24,6 +24,7 @@
 #include <mrpt/maps/CPointsMap.h>
 #include <mrpt/poses/CPose3D.h>
 #include <mrpt/system/filesystem.h>
+#include <mrpt/system/os.h>
 #include <mrpt/system/string_utils.h>
 #include <mrpt/topography/conversions.h>
 #include <mrpt/topography/data_types.h>
@@ -67,6 +68,10 @@ TCLAP::ValueArg<std::string> argFrame(
     "(requires georeferencing data). If per-point latitude/longitude/altitude fields already exist "
     "in the map, they are used directly; otherwise, the conversion is computed on the fly.",
     false, "map", "map|enu|geodetic", cmd);
+
+TCLAP::ValueArg<std::string> arg_plugins(
+    "l", "load-plugins", "One or more (comma separated) *.so files to load as plugins", false,
+    "foobar.so", "foobar.so", cmd);
 
 // ----------------------------------------------------------------
 // LAS 1.4 Format Structures
@@ -1187,6 +1192,19 @@ int main(int argc, char** argv)
         {
             return 0;
         }
+
+        // Load plugins:
+        if (arg_plugins.isSet())
+        {
+            std::string errMsg;
+            const auto  plugins = arg_plugins.getValue();
+            std::cout << "Loading plugin(s): " << plugins << std::endl;
+            if (!mrpt::system::loadPluginModules(plugins, errMsg))
+            {
+                throw std::runtime_error(errMsg);
+            }
+        }
+
         mp2p_icp::metric_map_t mm;
         mm.load_from_file(arg_input.getValue());
 

--- a/apps/mm2ply/main.cpp
+++ b/apps/mm2ply/main.cpp
@@ -24,6 +24,7 @@
 #include <mrpt/maps/CPointsMap.h>
 #include <mrpt/poses/CPose3D.h>
 #include <mrpt/system/filesystem.h>
+#include <mrpt/system/os.h>
 #include <mrpt/system/string_utils.h>
 #include <mrpt/version.h>
 
@@ -58,6 +59,10 @@ TCLAP::ValueArg<std::string> argFrame(
     "Coordinate frame for exported points: 'map' (default) uses the map local frame; "
     "'enu' transforms points to the East-North-Up frame (requires georeferencing data in the map).",
     false, "map", "map|enu", cmd);
+
+TCLAP::ValueArg<std::string> arg_plugins(
+    "l", "load-plugins", "One or more (comma separated) *.so files to load as plugins", false,
+    "foobar.so", "foobar.so", cmd);
 
 // ----------------------------------------------------------------
 // PLY Export Logic using CPointsMap field-generic API
@@ -401,6 +406,19 @@ int main(int argc, char** argv)
         {
             return 0;
         }
+
+        // Load plugins:
+        if (arg_plugins.isSet())
+        {
+            std::string errMsg;
+            const auto  plugins = arg_plugins.getValue();
+            std::cout << "Loading plugin(s): " << plugins << std::endl;
+            if (!mrpt::system::loadPluginModules(plugins, errMsg))
+            {
+                throw std::runtime_error(errMsg);
+            }
+        }
+
         mp2p_icp::metric_map_t mm;
         mm.load_from_file(arg_input.getValue());
 

--- a/apps/mm2ply/main.cpp
+++ b/apps/mm2ply/main.cpp
@@ -30,6 +30,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <stdexcept>
 
 // CLI flags
 TCLAP::CmdLine cmd("mm2ply");

--- a/apps/mm2txt/main.cpp
+++ b/apps/mm2txt/main.cpp
@@ -30,6 +30,8 @@
 #include <mrpt/system/string_utils.h>
 #include <mrpt/version.h>
 
+#include <stdexcept>
+
 #if MRPT_VERSION < 0x030000  // <3.0.0
 #include <mrpt/maps/CPointsMapXYZI.h>
 #include <mrpt/maps/CPointsMapXYZIRT.h>

--- a/apps/mm2txt/main.cpp
+++ b/apps/mm2txt/main.cpp
@@ -68,6 +68,10 @@ TCLAP::ValueArg<std::string> argFrame(
     "'enu' transforms points to the East-North-Up frame (requires georeferencing data in the map).",
     false, "map", "map|enu", cmd);
 
+TCLAP::ValueArg<std::string> arg_plugins(
+    "", "load-plugins", "One or more (comma separated) *.so files to load as plugins", false,
+    "foobar.so", "foobar.so", cmd);
+
 bool saveToTxt(
     const mrpt::maps::CGenericPointsMap& pts, const std::string& fileName, bool printHeader,
     const std::vector<std::string>&            selectedFields = {},
@@ -217,6 +221,18 @@ bool saveToTxt(
 void run_mm2txt()
 {
     using namespace std::string_literals;
+
+    // Load plugins:
+    if (arg_plugins.isSet())
+    {
+        std::string errMsg;
+        const auto  plugins = arg_plugins.getValue();
+        std::cout << "Loading plugin(s): " << plugins << std::endl;
+        if (!mrpt::system::loadPluginModules(plugins, errMsg))
+        {
+            throw std::runtime_error(errMsg);
+        }
+    }
 
     const auto& filInput = argMapFile.getValue();
 

--- a/apps/rawlog-filter/main.cpp
+++ b/apps/rawlog-filter/main.cpp
@@ -30,6 +30,7 @@
 #include <mrpt/obs/CSensoryFrame.h>
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/system/filesystem.h>
+#include <mrpt/system/os.h>
 #include <mrpt/system/progress.h>
 #include <mrpt/version.h>
 
@@ -81,11 +82,28 @@ struct Cli
     TCLAP::ValueArg<std::string> arg_verbosity_level{
         "v",    "verbosity", "Verbosity level: ERROR|WARN|INFO|DEBUG (Default: INFO)", false, "",
         "INFO", cmd};
+
+    TCLAP::ValueArg<std::string> arg_plugins{
+        "l",   "load-plugins", "One or more (comma separated) *.so files to load as plugins",
+        false, "foobar.so",    "foobar.so",
+        cmd};
 };
 
 void run_mm_filter(Cli& cli)
 {
     using namespace std::string_literals;
+
+    // Load plugins:
+    if (cli.arg_plugins.isSet())
+    {
+        std::string errMsg;
+        const auto  plugins = cli.arg_plugins.getValue();
+        std::cout << "Loading plugin(s): " << plugins << std::endl;
+        if (!mrpt::system::loadPluginModules(plugins, errMsg))
+        {
+            throw std::runtime_error(errMsg);
+        }
+    }
 
     ASSERT_FILE_EXISTS_(cli.argInput.getValue());
     ASSERT_FILE_EXISTS_(cli.argPipeline.getValue());

--- a/apps/rawlog-filter/main.cpp
+++ b/apps/rawlog-filter/main.cpp
@@ -34,6 +34,8 @@
 #include <mrpt/system/progress.h>
 #include <mrpt/version.h>
 
+#include <stdexcept>
+
 #if MRPT_VERSION >= 0x020f07
 #include <mrpt/io/CCompressedOutputStream.h>
 #else

--- a/docs/source/app_mm-info.rst
+++ b/docs/source/app_mm-info.rst
@@ -13,13 +13,18 @@ The tool provides information about the layers, point counts, and other metadata
 
     USAGE: 
 
-    mm-info  <myMap.mm> [--] [--version] [-h]
+    mm-info  <myMap.mm> [-l <foobar.so>] [--] [--version] [-h]
 
 
-    Where: 
+    Where:
 
     <myMap.mm>
         (required)  Load this metric map file (*.mm)
+
+    -l <foobar.so>,  --load-plugins <foobar.so>
+        One or more (comma separated) *.so files to load as plugins (e.g.
+        ``libmola_metric_maps.so``). Use this when the map contains custom
+        map types that are not part of the default mp2p_icp build.
 
     --,  --ignore_rest
         Ignores the rest of the labeled arguments following this flag.

--- a/docs/source/app_mm2grid.rst
+++ b/docs/source/app_mm2grid.rst
@@ -36,6 +36,7 @@ Usage
    mm2grid <input.mm> [-l <layer_name>] [-o <output_base>]
            [--occupied-thresh <value>] [--free-thresh <value>]
            [--mode trinary|scale|raw] [--negate]
+           [--load-plugins <plugin.so>]
 
 Arguments
 ^^^^^^^^^
@@ -61,6 +62,7 @@ Arguments
 - ``--negate`` (optional): If set, the color interpretation is inverted:
   black pixels are free and white pixels are occupied. Sets ``negate: 1`` in
   the YAML. Default: not set (``negate: 0``).
+- ``--load-plugins <file.so>`` (optional): One or more (comma separated) ``.so`` plugin files to load before reading the map. Use this to load custom map types (e.g. ``--load-plugins libmola_metric_maps.so``).
 
 Examples
 ^^^^^^^^

--- a/docs/source/app_mm2las.rst
+++ b/docs/source/app_mm2las.rst
@@ -26,7 +26,7 @@ Usage
 
 .. code-block:: bash
 
-   mm2las -i <input.mm> [-o <output_prefix>] [--export-fields <field1,field2,...>] [--frame map|enu|geodetic]
+   mm2las -i <input.mm> [-o <output_prefix>] [--export-fields <field1,field2,...>] [--frame map|enu|geodetic] [-l <plugin.so>]
 
 Arguments
 ^^^^^^^^^
@@ -36,6 +36,7 @@ Arguments
 - ``--export-fields <field1,field2,...>`` (optional): Comma-separated list of fields to export. If omitted, all available fields are exported, with non-standard fields becoming Extra Dimensions.
 - ``--system-id <string>``: Sets the System Identifier in the LAS header (default: "mm2las").
 - ``--generating-software <string>``: Sets the Generating Software in the LAS header (default: "MOLA mm2las").
+- ``-l, --load-plugins <file.so>`` (optional): One or more (comma separated) ``.so`` plugin files to load before reading the map. Use this to load custom map types (e.g. ``--load-plugins libmola_metric_maps.so``).
 - ``--frame <map|enu|geodetic>`` (optional): Coordinate frame for exported points. ``map`` (default) exports coordinates in the map local frame. ``enu`` transforms all point coordinates to the East-North-Up frame using the georeferencing information stored in the map. ``geodetic`` exports points as WGS-84 geographic coordinates (EPSG:4979) with longitude as X, latitude as Y, and ellipsoidal height as Z, embedding the CRS as a WKT VLR in the LAS file for full georeferencing support in GIS software. Requires that the input map contains georeferencing data with valid geodetic coordinates. If per-point ``latitude``/``longitude``/``altitude`` double fields already exist in the map (e.g., from ``mola-mm-add-geodetic``), they are used directly; otherwise, the conversion from map coordinates is computed on the fly.
 
 

--- a/docs/source/app_mm2ply.rst
+++ b/docs/source/app_mm2ply.rst
@@ -24,7 +24,7 @@ Usage
 
 .. code-block:: bash
 
-   mm2ply -i <input.mm> [-o <output_prefix>] [-b] [--export-fields <field1,field2,...>] [--ignore-missing-fields] [--frame map|enu]
+   mm2ply -i <input.mm> [-o <output_prefix>] [-b] [--export-fields <field1,field2,...>] [--ignore-missing-fields] [--frame map|enu] [-l <plugin.so>]
 
 Arguments
 ^^^^^^^^^
@@ -35,6 +35,7 @@ Arguments
 - ``--export-fields <field1,field2,...>`` (optional): Comma-separated list of fields to export in the specified order. If not provided, all available fields will be exported. Spaces around commas are allowed
 - ``--ignore-missing-fields`` (optional): If defined, the lack of any of the ``--export-fields`` in the map will be considered a warning instead of an error.
 - ``--frame <map|enu>`` (optional): Coordinate frame for exported points. ``map`` (default) exports coordinates in the map local frame. ``enu`` transforms all point coordinates to the East-North-Up frame using the georeferencing information stored in the map. Requires that the input map contains georeferencing data; otherwise, an error is raised.
+- ``-l, --load-plugins <file.so>`` (optional): One or more (comma separated) ``.so`` plugin files to load before reading the map. Use this to load custom map types (e.g. ``--load-plugins libmola_metric_maps.so``).
 
 Examples
 ^^^^^^^^

--- a/docs/source/app_mm2txt.rst
+++ b/docs/source/app_mm2txt.rst
@@ -25,7 +25,10 @@ Usage
 
 .. code-block:: bash
 
-   mm2txt <input.mm> [-l <layer_name>] [--export-fields <field1,field2,...>] [--ignore-missing-fields] [--frame map|enu]
+   mm2txt <input.mm> [-l <layer_name>] [--export-fields <field1,field2,...>] [--ignore-missing-fields] [--frame map|enu] [--load-plugins <plugin.so>]
+
+.. note::
+   In ``mm2txt``, ``-l`` is reserved for ``--layer``. Use ``--load-plugins`` (no short flag) for plugin loading.
 
 Arguments
 ^^^^^^^^^
@@ -34,6 +37,7 @@ Arguments
 - ``-l, --layer <name>`` (optional): Layer to export. If not provided, all layers will be exported. This argument can appear multiple times to export specific layers
 - ``--export-fields <field1,field2,...>`` (optional): Comma-separated list of fields to export in the specified order. If not provided, all available fields will be exported. Spaces around commas are allowed
 - ``--ignore-missing-fields`` (optional): If defined, the lack of any of the ``--export-fields`` in the map will be considered a warning instead of an error.
+- ``--load-plugins <file.so>`` (optional): One or more (comma separated) ``.so`` plugin files to load before reading the map. Use this to load custom map types (e.g. ``--load-plugins libmola_metric_maps.so``).
 - ``--frame <map|enu>`` (optional): Coordinate frame for exported points. ``map`` (default) exports coordinates in the map local frame. ``enu`` transforms all point coordinates to the East-North-Up frame using the georeferencing information stored in the map. Requires that the input map contains georeferencing data; otherwise, an error is raised.
 
 Examples

--- a/mp2p_icp_filters/src/FilterAbsoluteTimestamp.cpp
+++ b/mp2p_icp_filters/src/FilterAbsoluteTimestamp.cpp
@@ -25,6 +25,8 @@
 #include <mrpt/system/datetime.h>
 #include <mrpt/version.h>
 
+#include <stdexcept>
+
 IMPLEMENTS_MRPT_OBJECT(FilterAbsoluteTimestamp, mp2p_icp_filters::FilterBase, mp2p_icp_filters)
 
 using namespace mp2p_icp_filters;

--- a/mp2p_icp_filters/src/FilterDeskew.cpp
+++ b/mp2p_icp_filters/src/FilterDeskew.cpp
@@ -22,6 +22,8 @@
 #include <mola_imu_preintegration/ImuIntegrationParams.h>
 #include <mola_imu_preintegration/ImuTransformer.h>
 #include <mola_imu_preintegration/trajectory_from_buffer.h>
+
+#include <stdexcept>
 #endif
 
 #include <mp2p_icp/pointcloud_field_utils.h>

--- a/mp2p_icp_filters/src/FilterSOR.cpp
+++ b/mp2p_icp_filters/src/FilterSOR.cpp
@@ -27,6 +27,8 @@
 #include <mrpt/math/ops_containers.h>  // meanAndCov
 #include <mrpt/version.h>
 
+#include <stdexcept>
+
 #if defined(MP2P_HAS_TBB)
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>

--- a/mp2p_icp_filters/src/PointCloudToVoxelGridSingle.cpp
+++ b/mp2p_icp_filters/src/PointCloudToVoxelGridSingle.cpp
@@ -69,12 +69,13 @@ void PointCloudToVoxelGridSingle::processPointCloud(
 
             const indices_t vxl_idx = {coord2idx(x), coord2idx(y), coord2idx(z)};
 
-            auto itVoxel = pts_voxels.find(vxl_idx);
+            // try_emplace: single hash lookup for both insert and existing-key cases
+            auto [it, inserted] =
+                pts_voxels.try_emplace(vxl_idx, mrpt::math::TPoint3Df(x, y, z), i, &p, 1);
 
-            if (itVoxel != pts_voxels.end())
+            if (!inserted)
             {
-                // (const cast: required for tsl::robin_map)
-                auto& vx = const_cast<voxel_t&>(itVoxel->second);
+                auto& vx = const_cast<voxel_t&>(it->second);
 
                 if (vx.pointCount == 0)
                 {
@@ -84,11 +85,6 @@ void PointCloudToVoxelGridSingle::processPointCloud(
                 {
                     vx.pointCount++;
                 }
-            }
-            else
-            {
-                // insert new
-                pts_voxels[vxl_idx] = {mrpt::math::TPoint3Df(x, y, z), i, &p, 1};
             }
         }
     };

--- a/tests/test-mp2p_quality_reproject_ranges.cpp
+++ b/tests/test-mp2p_quality_reproject_ranges.cpp
@@ -26,6 +26,7 @@
 #include <mrpt/maps/CSimplePointsMap.h>
 
 #include <cstdlib>
+#include <stdexcept>
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {

--- a/tests/test-mp2p_quality_voxels.cpp
+++ b/tests/test-mp2p_quality_voxels.cpp
@@ -25,6 +25,8 @@
 #include <mrpt/core/get_env.h>
 #include <mrpt/system/filesystem.h>  // pathJoin()
 
+#include <stdexcept>
+
 const bool   VERBOSE = mrpt::get_env<bool>("VERBOSE", false);
 const double SCALE   = mrpt::get_env<double>("SCALE", 3.0);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --load-plugins/-l to multiple CLI tools (mm-info, mm2grid, mm2las, mm2ply, mm2txt, rawlog-filter) to load comma-separated plugin .so files at startup; tools now report the plugin list before processing.

* **Bug Fixes**
  * Added missing exception headers to several binaries and tests to ensure proper runtime error reporting when plugin loading or other errors occur.

* **Documentation**
  * Updated CLI docs for all affected tools to describe the new plugin-loading option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->