### PR TITLE
fix(FilterDeskew): never let IMU trajectory errors crash the pipeline

### DIFF
--- a/mp2p_icp_filters/src/FilterDeskew.cpp
+++ b/mp2p_icp_filters/src/FilterDeskew.cpp
@@ -503,6 +503,10 @@ void FilterDeskew::filter(mp2p_icp::metric_map_t& inOut) const
 
     const mrpt::math::TTwist3D* constant_twist = nullptr;
 
+    // Set if trajectory reconstruction threw: used below to avoid emitting a
+    // second, misleading "empty buffer" warning for the same failure.
+    bool trajectory_reconstruction_failed = false;
+
     switch (method)
     {
         case MotionCompensationMethod::IMU:
@@ -562,6 +566,7 @@ void FilterDeskew::filter(mp2p_icp::metric_map_t& inOut) const
                 }
                 catch (const std::exception& e)
                 {
+                    trajectory_reconstruction_failed = true;
                     reconstructed_trajectory.clear();
 
                     thread_local double last_warning_t = 0;
@@ -623,15 +628,21 @@ void FilterDeskew::filter(mp2p_icp::metric_map_t& inOut) const
 
     if (needsTrajectory && reconstructed_trajectory.empty())
     {
-        thread_local double last_warning_t = 0;
-        const auto          tNow           = mrpt::Clock::nowDouble();
-        if (tNow - last_warning_t > 5.0)
+        // Skip this warning if reconstruction threw: the catch above already
+        // logged the actual cause, and blaming an empty buffer here would be
+        // misleading.
+        if (!trajectory_reconstruction_failed)
         {
-            last_warning_t = tNow;
-            MRPT_LOG_WARN_STREAM(
-                "Local velocity buffer is empty (likely a transient sensor "
-                "data gap); skipping deskew for this scan. Points will be "
-                "passed through uncorrected.");
+            thread_local double last_warning_t = 0;
+            const auto          tNow           = mrpt::Clock::nowDouble();
+            if (tNow - last_warning_t > 5.0)
+            {
+                last_warning_t = tNow;
+                MRPT_LOG_WARN_STREAM(
+                    "Local velocity buffer is empty (likely a transient sensor "
+                    "data gap); skipping deskew for this scan. Points will be "
+                    "passed through uncorrected.");
+            }
         }
 
         if (!in_place)

--- a/mp2p_icp_filters/src/FilterDeskew.cpp
+++ b/mp2p_icp_filters/src/FilterDeskew.cpp
@@ -550,8 +550,31 @@ void FilterDeskew::filter(mp2p_icp::metric_map_t& inOut) const
                     }
                 }
 
-                reconstructed_trajectory =
-                    mola::imu::trajectory_from_buffer(sample_history, imu_params, use_higher_order);
+                // Defense-in-depth: trajectory_from_buffer() reports insufficient
+                // sensor data by returning an empty trajectory, which is handled
+                // gracefully below. Catch any other unexpected exception too and
+                // funnel it into the same skip path, so a transient integration
+                // failure never crashes the whole pipeline.
+                try
+                {
+                    reconstructed_trajectory = mola::imu::trajectory_from_buffer(
+                        sample_history, imu_params, use_higher_order);
+                }
+                catch (const std::exception& e)
+                {
+                    reconstructed_trajectory.clear();
+
+                    thread_local double last_warning_t = 0;
+                    const auto          tNow           = mrpt::Clock::nowDouble();
+                    if (tNow - last_warning_t > 5.0)
+                    {
+                        last_warning_t = tNow;
+                        MRPT_LOG_WARN_STREAM(
+                            "Exception while reconstructing trajectory for deskew; "
+                            "skipping deskew for this scan. Details: "
+                            << e.what());
+                    }
+                }
             }
 
 #if 0  // For *really* in-depth debugging


### PR DESCRIPTION
## Summary

When an IMU-based deskew method was selected and the local velocity buffer lacked a required anchor (e.g. gravity-aligned orientation during sensor warm-up), `trajectory_from_buffer()` could throw. The exception propagated up through the filter pipeline and lidar odometry, crashing the node:

```
At least one entry with gravity-aligned orientation is needed for IMU integration
  ... FilterDeskew::filter(...)
  ... apply_filter_pipeline(...)
  ... LidarOdometry::processLidarScan(...)
```

## Change

Wrap the trajectory reconstruction in a `try/catch` as **defense-in-depth**: any exception is funneled into the existing empty-trajectory skip path, which passes the scan through uncorrected with a throttled WARN.

`FilterDeskew` already gracefully handles an empty reconstructed trajectory; this ensures it also handles an unexpected throw.

## Companion PR

Upstream `mola_imu_preintegration` now returns an empty trajectory (instead of throwing) on insufficient data, which is the primary fix: MOLAorg/mola_imu_preintegration#9. This PR is the belt-and-suspenders guard at the call site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan deskewing resilience when IMU-based trajectory reconstruction fails.
  * If trajectory reconstruction encounters an error, the scan now falls back safely instead of propagating the failure.
  * Added throttled warnings to reduce repeated log noise during recurring issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->