### PR TITLE
Expose cov2cov_alpha and cov2cov_auto_balance_with_prior in Solver_Ga…

### DIFF
--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Solver_GaussNewton.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Solver_GaussNewton.h
@@ -47,6 +47,14 @@ class Solver_GaussNewton : public Solver
      *  OptimalTF_GN_Parameters::kernelPriorRefBlend. */
     double robustKernelPriorRefBlend = 0.0;
 
+    /** Scaling of the cov-to-cov data block against the prior. See
+     *  OptimalTF_GN_Parameters::cov2cov_alpha. */
+    double cov2cov_alpha = 1.0;
+
+    /** Automatic Birge-ratio balancing of the cov2cov block against the prior.
+     *  See OptimalTF_GN_Parameters::cov2cov_auto_balance_with_prior. */
+    bool cov2cov_auto_balance_with_prior = true;
+
     void initialize(const mrpt::containers::yaml& params) override;
 
    protected:

--- a/mp2p_icp_core/mp2p_icp/src/Solver_GaussNewton.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/Solver_GaussNewton.cpp
@@ -38,6 +38,9 @@ void Solver_GaussNewton::initialize(const mrpt::containers::yaml& params)
 
     MCP_LOAD_OPT(params, robustKernelPriorRefBlend);
 
+    MCP_LOAD_OPT(params, cov2cov_alpha);
+    MCP_LOAD_OPT(params, cov2cov_auto_balance_with_prior);
+
     if (params.has("pair_weights")) pairWeights.load_from(params["pair_weights"]);
 }
 
@@ -51,12 +54,14 @@ bool Solver_GaussNewton::impl_optimal_pose(
     out = OptimalTF_Result();
 
     OptimalTF_GN_Parameters gnParams;
-    gnParams.maxInnerLoopIterations = maxIterations;
-    gnParams.pairWeights            = pairWeights;
-    gnParams.kernel                 = robustKernel;
-    gnParams.kernelParam            = robustKernelParam;
-    gnParams.kernelPriorRefBlend    = robustKernelPriorRefBlend;
-    gnParams.prior                  = sc.prior;
+    gnParams.maxInnerLoopIterations          = maxIterations;
+    gnParams.pairWeights                     = pairWeights;
+    gnParams.kernel                          = robustKernel;
+    gnParams.kernelParam                     = robustKernelParam;
+    gnParams.kernelPriorRefBlend             = robustKernelPriorRefBlend;
+    gnParams.cov2cov_alpha                   = cov2cov_alpha;
+    gnParams.cov2cov_auto_balance_with_prior = cov2cov_auto_balance_with_prior;
+    gnParams.prior                           = sc.prior;
 
     ASSERT_(sc.guessRelativePose.has_value());
     gnParams.linearizationPoint = mrpt::poses::CPose3D(sc.guessRelativePose.value());


### PR DESCRIPTION
…ussNewton

These OptimalTF_GN_Parameters knobs were hard-coded to their struct defaults (1.0 and true). Load them via MCP_LOAD_OPT and forward them to gnParams so a pipeline YAML can scale the cov-to-cov data block against the pose prior (e.g. to let an IMU gravity pitch/roll prior carry more relative weight).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options for scaling covariance-to-covariance constraints.
  * Added an option to automatically balance these constraints against the prior pose.
  * Both settings are applied during Gauss-Newton pose optimization and support optional parameter loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->