### PR TITLE
FIX: robust against temporary lack of IMU in Deskew

### DIFF
--- a/mp2p_icp_filters/src/FilterDeskew.cpp
+++ b/mp2p_icp_filters/src/FilterDeskew.cpp
@@ -192,12 +192,10 @@ void correctPointsLoop(const CorrectPointsArguments& args)
     ASSERT_(Ts != nullptr);
     ASSERT_EQUAL_(Ts->size(), xs.size());
 
-    if constexpr (method != MotionCompensationMethod::Linear)
-    {
-        ASSERTMSG_(
-            !reconstructed_trajectory.empty(),
-            "FilterDeskew: It seems the local velocity buffer is empty, cannot do deskew!");
-    }
+    // Note: emptiness of reconstructed_trajectory is checked by the caller
+    // (FilterDeskew::filter), which gracefully bypasses deskew with a
+    // throttled warning instead of throwing, to keep robustness against
+    // transient sensor data gaps.
 
     // Is it worth to first build a cache with unique point stamps to pose corrections?
     // From initial benchmarking, it seems it doesn't...
@@ -590,6 +588,38 @@ void FilterDeskew::filter(mp2p_icp::metric_map_t& inOut) const
             break;
         }
     };
+
+    // Graceful degradation: if an IMU-based method was selected but the local
+    // velocity buffer yielded no trajectory (e.g., a transient sensor data
+    // gap), skip deskew for this scan rather than throwing. Points are copied
+    // through uncorrected, with a throttled WARN trace so users can see it
+    // happening without flooding the log.
+    const bool needsTrajectory = (method == MotionCompensationMethod::IMU) ||
+                                 (method == MotionCompensationMethod::IMUh) ||
+                                 (method == MotionCompensationMethod::IMUt);
+
+    if (needsTrajectory && reconstructed_trajectory.empty())
+    {
+        thread_local double last_warning_t = 0;
+        const auto          tNow           = mrpt::Clock::nowDouble();
+        if (tNow - last_warning_t > 5.0)
+        {
+            last_warning_t = tNow;
+            MRPT_LOG_WARN_STREAM(
+                "Local velocity buffer is empty (likely a transient sensor "
+                "data gap); skipping deskew for this scan. Points will be "
+                "passed through uncorrected.");
+        }
+
+        if (!in_place)
+        {
+            // Resize back: we will let insertAnotherMap handle the append
+            // (which manages size and per-point fields consistently).
+            outPc->resize(n0);
+            outPc->insertAnotherMap(inPc, mrpt::poses::CPose3D::Identity());
+        }
+        return;
+    }
 
     // Prepare call arguments:
     const CorrectPointsArguments args = {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ endfunction()
 
 if (mola_imu_preintegration_FOUND)
 mp2p_add_test(mp2p_deskew EXTRA_LIBS mp2p_icp_filters)
+mp2p_add_test(mp2p_deskew_empty_buffer EXTRA_LIBS mp2p_icp_filters)
 endif()
 
 #mp2p_add_test(mp2p_matcher_pt2pl)  # TODO: This now requires a NP metric map to run the test

--- a/tests/test-mp2p_deskew_empty_buffer.cpp
+++ b/tests/test-mp2p_deskew_empty_buffer.cpp
@@ -1,0 +1,158 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/**
+ * @file   test-mp2p_deskew_empty_buffer.cpp
+ * @brief  Regression test: FilterDeskew must not throw when the local
+ *         velocity buffer yields an empty trajectory (e.g., transient
+ *         sensor data gap). It should bypass deskew and pass points
+ *         through unchanged.
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <mp2p_icp/metricmap.h>
+#include <mp2p_icp_filters/FilterDeskew.h>
+#include <mrpt/maps/CGenericPointsMap.h>
+
+#include <cstdio>
+#include <iostream>
+
+namespace
+{
+mrpt::maps::CGenericPointsMap::Ptr make_skewed_scan(std::size_t n_points, double scan_period)
+{
+    auto pts = mrpt::maps::CGenericPointsMap::Create();
+    pts->registerField_float(mp2p_icp_filters::POINT_FIELD_TIMESTAMP);
+    pts->registerField_float(mp2p_icp_filters::POINT_FIELD_INTENSITY);
+
+    for (std::size_t i = 0; i < n_points; ++i)
+    {
+        const float x        = 5.0f + 0.1f * static_cast<float>(i);
+        const float y        = -3.0f + 0.05f * static_cast<float>(i);
+        const float z        = 0.5f;
+        const float rel_time = static_cast<float>(
+            scan_period * static_cast<double>(i) /
+            static_cast<double>(std::max<std::size_t>(1U, n_points - 1)));
+
+        pts->insertPointFast(x, y, z);
+        pts->insertPointField_float(mp2p_icp_filters::POINT_FIELD_TIMESTAMP, rel_time);
+        pts->insertPointField_float(mp2p_icp_filters::POINT_FIELD_INTENSITY, 1.0f);
+    }
+    return pts;
+}
+
+[[nodiscard]] bool run_one(mp2p_icp_filters::MotionCompensationMethod method)
+{
+    using namespace mp2p_icp_filters;
+
+    const std::size_t n_points    = 32;
+    const double      scan_period = 0.1;
+    const auto        skewed      = make_skewed_scan(n_points, scan_period);
+
+    // Snapshot expected XYZ (must remain unchanged after deskew bypass)
+    std::vector<mrpt::math::TPoint3Df> expected;
+    expected.reserve(n_points);
+    for (std::size_t i = 0; i < skewed->size(); ++i)
+    {
+        mrpt::math::TPoint3Df p;
+        skewed->getPoint(i, p.x, p.y, p.z);
+        expected.push_back(p);
+    }
+
+    // Attach a ParameterSource with an INTENTIONALLY EMPTY localVelocityBuffer.
+    // This mimics the situation where a LiDAR scan arrives after a sensor data
+    // gap: no IMU samples are available around the scan's reference time.
+    mp2p_icp::ParameterSource ps;
+
+    FilterDeskew deskew;
+    deskew.silently_ignore_no_timestamps = false;
+    deskew.input_pointcloud_layer        = "raw";
+    deskew.output_pointcloud_layer       = "deskewed";
+    deskew.method                        = method;
+    deskew.output_layer_class            = "mrpt::maps::CGenericPointsMap";
+    deskew.attachToParameterSource(ps);
+
+    mp2p_icp::metric_map_t m;
+    m.layers["raw"] = skewed;
+
+    try
+    {
+        deskew.filter(m);
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "[FAIL] Filter threw with empty velocity buffer (method="
+                  << mrpt::typemeta::enum2str(method) << "): " << e.what() << "\n";
+        return false;
+    }
+
+    const auto out = m.point_layer("deskewed");
+    if (!out)
+    {
+        std::cerr << "[FAIL] No 'deskewed' layer produced.\n";
+        return false;
+    }
+    if (out->size() != n_points)
+    {
+        std::cerr << "[FAIL] Output size " << out->size() << " != input size " << n_points << "\n";
+        return false;
+    }
+
+    // With an empty trajectory, the filter must pass points through unchanged.
+    for (std::size_t i = 0; i < out->size(); ++i)
+    {
+        mrpt::math::TPoint3Df p;
+        out->getPoint(i, p.x, p.y, p.z);
+        const auto err = (p - expected[i]).norm();
+        if (err > 1e-5f)
+        {
+            std::cerr << "[FAIL] Point " << i << " modified (err=" << err
+                      << ") despite empty velocity buffer.\n";
+            return false;
+        }
+    }
+
+    std::cout << "[OK ] empty-buffer bypass for method=" << mrpt::typemeta::enum2str(method)
+              << "\n";
+    return true;
+}
+
+}  // namespace
+
+int main()
+{
+    int failures = 0;
+
+    // Linear with no twist defined would be a misconfiguration; not tested here.
+    // The IMU* methods are the ones that previously threw the hard assert.
+#if defined(MP2P_ICP_HAS_MOLA_IMU_PREINTEGRATION)
+    if (!run_one(mp2p_icp_filters::MotionCompensationMethod::IMU))
+    {
+        ++failures;
+    }
+    if (!run_one(mp2p_icp_filters::MotionCompensationMethod::IMUh))
+    {
+        ++failures;
+    }
+    if (!run_one(mp2p_icp_filters::MotionCompensationMethod::IMUt))
+    {
+        ++failures;
+    }
+#else
+    std::cout << "Skipping test: built without mola_imu_preintegration.\n";
+#endif
+
+    std::printf("Number of test failures: %i\n", failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deskewing robustness for IMU-based methods: when trajectory data is missing, the system now emits a throttled warning and safely skips correction, passing input points through unmodified instead of failing.

* **Tests**
  * Added a regression test that verifies behavior when trajectory/velocity buffer is empty and integrated the test into the build condition for IMU-enabled builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MOLAorg/mp2p_icp/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->