### PR TITLE
feat: FilterDecimateRangeAdaptive (EllipseLIO range-adaptive scan filter)

### DIFF
--- a/docs/source/mp2p_icp_filters.rst
+++ b/docs/source/mp2p_icp_filters.rst
@@ -5,10 +5,41 @@
 Point cloud **Filters** in ``mp2p_icp`` are used to modify or extract part of the information from an input point cloud.
 This can involve tasks like removing noise, downsampling, segmenting points into different layers based on properties
 (like intensity or curvature), or adjusting per-point attributes (like timestamps or intensity).
-All filters inherit from :cpp:class:`mp2p_icp_filters::FilterBase` and can be configured either programmatically 
+All filters inherit from :cpp:class:`mp2p_icp_filters::FilterBase` and can be configured either programmatically
 or via a YAML file using the **filter pipeline** API, e.g.
-:cpp:class:`mp2p_icp_filters::filter_pipeline_from_yaml()` 
+:cpp:class:`mp2p_icp_filters::filter_pipeline_from_yaml()`
 or :cpp:class:`mp2p_icp_filters::filter_pipeline_from_yaml_file()`.
+
+**Common parameters** (available on every filter):
+
+* **name** (:cpp:type:`std::string`, optional): A custom name for the filter, used in log output and profiler entries.
+
+* **enabled** (:cpp:type:`bool`, default: ``true``): When ``false``, the filter is silently skipped in
+  :cpp:func:`mp2p_icp_filters::apply_filter_pipeline`. Accepts ``true``/``false`` YAML booleans and
+  string values ``"1"``/``"0"`` (so that ``mola_yaml`` ``${ENV_VAR|1}`` expressions work transparently
+  for environment-based toggling):
+
+  .. code-block:: yaml
+
+      # Export MOLA_RANGE_ADAPTIVE_FILTER=1 in the shell to activate the new filter and
+      # deactivate the old one. Default (unset): old uniform filter is active.
+      filters:
+        - class_name: mp2p_icp_filters::FilterDecimateRangeAdaptive
+          params:
+            enabled: '${MOLA_RANGE_ADAPTIVE_FILTER|0}'  # off by default; set to "1" to enable
+            input_pointcloud_layer: 'raw'
+            output_pointcloud_layer: 'decimated'
+            bin_width: 1.0
+            min_voxel_size: 0.05
+            max_voxel_size: 2.0
+
+        - class_name: mp2p_icp_filters::FilterDecimateVoxels
+          params:
+            enabled: '$(test "${MOLA_RANGE_ADAPTIVE_FILTER:-0}" = "1" && echo 0 || echo 1)'
+            input_pointcloud_layer: 'raw'
+            output_pointcloud_layer: 'decimated'
+            voxel_filter_resolution: 0.2
+            decimate_method: 'DecimateMethod::VoxelAverage'
 
 .. note::
 

--- a/mp2p_icp_filters/include/mp2p_icp_filters/FilterBase.h
+++ b/mp2p_icp_filters/include/mp2p_icp_filters/FilterBase.h
@@ -88,6 +88,12 @@ class FilterBase : public mrpt::rtti::CObject,  // RTTI support
      *  This is loaded from the `name` key in the YAML configuration block.
      */
     std::string name;
+
+    /** If false, the filter is skipped in apply_filter_pipeline().
+     *  Loaded from the `enabled` key in the YAML params block (default: true).
+     *  Compatible with mola_yaml `${ENV_VAR|1}` expressions for env-based toggling.
+     */
+    bool enabled = true;
 };
 
 /** A sequence of filters */

--- a/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateRangeAdaptive.h
+++ b/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateRangeAdaptive.h
@@ -30,8 +30,9 @@ namespace mp2p_icp_filters
 {
 /** Range-adaptive voxel decimation following EllipseLIO (arXiv:2605.21150, Eqs. 1-3).
  *
- * The input cloud is split into 1-m-wide radial bins. Within bin `i` (points
- * in [i, i+1) m), the voxel size is set to the scan-line separation at that
+ * The input cloud is split into configurable-width radial bins (see
+ * `bin_width`). Within bin `i` (points in [i*bin_width, (i+1)*bin_width) m),
+ * the voxel size is set to the scan-line separation at that
  * range:
  *
  *   v_i = (i+1) * vertical_fov_rad / (num_scan_lines - 1)

--- a/mp2p_icp_filters/src/FilterBase.cpp
+++ b/mp2p_icp_filters/src/FilterBase.cpp
@@ -41,6 +41,30 @@ void FilterBase::initialize(const mrpt::containers::yaml& cfg_block)
     {
         mrpt::system::COutputLogger::setLoggerName(name);
     }
+
+    // Load the optional enabled flag (default: true).
+    // Accepts bool literals (true/false) and string "0"/"1" so that
+    // mola_yaml ${ENV_VAR|1} expansions work transparently.
+    if (cfg_block.has("enabled"))
+    {
+        const auto& ev = cfg_block["enabled"];
+        if (ev.isScalar())
+        {
+            const std::string vs = ev.as<std::string>();
+            if (vs == "0" || vs == "false" || vs == "False" || vs == "FALSE")
+            {
+                enabled = false;
+            }
+            else
+            {
+                enabled = true;
+            }
+        }
+        else
+        {
+            enabled = ev.as<bool>();
+        }
+    }
 }
 
 void mp2p_icp_filters::apply_filter_pipeline(
@@ -50,6 +74,11 @@ void mp2p_icp_filters::apply_filter_pipeline(
     for (const auto& f : filters)
     {
         ASSERT_(f.get() != nullptr);
+
+        if (!f->enabled)
+        {
+            continue;
+        }
 
         // Optional profiler:
         std::optional<mrpt::system::CTimeLoggerEntry> tle;

--- a/mp2p_icp_filters/src/FilterDecimateRangeAdaptive.cpp
+++ b/mp2p_icp_filters/src/FilterDecimateRangeAdaptive.cpp
@@ -31,8 +31,9 @@
 #include <vector>
 
 #if defined(MP2P_HAS_TBB)
-#include <tbb/parallel_for.h>
 #include <tbb/blocked_range.h>
+#include <tbb/parallel_for.h>
+
 #include <mutex>
 #endif
 
@@ -95,6 +96,11 @@ void FilterDecimateRangeAdaptive::initialize_filter(const mrpt::containers::yaml
     MRPT_LOG_DEBUG_STREAM("Loading these params:\n" << c);
     params.load_from_yaml(c);
 
+    ASSERTMSG_(params.bin_width > 0, "FilterDecimateRangeAdaptive: bin_width must be > 0.");
+    ASSERTMSG_(
+        params.min_voxel_size <= params.max_voxel_size,
+        "FilterDecimateRangeAdaptive: min_voxel_size must be <= max_voxel_size.");
+
     MRPT_END
 }
 
@@ -111,17 +117,17 @@ void FilterDecimateRangeAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
         mrpt::format(
             "Input point cloud layer '%s' was not found.", params.input_pointcloud_layer.c_str()));
 
-    const auto& pc = *pcPtr;
-    const auto& xs = pc.getPointsBufferRef_x();
-    const auto& ys = pc.getPointsBufferRef_y();
-    const auto& zs = pc.getPointsBufferRef_z();
+    const auto&  pc = *pcPtr;
+    const auto&  xs = pc.getPointsBufferRef_x();
+    const auto&  ys = pc.getPointsBufferRef_y();
+    const auto&  zs = pc.getPointsBufferRef_z();
     const size_t N  = xs.size();
 
     // --- Auto-derive sensor geometry from ring channel ---
     const auto* ptrRing = pc.getPointsBufferRef_uint16_field("ring");
 
-    double       fov_rad    = params.vertical_fov_rad;
-    unsigned int num_lines  = params.num_scan_lines;
+    double       fov_rad   = params.vertical_fov_rad;
+    unsigned int num_lines = params.num_scan_lines;
 
     if (ptrRing && !ptrRing->empty() && ptrRing->size() == N)
     {
@@ -149,8 +155,14 @@ void FilterDecimateRangeAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
                 const double rxy = std::sqrt(
                     static_cast<double>(xs[i]) * xs[i] + static_cast<double>(ys[i]) * ys[i]);
                 const double el = std::atan2(static_cast<double>(zs[i]), rxy);
-                if (el < el_min) { el_min = el; }
-                if (el > el_max) { el_max = el; }
+                if (el < el_min)
+                {
+                    el_min = el;
+                }
+                if (el > el_max)
+                {
+                    el_max = el;
+                }
             }
             fov_rad = el_max - el_min;
         }
@@ -196,17 +208,22 @@ void FilterDecimateRangeAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
     mp2p_icp::warn_on_field_padding_mismatch(pc, *outPc, *this);
 
     // --- Radial binning ---
-    const double   bin_w     = params.bin_width;
-    const double   theta     = fov_rad;
-    const double   beta_m1   = static_cast<double>(num_lines - 1u);
+    const double bin_w   = params.bin_width;
+    const double theta   = fov_rad;
+    const double beta_m1 = static_cast<double>(num_lines - 1u);
 
     // For each bin index, build a voxel hash of first-point indices.
     // Collect bin indices needed:
     const size_t num_bins =
         (max_r <= 0) ? 1u : (static_cast<size_t>(std::ceil(max_r / bin_w)) + 1u);
 
-    // Per-bin voxel maps: bin_idx -> (VoxelKey -> first_point_index)
-    std::vector<std::unordered_map<VoxelKey, size_t, VoxelKeyHash>> bin_voxels(num_bins);
+    // Per-bin voxel maps: bin_idx -> (VoxelKey -> {count, first_point_index})
+    struct VoxelEntry
+    {
+        size_t count     = 0;
+        size_t first_idx = 0;
+    };
+    std::vector<std::unordered_map<VoxelKey, VoxelEntry, VoxelKeyHash>> bin_voxels(num_bins);
 
     for (size_t i = 0; i < N; i++)
     {
@@ -227,16 +244,18 @@ void FilterDecimateRangeAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
         }
 
         // Eq. 1: v_i = (bin_i + 1) * theta / (beta - 1)
-        const double v_raw =
-            static_cast<double>(bin_i + 1u) * theta / beta_m1;
-        const double v = std::clamp(v_raw, params.min_voxel_size, params.max_voxel_size);
+        const double v_raw = static_cast<double>(bin_i + 1u) * theta / beta_m1;
+        const double v     = std::clamp(v_raw, params.min_voxel_size, params.max_voxel_size);
 
         const int32_t cx = static_cast<int32_t>(std::floor(x / v));
         const int32_t cy = static_cast<int32_t>(std::floor(y / v));
         const int32_t cz = static_cast<int32_t>(std::floor(z / v));
 
-        bin_voxels[bin_i].emplace(VoxelKey{cx, cy, cz}, i);
-        // emplace does nothing if key already exists — keeps first point
+        auto [it, inserted] = bin_voxels[bin_i].emplace(VoxelKey{cx, cy, cz}, VoxelEntry{1, i});
+        if (!inserted)
+        {
+            it->second.count++;
+        }
     }
 
     // --- Collect survivors into output (Eq. 3: union of bin outputs) ---
@@ -245,7 +264,11 @@ void FilterDecimateRangeAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
     {
         for (const auto& kv : vmap)
         {
-            outPc->insertPointFrom(kv.second, ctx);
+            if (kv.second.count < params.min_input_points_per_voxel)
+            {
+                continue;
+            }
+            outPc->insertPointFrom(kv.second.first_idx, ctx);
             total_voxels++;
         }
     }
@@ -253,9 +276,8 @@ void FilterDecimateRangeAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
     outPc->mark_as_modified();
 
     MRPT_LOG_DEBUG_STREAM(
-        "Input=" << N << " output_voxels=" << total_voxels
-                 << " fov_rad=" << fov_rad << " num_lines=" << num_lines
-                 << " num_bins=" << num_bins);
+        "Input=" << N << " output_voxels=" << total_voxels << " fov_rad=" << fov_rad
+                 << " num_lines=" << num_lines << " num_bins=" << num_bins);
 
     MRPT_END
 }

--- a/tests/test-mp2p_FilterDecimateRangeAdaptive.cpp
+++ b/tests/test-mp2p_FilterDecimateRangeAdaptive.cpp
@@ -32,12 +32,11 @@
 using namespace mp2p_icp_filters;
 
 // Helper: count output points in shells between r_min and r_max
-static size_t count_in_shell(
-    const mrpt::maps::CPointsMap& pc, float r_min, float r_max)
+static size_t count_in_shell(const mrpt::maps::CPointsMap& pc, float r_min, float r_max)
 {
-    const auto& xs = pc.getPointsBufferRef_x();
-    const auto& ys = pc.getPointsBufferRef_y();
-    const auto& zs = pc.getPointsBufferRef_z();
+    const auto& xs    = pc.getPointsBufferRef_x();
+    const auto& ys    = pc.getPointsBufferRef_y();
+    const auto& zs    = pc.getPointsBufferRef_z();
     size_t      count = 0;
     for (size_t i = 0; i < xs.size(); i++)
     {
@@ -75,15 +74,12 @@ static void test_near_denser_than_far()
 
             // Near shell
             pc->insertPointFast(
-                r_near * cosEl * std::cos(az),
-                r_near * cosEl * std::sin(az),
+                r_near * cosEl * std::cos(az), r_near * cosEl * std::sin(az),
                 r_near * std::sin(el));
 
             // Far shell
             pc->insertPointFast(
-                r_far * cosEl * std::cos(az),
-                r_far * cosEl * std::sin(az),
-                r_far * std::sin(el));
+                r_far * cosEl * std::cos(az), r_far * cosEl * std::sin(az), r_far * std::sin(el));
         }
     }
 
@@ -96,7 +92,7 @@ static void test_near_denser_than_far()
     mrpt::containers::yaml      p;
     p["input_pointcloud_layer"]  = "raw";
     p["output_pointcloud_layer"] = "out";
-    p["vertical_fov_rad"]        = 1.0;   // ~57 deg
+    p["vertical_fov_rad"]        = 1.0;  // ~57 deg
     p["num_scan_lines"]          = 64;
     p["bin_width"]               = 1.0;
     p["min_voxel_size"]          = 0.01;
@@ -117,8 +113,8 @@ static void test_near_denser_than_far()
 
     std::cout << "Near shell (r=" << r_near << "m): " << near_count
               << " pts, density=" << near_density << "\n";
-    std::cout << "Far  shell (r=" << r_far << "m): " << far_count
-              << " pts, density=" << far_density << "\n";
+    std::cout << "Far  shell (r=" << r_far << "m): " << far_count << " pts, density=" << far_density
+              << "\n";
 
     // Near voxel size = bin_i * fov / (lines-1) with bin_i ~5 => v ~ 5*1.0/63 = 0.079 m
     // Far  voxel size => bin_i ~20 => v ~ 20*1.0/63 = 0.317 m
@@ -166,8 +162,8 @@ static void test_auto_derive_from_ring()
     mrpt::containers::yaml      p;
     p["input_pointcloud_layer"]  = "raw";
     p["output_pointcloud_layer"] = "out";
-    p["vertical_fov_rad"]        = 0;   // auto
-    p["num_scan_lines"]          = 0;   // auto
+    p["vertical_fov_rad"]        = 0;  // auto
+    p["num_scan_lines"]          = 0;  // auto
     p["bin_width"]               = 1.0;
     p["min_voxel_size"]          = 0.01;
     p["max_voxel_size"]          = 5.0;
@@ -195,8 +191,7 @@ static void test_output_never_exceeds_input()
     for (int i = 0; i < 5000; i++)
     {
         pc->insertPointFast(
-            static_cast<float>(i % 70) * 0.15f,
-            static_cast<float>((i / 70) % 70) * 0.15f,
+            static_cast<float>(i % 70) * 0.15f, static_cast<float>((i / 70) % 70) * 0.15f,
             static_cast<float>(i % 20) * 0.5f);
     }
 
@@ -224,6 +219,68 @@ static void test_output_never_exceeds_input()
     std::cout << "[Test Passed] Output never exceeds input\n";
 }
 
+// Test 4: min_input_points_per_voxel drops sparse voxels
+static void test_min_input_points_per_voxel()
+{
+    // Build a cloud with two regions:
+    //   - "dense" zone: many points packed into the same voxels at ~5 m range
+    //   - "sparse" zone: one point per voxel at ~15 m range
+    // With min_input_points_per_voxel=10, the sparse zone should be dropped.
+    auto pc = mrpt::maps::CSimplePointsMap::Create();
+
+    // Dense zone: 20x20 grid of points, 3 cm spacing => ~400 points, all map to
+    // the same voxel neighbourhood at 5 m (voxel ~ 5*1.0/63 ~ 0.08 m, so many
+    // of these will share a voxel).
+    for (int ia = 0; ia < 20; ia++)
+    {
+        for (int ib = 0; ib < 20; ib++)
+        {
+            pc->insertPointFast(
+                5.0f + ia * 0.01f,  // tightly clustered in x
+                ib * 0.01f,  // tight y spread
+                0.0f);
+        }
+    }
+
+    // Sparse zone: 1 isolated point per voxel at 15 m, spread far apart so each
+    // ends up in its own voxel.
+    for (int i = 0; i < 30; i++)
+    {
+        pc->insertPointFast(15.0f + i * 1.0f, 0.0f, 0.0f);
+    }
+
+    mp2p_icp::metric_map_t map;
+    map.layers["raw"] = pc;
+
+    FilterDecimateRangeAdaptive filter;
+    mrpt::containers::yaml      p;
+    p["input_pointcloud_layer"]     = "raw";
+    p["output_pointcloud_layer"]    = "out";
+    p["vertical_fov_rad"]           = 1.0;
+    p["num_scan_lines"]             = 64;
+    p["bin_width"]                  = 1.0;
+    p["min_voxel_size"]             = 0.05;
+    p["max_voxel_size"]             = 5.0;
+    p["min_input_points_per_voxel"] = 10u;
+
+    filter.initialize(p);
+    filter.filter(map);
+
+    auto outPtr = map.layer<mrpt::maps::CPointsMap>("out");
+    ASSERT_(outPtr);
+
+    const size_t dense_out  = count_in_shell(*outPtr, 4.0f, 6.0f);
+    const size_t sparse_out = count_in_shell(*outPtr, 14.0f, 50.0f);
+
+    std::cout << "min_input_points_per_voxel=10 test: dense_out=" << dense_out
+              << " sparse_out=" << sparse_out << "\n";
+
+    ASSERTMSG_(dense_out > 0, "Dense zone must produce output points");
+    ASSERTMSG_(sparse_out == 0, "Sparse zone (1 pt/voxel) must be fully suppressed");
+
+    std::cout << "[Test Passed] min_input_points_per_voxel filters sparse voxels\n";
+}
+
 int main()
 {
     try
@@ -231,6 +288,7 @@ int main()
         test_near_denser_than_far();
         test_auto_derive_from_ring();
         test_output_never_exceeds_input();
+        test_min_input_points_per_voxel();
 
         std::cout << "\nAll FilterDecimateRangeAdaptive tests passed!\n";
     }

--- a/tests/test-mp2p_Filters.cpp
+++ b/tests/test-mp2p_Filters.cpp
@@ -20,10 +20,13 @@
  */
 
 #include <mp2p_icp/metricmap.h>
+#include <mp2p_icp_filters/FilterBase.h>
 #include <mp2p_icp_filters/FilterBoundingBox.h>
 #include <mp2p_icp_filters/FilterByIntensity.h>
 #include <mp2p_icp_filters/FilterMLS.h>
+#include <mp2p_icp_filters/FilterRenameLayer.h>
 #include <mrpt/maps/CGenericPointsMap.h>
+#include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/math/TPlane.h>
 #include <mrpt/math/ops_containers.h>
 #include <mrpt/system/filesystem.h>
@@ -620,6 +623,108 @@ void test_FilterMLS_DistinctCloudProjection()
     std::cout << "Success ✅ (avg z: " << avg_z << ")" << std::endl;
 }
 
+// ---------------------------------------------------------------------------
+// Tests for FilterBase::enabled
+// ---------------------------------------------------------------------------
+
+// Helper: create a map with a "raw" layer of N points
+mp2p_icp::metric_map_t makeMapWithNPoints(size_t n)
+{
+    auto pc = mrpt::maps::CSimplePointsMap::Create();
+    for (size_t i = 0; i < n; i++)
+    {
+        pc->insertPointFast(static_cast<float>(i), 0.0f, 0.0f);
+    }
+    mp2p_icp::metric_map_t m;
+    m.layers["raw"] = pc;
+    return m;
+}
+
+void test_FilterBase_enabled_bool_true()
+{
+    // A filter with enabled: true (default) must run
+    auto map = makeMapWithNPoints(10);
+
+    FilterBase::Ptr        f = std::make_shared<FilterRenameLayer>();
+    mrpt::containers::yaml p;
+    p["input_layer"]  = "raw";
+    p["output_layer"] = "renamed";
+    p["enabled"]      = true;
+    f->initialize(p);
+
+    ASSERT_(f->enabled);
+
+    mp2p_icp_filters::FilterPipeline pipeline = {f};
+    mp2p_icp_filters::apply_filter_pipeline(pipeline, map);
+
+    ASSERTMSG_(map.layers.count("renamed") != 0, "Enabled filter must have produced output layer");
+    std::cout << "[test_FilterBase_enabled_bool_true] Passed\n";
+}
+
+void test_FilterBase_enabled_bool_false()
+{
+    // A filter with enabled: false must be skipped
+    auto map = makeMapWithNPoints(10);
+
+    FilterBase::Ptr        f = std::make_shared<FilterRenameLayer>();
+    mrpt::containers::yaml p;
+    p["input_layer"]  = "raw";
+    p["output_layer"] = "renamed";
+    p["enabled"]      = false;
+    f->initialize(p);
+
+    ASSERT_(!f->enabled);
+
+    mp2p_icp_filters::FilterPipeline pipeline = {f};
+    mp2p_icp_filters::apply_filter_pipeline(pipeline, map);
+
+    ASSERTMSG_(
+        map.layers.count("renamed") == 0, "Disabled filter must NOT have produced output layer");
+    std::cout << "[test_FilterBase_enabled_bool_false] Passed\n";
+}
+
+void test_FilterBase_enabled_string_zero()
+{
+    // enabled: "0" must disable the filter (for mola_yaml ${ENV_VAR|1} pattern)
+    auto map = makeMapWithNPoints(10);
+
+    FilterBase::Ptr        f = std::make_shared<FilterRenameLayer>();
+    mrpt::containers::yaml p;
+    p["input_layer"]  = "raw";
+    p["output_layer"] = "renamed";
+    p["enabled"]      = "0";  // string "0" from ${ENV_VAR|0}
+    f->initialize(p);
+
+    ASSERT_(!f->enabled);
+
+    mp2p_icp_filters::FilterPipeline pipeline = {f};
+    mp2p_icp_filters::apply_filter_pipeline(pipeline, map);
+
+    ASSERTMSG_(map.layers.count("renamed") == 0, "enabled='0' must disable the filter");
+    std::cout << "[test_FilterBase_enabled_string_zero] Passed\n";
+}
+
+void test_FilterBase_enabled_string_one()
+{
+    // enabled: "1" must keep the filter active
+    auto map = makeMapWithNPoints(10);
+
+    FilterBase::Ptr        f = std::make_shared<FilterRenameLayer>();
+    mrpt::containers::yaml p;
+    p["input_layer"]  = "raw";
+    p["output_layer"] = "renamed";
+    p["enabled"]      = "1";  // string "1" from ${ENV_VAR|1}
+    f->initialize(p);
+
+    ASSERT_(f->enabled);
+
+    mp2p_icp_filters::FilterPipeline pipeline = {f};
+    mp2p_icp_filters::apply_filter_pipeline(pipeline, map);
+
+    ASSERTMSG_(map.layers.count("renamed") != 0, "enabled='1' must keep the filter active");
+    std::cout << "[test_FilterBase_enabled_string_one] Passed\n";
+}
+
 }  // namespace
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
@@ -637,6 +742,10 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
             test_FilterMLS_PlanarCloud,
             test_FilterMLS_QuadraticSurface,
             test_FilterMLS_DistinctCloudProjection,
+            test_FilterBase_enabled_bool_true,
+            test_FilterBase_enabled_bool_false,
+            test_FilterBase_enabled_string_zero,
+            test_FilterBase_enabled_string_one,
         };
 
         int failures = 0;


### PR DESCRIPTION
## Summary

- Implements `FilterDecimateRangeAdaptive`, an EllipseLIO-style range-based adaptive voxel decimation filter (arXiv:2605.21150, Eqs. 1-3)
- Within each radial bin of width `bin_width` meters, the voxel size follows `v_i = clamp((i+1)*theta/(beta-1), v_min, v_max)` — smaller near the sensor, larger at distance
- `vertical_fov_rad` and `num_scan_lines` can be set to 0 for auto-derivation from the cloud's `ring` channel, making a single YAML config work across heterogeneous LiDAR sensors
- Registered in RTTI, documented in RST docs, and added to the pipeline editor block registry

## Changed files

- `mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateRangeAdaptive.h` — new header
- `mp2p_icp_filters/src/FilterDecimateRangeAdaptive.cpp` — implementation
- `tests/test-mp2p_FilterDecimateRangeAdaptive.cpp` — 3 unit tests
- `mp2p_icp_filters/src/register.cpp` — RTTI registration
- `mp2p_icp_filters/CMakeLists.txt` — build wiring
- `tests/CMakeLists.txt` — test registration
- `docs/source/mp2p_icp_filters.rst` — documentation section
- `agents.md` — updated filter category description

## Test plan

- [x] `colcon build --packages-select mp2p_icp` — clean build, no warnings
- [x] `test-mp2p_FilterDecimateRangeAdaptive` — all 3 tests pass:
  - Near shell has ~15x higher output density than far shell (470 vs 30 pts/m^2)
  - Auto-derive of ring count and FOV from ring channel works
  - Output point count never exceeds input count

## Example YAML

```yaml
filters:
  - class_name: mp2p_icp_filters::FilterDecimateRangeAdaptive
    params:
      input_pointcloud_layer: 'raw'
      output_pointcloud_layer: 'decimated'
      vertical_fov_rad: 0     # auto from ring channel
      num_scan_lines: 0       # auto from ring channel
      bin_width: 1.0
      min_voxel_size: 0.05
      max_voxel_size: 2.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filters can now be enabled or disabled via YAML configuration using the `enabled` property.
  * `enabled` supports environment-driven expressions (e.g., `${ENV_VAR|default}`) to dynamically control whether a filter runs.

* **Bug Fixes**
  * Improved `FilterDecimateRangeAdaptive` robustness with runtime parameter validation and stricter suppression of sparse radial bins based on `min_input_points_per_voxel`.

* **Tests**
  * Added coverage for `enabled` behavior and for `min_input_points_per_voxel` decimation outcomes.

* **Documentation**
  * Updated filter-pipeline docs with YAML examples for `enabled` and `FilterDecimateRangeAdaptive` configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->