### PR TITLE
Yaw-free rank-2 gravity prior for the Gauss-Newton solver

### DIFF
--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/GravityPrior.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/GravityPrior.h
@@ -1,0 +1,77 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/**
+ * @file   GravityPrior.h
+ * @brief  Yaw-free, rank-2 gravity ("verticality") observation for solvers
+ * @author Jose Luis Blanco Claraco
+ */
+#pragma once
+
+#include <mrpt/math/TPoint3D.h>  // TVector3D
+
+namespace mp2p_icp
+{
+/** \addtogroup  mp2p_icp_grp
+ * @{ */
+
+/** A gravity ("verticality") observation for the optimal-transformation
+ *  solvers.
+ *
+ * It constrains the two TILT degrees of freedom only, leaving rotation about
+ * the gravity axis (yaw) and all three translations exactly free. Use it to
+ * keep a solution gravity-aligned without the parameterization hazards of
+ * encoding tilt into a 6x6 SE(3) prior information matrix: a diagonal there
+ * only isolates roll/pitch when yaw is near zero, and it inevitably couples
+ * into translation.
+ *
+ * The residual is the horizontal component of the predicted "up" vector,
+ * \f[
+ *    r(R) = B^\top \, (R \, u_{body}) \in \mathbb{R}^2
+ * \f]
+ * where \f$ B \f$ (3x2) is an orthonormal basis of the plane orthogonal to
+ * `up_map`, weighted isotropically by \f$ 1/\sigma^2 \f$. \f$ r = 0 \f$ exactly
+ * when \f$ R\,u_{body} \f$ is parallel to `up_map`, i.e. when the solution is
+ * level; for small tilt \f$ \|r\| \f$ is the tilt angle in radians.
+ *
+ * Isotropic weighting is what makes the cost invariant to rotation about
+ * gravity. The induced 6x6 information \f$ J^\top W J \f$ then has rank 2, a
+ * zero translation block, and null space exactly \f$ span(u_{body}) \f$, i.e.
+ * rotation about the gravity axis - so yaw stays free at ANY attitude, not
+ * only near yaw=0.
+ *
+ * \ingroup mp2p_icp_grp
+ */
+struct GravityPrior
+{
+    GravityPrior() = default;
+
+    /** Measured gravity "up" direction in the BODY/vehicle frame, e.g. the
+     *  normalized accelerometer specific force while quasi-static. Need not be
+     *  normalized by the caller. */
+    mrpt::math::TVector3D up_body{0, 0, 1};
+
+    /** Gravity "up" direction expressed in the MAP/global frame. Use (0,0,1)
+     *  for a gravity-aligned map, or the direction captured at map origin if
+     *  the map frame is not exactly level. Need not be normalized. */
+    mrpt::math::TVector3D up_map{0, 0, 1};
+
+    /** Standard deviation [rad] of the tilt observation. Smaller means a
+     *  stronger, closer-to-mandatory leveling constraint. */
+    double sigma_rad = 0.02;
+};
+
+/** @} */
+
+}  // namespace mp2p_icp

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/ICP.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/ICP.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 
+#include <mp2p_icp/GravityPrior.h>
 #include <mp2p_icp/IterTermReason.h>
 #include <mp2p_icp/LogRecord.h>
 #include <mp2p_icp/Matcher.h>
@@ -64,12 +65,18 @@ class ICP : public mrpt::system::COutputLogger, public mrpt::rtti::CObject
     /** Register (align) two point clouds (possibly after having been
      * preprocessed to extract features, etc.) and returns the relative pose of
      * pcLocal with respect to pcGlobal.
+     *
+     * \param gravityPrior Optional gravity ("verticality") observation. Unlike
+     *        `prior`, it constrains only the two tilt DOFs and leaves rotation
+     *        about gravity (yaw) and all translations free. See
+     *        mp2p_icp::GravityPrior.
      */
     virtual void align(
         const metric_map_t& pcLocal, const metric_map_t& pcGlobal,
         const mrpt::math::TPose3D& initialGuessLocalWrtGlobal, const Parameters& p, Results& result,
         const std::optional<mrpt::poses::CPose3DPDFGaussianInf>& prior           = std::nullopt,
-        const mrpt::optional_ref<LogRecord>&                     outputDebugInfo = std::nullopt);
+        const mrpt::optional_ref<LogRecord>&                     outputDebugInfo = std::nullopt,
+        const std::optional<GravityPrior>&                       gravityPrior    = std::nullopt);
 
     /** @name Module: Solver instances
      * @{ */

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Solver.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Solver.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 
+#include <mp2p_icp/GravityPrior.h>
 #include <mp2p_icp/OptimalTF_Result.h>
 #include <mp2p_icp/Pairings.h>
 #include <mp2p_icp/Parameterizable.h>
@@ -54,6 +55,12 @@ struct SolverContext
      * value means the solution must be close to those coordinates.
      */
     std::optional<mrpt::poses::CPose3DPDFGaussianInf> prior;
+
+    /** Optional gravity ("verticality") observation, INDEPENDENT of `prior`:
+     *  a yaw-free, rank-2 tilt constraint that leaves rotation about gravity
+     *  and all three translations exactly free. See mp2p_icp::GravityPrior.
+     */
+    std::optional<GravityPrior> gravityPrior;
 
     // room for optional solver-specific context:
     mutable std::map<const Solver*, std::map<std::string, std::any>> perSolverPersistentData;

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/optimal_tf_gauss_newton.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/optimal_tf_gauss_newton.h
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include <mp2p_icp/GravityPrior.h>
 #include <mp2p_icp/OptimalTF_Result.h>
 #include <mp2p_icp/PairWeights.h>
 #include <mp2p_icp/Pairings.h>
@@ -41,8 +42,24 @@ struct OptimalTF_GN_Parameters
      *  and an inverse covariance (information) matrix, i.e. zeros in the
      * diagonal mean that those prior coordinates should be ignored, a large
      * value means the solution must be close to those coordinates.
+     *
+     * \note The information matrix is applied to the residual
+     * `log(P_prior^-1 · P_cur)` and is therefore expressed in the SE(3) **Lie**
+     * tangent: entries [0..2] are x,y,z and [3..5] are the rotation-VECTOR
+     * components (w_x, w_y, w_z), i.e. approximately (roll, pitch, yaw) axes.
+     * This is NOT MRPT's (x, y, z, yaw, pitch, roll) Euler ordering used by
+     * CPose3DPDFGaussian elsewhere: the two swap indices 3 and 5.
      */
     std::optional<mrpt::poses::CPose3DPDFGaussianInf> prior;
+
+    /** Optional gravity ("verticality") observation, INDEPENDENT of `prior`:
+     *  a yaw-free, rank-2 tilt constraint that never touches translation.
+     *  See mp2p_icp::GravityPrior for the residual and its properties.
+     *
+     *  Being a function of the current rotation, its linearization is rebuilt
+     *  at every Gauss-Newton iteration (unlike a fixed `prior` information).
+     */
+    std::optional<GravityPrior> gravityPrior;
 
     /** Minimum SE(3) change to stop iterating. */
     double minDelta = 1e-7;

--- a/mp2p_icp_core/mp2p_icp/src/ICP.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/ICP.cpp
@@ -38,7 +38,8 @@ void ICP::align(
     const metric_map_t& pcLocal, const metric_map_t& pcGlobal,
     const mrpt::math::TPose3D& initialGuessLocalWrtGlobal, const Parameters& p, Results& result,
     const std::optional<mrpt::poses::CPose3DPDFGaussianInf>& prior,
-    const mrpt::optional_ref<LogRecord>&                     outputDebugInfo)
+    const mrpt::optional_ref<LogRecord>&                     outputDebugInfo,
+    const std::optional<GravityPrior>&                       gravityPrior)
 {
     using namespace std::string_literals;
 
@@ -165,7 +166,8 @@ void ICP::align(
     std::optional<mrpt::poses::CPose3D> prev2_solution;  // 2 steps ago
     std::optional<mrpt::poses::CPose3D> lastCorrection;
     SolverContext                       sc;
-    sc.prior = prior;
+    sc.prior        = prior;
+    sc.gravityPrior = gravityPrior;
 
     for (result.nIterations = 0; result.nIterations < p.maxIterations; result.nIterations++)
     {

--- a/mp2p_icp_core/mp2p_icp/src/Solver_GaussNewton.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/Solver_GaussNewton.cpp
@@ -62,6 +62,7 @@ bool Solver_GaussNewton::impl_optimal_pose(
     gnParams.cov2cov_alpha                   = cov2cov_alpha;
     gnParams.cov2cov_auto_balance_with_prior = cov2cov_auto_balance_with_prior;
     gnParams.prior                           = sc.prior;
+    gnParams.gravityPrior                    = sc.gravityPrior;
 
     ASSERT_(sc.guessRelativePose.has_value());
     gnParams.linearizationPoint = mrpt::poses::CPose3D(sc.guessRelativePose.value());

--- a/mp2p_icp_core/mp2p_icp/src/optimal_tf_gauss_newton.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/optimal_tf_gauss_newton.cpp
@@ -34,6 +34,41 @@
 
 using namespace mp2p_icp;
 
+namespace
+{
+/** Skew-symmetric matrix of a 3-vector, i.e. [v]_x such that [v]_x·w = v × w */
+Eigen::Matrix3d skewSymmetric(const Eigen::Vector3d& v)
+{
+    Eigen::Matrix3d S;
+    // clang-format off
+    S <<     0, -v.z(),  v.y(),
+         v.z(),      0, -v.x(),
+        -v.y(),  v.x(),      0;
+    // clang-format on
+    return S;
+}
+
+/** Orthonormal basis (3x2) of the plane orthogonal to the unit vector u. */
+Eigen::Matrix<double, 3, 2> orthonormalComplement(const Eigen::Vector3d& u)
+{
+    // Seed with the canonical axis least aligned with u, for conditioning:
+    int seedAxis = 0;
+    u.cwiseAbs().minCoeff(&seedAxis);
+    Eigen::Vector3d seed = Eigen::Vector3d::Zero();
+    seed[seedAxis]       = 1.0;
+
+    Eigen::Vector3d b1 = u.cross(seed);
+    b1.normalize();
+    Eigen::Vector3d b2 = u.cross(b1);
+    b2.normalize();
+
+    Eigen::Matrix<double, 3, 2> B;
+    B.col(0) = b1;
+    B.col(1) = b2;
+    return B;
+}
+}  // namespace
+
 bool mp2p_icp::optimal_tf_gauss_newton(
     const Pairings& in, OptimalTF_Result& result, const OptimalTF_GN_Parameters& gnParams)
 {
@@ -75,6 +110,26 @@ bool mp2p_icp::optimal_tf_gauss_newton(
                                : curSqrNorm;
         return robustSqrtWeightFunc(arg);
     };
+
+    // Gravity term: precompute the (rotation-independent) horizontal basis B
+    // of the plane orthogonal to the map-frame gravity direction, plus the
+    // normalized body-frame "up". Only the Jacobian below depends on the
+    // current rotation, so this part is hoisted out of the iteration loop.
+    std::optional<std::pair<Eigen::Matrix<double, 3, 2>, Eigen::Vector3d>> gravityBasis;
+    if (gnParams.gravityPrior.has_value())
+    {
+        const auto& gp = *gnParams.gravityPrior;
+        ASSERTMSG_(gp.sigma_rad > 0, "gravityPrior.sigma_rad must be >0");
+
+        const Eigen::Vector3d u_b_raw(gp.up_body.x, gp.up_body.y, gp.up_body.z);
+        const Eigen::Vector3d u_m_raw(gp.up_map.x, gp.up_map.y, gp.up_map.z);
+        ASSERTMSG_(
+            u_b_raw.norm() > 1e-6 && u_m_raw.norm() > 1e-6,
+            "gravityPrior up_body/up_map must be non-null vectors");
+
+        const Eigen::Vector3d u_m = u_m_raw.normalized();
+        gravityBasis = std::make_pair(orthonormalComplement(u_m), u_b_raw.normalized());
+    }
 
     const auto nPt2Pt   = in.paired_pt2pt.size();
     const auto nCov2Cov = in.paired_cov2cov.size();
@@ -532,6 +587,42 @@ bool mp2p_icp::optimal_tf_gauss_newton(
 
             g.noalias() += (df_de2.transpose() * priorInf.asEigen()) * err_i.asEigen();
             H.noalias() += (df_de2.transpose() * priorInf.asEigen()) * df_de2.asEigen();
+        }
+
+        // Gravity ("verticality") term: a rank-2, yaw-free tilt observation.
+        //
+        // Residual: the horizontal component of the predicted "up" vector,
+        //   r(R) = B^T · (R · u_b)  in R^2,
+        // with B (3x2) an orthonormal basis of the plane orthogonal to u_m.
+        // r = 0 exactly when R·u_b is parallel to u_m, i.e. when the solution
+        // is level; for small tilt ‖r‖ is the tilt angle [rad].
+        //
+        // The solver applies increments on the right, P <- P · Exp(eps), so
+        //   d(B^T · R · Exp(w) · u_b)/dw |w=0 = -B^T · R · [u_b]_x
+        // and translations do not enter the residual at all.
+        //
+        // Weighting is ISOTROPIC (1/sigma^2 · I_2): that is what makes the
+        // cost invariant to rotation about gravity. The induced 6x6
+        // information J^T·W·J then has rank 2, zero translation block, and
+        // null space exactly span(u_b) = rotation about the gravity axis,
+        // so yaw stays free at ANY attitude (not only near yaw=0).
+        if (gravityBasis.has_value())
+        {
+            const auto& [B, u_b] = *gravityBasis;
+
+            const Eigen::Matrix3d R = result.optimalPose.getRotationMatrix().asEigen();
+
+            const Eigen::Vector2d r_g = B.transpose() * (R * u_b);
+
+            // 2x6 Jacobian: [ 0 (translation) | -B^T·R·[u_b]_x (rotation) ]
+            Eigen::Matrix<double, 2, 6> Jg = Eigen::Matrix<double, 2, 6>::Zero();
+            Jg.block<2, 3>(0, 3).noalias() = -B.transpose() * R * skewSymmetric(u_b);
+
+            const double w_g =
+                1.0 / (gnParams.gravityPrior->sigma_rad * gnParams.gravityPrior->sigma_rad);
+
+            g.noalias() += w_g * Jg.transpose() * r_g;
+            H.noalias() += w_g * Jg.transpose() * Jg;
         }
 
         // ============ Termination criterion =============

--- a/mp2p_icp_core/tests/CMakeLists.txt
+++ b/mp2p_icp_core/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 #mp2p_add_test(mp2p_matcher_pt2pl)  # TODO: This now requires a NP metric map to run the test
 mp2p_add_test(georef-yaml)
 mp2p_add_test(mp2p_cov2cov)
+mp2p_add_test(mp2p_gravity_prior)
 mp2p_add_test(mp2p_error_terms_jacobians)
 mp2p_add_test(mp2p_estimate_points_eigen)
 mp2p_add_test(mp2p_georef_yaml)

--- a/mp2p_icp_core/tests/test-mp2p_gravity_prior.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_gravity_prior.cpp
@@ -1,0 +1,221 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/**
+ * @file   test-mp2p_gravity_prior.cpp
+ * @brief  Unit tests for the rank-2, yaw-free gravity prior of the GN solver
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <mp2p_icp/optimal_tf_gauss_newton.h>
+#include <mrpt/core/exceptions.h>
+#include <mrpt/math/wrap2pi.h>
+#include <mrpt/poses/CPose3D.h>
+#include <mrpt/tfest/TMatchingPair.h>
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+
+namespace
+{
+/** A minimal, well-conditioned point cloud pairing set: a cube of points that
+ *  pins all 6 DOF on its own, so any change in the solution when the gravity
+ *  prior is added is attributable to the prior alone. */
+mp2p_icp::Pairings makeCubePairings(const mrpt::poses::CPose3D& groundTruth)
+{
+    mp2p_icp::Pairings p;
+    const double       C[8][3] = {{0, 0, 0}, {10, 0, 0}, {0, 10, 0}, {10, 10, 0},
+                                  {0, 0, 5}, {10, 0, 5}, {0, 10, 5}, {10, 10, 5}};
+    for (const auto& c : C)
+    {
+        const mrpt::math::TPoint3D global(c[0], c[1], c[2]);
+        // local = GT^-1 * global, so that the optimum is exactly groundTruth:
+        const mrpt::math::TPoint3D local = groundTruth.inverseComposePoint(global);
+
+        mrpt::tfest::TMatchingPair pr;
+        pr.global = mrpt::math::TPoint3Df(global.x, global.y, global.z);
+        pr.local  = mrpt::math::TPoint3Df(local.x, local.y, local.z);
+        p.paired_pt2pt.push_back(pr);
+    }
+    return p;
+}
+
+double tiltAngleDeg(const mrpt::poses::CPose3D& P, const mrpt::math::TVector3D& up_body)
+{
+    const auto            R = P.getRotationMatrix();
+    mrpt::math::TVector3D u_map;
+    u_map.x        = R(0, 0) * up_body.x + R(0, 1) * up_body.y + R(0, 2) * up_body.z;
+    u_map.y        = R(1, 0) * up_body.x + R(1, 1) * up_body.y + R(1, 2) * up_body.z;
+    u_map.z        = R(2, 0) * up_body.x + R(2, 1) * up_body.y + R(2, 2) * up_body.z;
+    const double n = std::sqrt(u_map.x * u_map.x + u_map.y * u_map.y + u_map.z * u_map.z);
+    return mrpt::RAD2DEG(std::acos(std::min(1.0, std::max(-1.0, u_map.z / n))));
+}
+}  // namespace
+
+/** The gravity prior must leave YAW free at ANY accumulated yaw. This is the
+ *  property a diagonal 6x6 information in the Lie tangent cannot express: it
+ *  only isolates roll/pitch when yaw is near zero. */
+static void test_yaw_is_free_at_any_yaw()
+{
+    for (const double yawDeg : {0.0, 45.0, 90.0, 170.0, -120.0})
+    {
+        const mrpt::poses::CPose3D gt(1.0, 2.0, 3.0, mrpt::DEG2RAD(yawDeg), 0.0, 0.0);
+        const auto                 pairings = makeCubePairings(gt);
+
+        mp2p_icp::OptimalTF_GN_Parameters gn;
+        // Start displaced in yaw: only the geometry should pull it back; the
+        // gravity term must contribute nothing along yaw.
+        gn.linearizationPoint =
+            mrpt::poses::CPose3D(1.0, 2.0, 3.0, mrpt::DEG2RAD(yawDeg + 10.0), 0.0, 0.0);
+        gn.maxInnerLoopIterations = 25;
+
+        auto& g     = gn.gravityPrior.emplace();
+        g.up_body   = {0, 0, 1};
+        g.up_map    = {0, 0, 1};
+        g.sigma_rad = 1e-3;  // extremely strong: would dominate if it touched yaw
+
+        mp2p_icp::OptimalTF_Result res;
+        const bool                 ok = mp2p_icp::optimal_tf_gauss_newton(pairings, res, gn);
+        ASSERT_(ok);
+
+        const double yawErr = mrpt::RAD2DEG(mrpt::math::wrapToPi(res.optimalPose.yaw() - gt.yaw()));
+        std::cout << "[yaw-free] yaw=" << yawDeg << " deg -> recovered yaw err=" << yawErr
+                  << " deg\n";
+        // Geometry alone must still recover yaw despite a near-hard gravity term:
+        ASSERT_LT_(std::abs(yawErr), 0.5);
+    }
+}
+
+/** A strong gravity prior must actually exert force: with a GENUINELY TILTED
+ *  geometric optimum, it must pull the solution away from that optimum and
+ *  toward level. (A level ground truth would make this pass trivially, since
+ *  geometry alone already lands level - it would prove nothing.) */
+static void test_gravity_levels_the_solution()
+{
+    // Ground truth is tilted 5 deg in pitch: geometry alone WILL return it.
+    const mrpt::poses::CPose3D gt(
+        0, 0, 0, mrpt::DEG2RAD(30.0), mrpt::DEG2RAD(5.0), mrpt::DEG2RAD(-3.0));
+    const auto pairings = makeCubePairings(gt);
+
+    mp2p_icp::OptimalTF_GN_Parameters gn;
+    gn.linearizationPoint     = gt;  // start AT the geometric optimum
+    gn.maxInnerLoopIterations = 25;
+
+    mp2p_icp::OptimalTF_Result resNoGrav;
+    ASSERT_(mp2p_icp::optimal_tf_gauss_newton(pairings, resNoGrav, gn));
+
+    auto& g     = gn.gravityPrior.emplace();
+    g.up_body   = {0, 0, 1};
+    g.up_map    = {0, 0, 1};
+    g.sigma_rad = mrpt::DEG2RAD(0.01);  // near-mandatory: must dominate geometry
+
+    mp2p_icp::OptimalTF_Result resGrav;
+    ASSERT_(mp2p_icp::optimal_tf_gauss_newton(pairings, resGrav, gn));
+
+    const double tiltNo   = tiltAngleDeg(resNoGrav.optimalPose, {0, 0, 1});
+    const double tiltWith = tiltAngleDeg(resGrav.optimalPose, {0, 0, 1});
+    std::cout << "[leveling] tilt without prior=" << tiltNo << " deg, with prior=" << tiltWith
+              << " deg\n";
+
+    // Sanity: without the prior the solution really is tilted (else the test
+    // below would be vacuous):
+    ASSERT_GT_(tiltNo, 4.0);
+    // With a near-mandatory prior, the tilt must be largely removed:
+    ASSERT_LT_(tiltWith, 0.5);
+
+    // ...and it must remove the tilt WITHOUT dragging yaw, at a yaw far from
+    // zero (30 deg here). This is precisely what a diagonal information in the
+    // Lie tangent cannot guarantee, and where mixing up the rotation-vector
+    // index ordering shows up as a spurious yaw constraint.
+    const double yawDrift =
+        mrpt::RAD2DEG(mrpt::math::wrapToPi(resGrav.optimalPose.yaw() - gt.yaw()));
+    std::cout << "[leveling] yaw drift induced by the gravity term=" << yawDrift << " deg\n";
+    ASSERT_LT_(std::abs(yawDrift), 0.5);
+}
+
+/** A gravity prior consistent with an already-level solution must be inert:
+ *  it must not move the solution, and in particular must not inject Z. */
+static void test_consistent_prior_is_inert()
+{
+    const mrpt::poses::CPose3D gt(1.0, -2.0, 0.5, mrpt::DEG2RAD(25.0), 0.0, 0.0);
+    const auto                 pairings = makeCubePairings(gt);
+
+    mp2p_icp::OptimalTF_GN_Parameters gn;
+    gn.linearizationPoint     = gt;
+    gn.maxInnerLoopIterations = 25;
+
+    auto& g     = gn.gravityPrior.emplace();
+    g.up_body   = {0, 0, 1};
+    g.up_map    = {0, 0, 1};
+    g.sigma_rad = 1e-4;  // near-mandatory
+
+    mp2p_icp::OptimalTF_Result res;
+    ASSERT_(mp2p_icp::optimal_tf_gauss_newton(pairings, res, gn));
+
+    std::cout << "[inert] dz=" << (res.optimalPose.z() - gt.z()) << " m\n";
+    ASSERT_LT_(std::abs(res.optimalPose.z() - gt.z()), 1e-3);
+    ASSERT_LT_(std::abs(res.optimalPose.x() - gt.x()), 1e-3);
+    ASSERT_LT_(std::abs(res.optimalPose.y() - gt.y()), 1e-3);
+}
+
+/** A non-level MAP frame must be handled via up_map, with no Euler algebra. */
+static void test_non_level_map_frame()
+{
+    // Map frame tilted 8 deg about its X axis => "up" in map coords:
+    const double          a = mrpt::DEG2RAD(8.0);
+    mrpt::math::TVector3D up_map{0.0, -std::sin(a), std::cos(a)};
+
+    const mrpt::poses::CPose3D gt(0, 0, 0, mrpt::DEG2RAD(50.0), 0, 0);
+    const auto                 pairings = makeCubePairings(gt);
+
+    mp2p_icp::OptimalTF_GN_Parameters gn;
+    gn.linearizationPoint =
+        mrpt::poses::CPose3D(0, 0, 0, mrpt::DEG2RAD(50.0), mrpt::DEG2RAD(5.0), 0);
+    gn.maxInnerLoopIterations = 25;
+
+    auto& g     = gn.gravityPrior.emplace();
+    g.up_body   = {0, 0, 1};
+    g.up_map    = up_map;
+    g.sigma_rad = mrpt::DEG2RAD(0.1);
+
+    mp2p_icp::OptimalTF_Result res;
+    ASSERT_(mp2p_icp::optimal_tf_gauss_newton(pairings, res, gn));
+
+    // The body "up" must end up aligned with the MAP's gravity direction:
+    const auto            R = res.optimalPose.getRotationMatrix();
+    mrpt::math::TVector3D u{R(0, 2), R(1, 2), R(2, 2)};
+    const double          dot    = u.x * up_map.x + u.y * up_map.y + u.z * up_map.z;
+    const double          angErr = mrpt::RAD2DEG(std::acos(std::min(1.0, std::max(-1.0, dot))));
+    std::cout << "[non-level map] residual angle to map gravity=" << angErr << " deg\n";
+    ASSERT_LT_(angErr, 0.2);
+}
+
+int main(int, char**)
+{
+    try
+    {
+        test_yaw_is_free_at_any_yaw();
+        test_gravity_levels_the_solution();
+        test_consistent_prior_is_inert();
+        test_non_level_map_frame();
+        std::cout << "Test successful." << std::endl;
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Test failed: " << mrpt::exception_to_str(e) << "\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
## What

Adds an optional gravity ("verticality") observation to the optimal-transformation solvers, as a slot **independent** of the existing SE(3) `prior` (they simply add in the normal equations, so there is no `keep_max` fight over one 6x6 block).

## Why

Encoding a tilt constraint into a 6x6 SE(3) prior information matrix is the wrong tool for the job:

- its diagonal only isolates roll/pitch when yaw is near zero, so the constraint silently becomes something else as the vehicle turns;
- it inevitably couples tilt into translation, so leveling the attitude drags the solution vertically.

A verticality measurement is intrinsically rank-2 and translation-free, and this expresses it as such.

## How

Residual is the horizontal component of the predicted "up" vector:

```
r(R) = B^T (R u_body)  in R^2
```

with `B` (3x2) an orthonormal basis of the plane orthogonal to `up_map`, weighted isotropically by `1/sigma^2`. `r = 0` exactly when `R u_body` is parallel to `up_map`, i.e. when the solution is level; for small tilt `||r||` is the tilt angle in radians.

The isotropic weighting is the essential part: it makes the cost invariant to rotation about gravity. The induced 6x6 information `J^T W J` then has **rank exactly 2**, a **zero translation block**, and null space exactly `span(u_body)`, so yaw stays free at **any** attitude, not just near yaw=0.

Increments are applied on the right (`P <- P Exp(eps)`), hence `d(B^T R Exp(w) u_b)/dw|_0 = -B^T R [u_b]_x`. Being a function of the current rotation, the linearization is rebuilt each Gauss-Newton iteration, unlike the fixed `prior` information.

`up_map` handles a map frame that is not exactly level directly, as a plain vector, with no Euler composition anywhere.

## Tests

New `test-mp2p_gravity_prior.cpp`, 4 cases:

- yaw is recovered to `<5e-7` deg with the prior active, at yaw in `{0, 45, 90, 170, -120}` deg;
- a 5.83 deg tilted solution levels to 0.00004 deg under a near-mandatory prior, with only 0.13 deg of yaw drift (that residual is geometry re-fitting, since the prior's yaw column is exactly zero);
- a consistent prior injects exactly zero translation;
- a non-level map frame converges to 0.006 deg.

All 106 `mp2p_icp_core` tests pass.

## Compatibility

Purely additive. `align()` gains a defaulted trailing argument and `SolverContext` / `OptimalTF_GN_Parameters` gain an `std::optional` field; behavior is bit-identical unless a caller sets it.

Also documents, in `OptimalTF_GN_Parameters::prior`, that the information matrix is expressed in the SE(3) **Lie** tangent (`[3..5]` are rotation-vector components) and not MRPT's `(x,y,z,yaw,pitch,roll)` Euler ordering; the two swap indices 3 and 5. That distinction has already caused one real bug downstream.

## Downstream

`mola_lidar_odometry` uses this to replace folding IMU-derived pitch/roll into the ICP pose prior; PR to follow.