### PR TITLE
fix: remove racy per-point pt2pt weight path in Gauss-Newton solver

### DIFF
--- a/mp2p_icp_core/demos/icp-settings-2d-lidar-example-point2line.yaml
+++ b/mp2p_icp_core/demos/icp-settings-2d-lidar-example-point2line.yaml
@@ -39,7 +39,7 @@ matchers:
       # maximum e0/e2 and e1/e2 ratio [mandatory]
       lineEigenThreshold: 1e-2
       pointLayerMatches:
-        - {global: "2d_lidar", local: "2d_lidar", weight: 1.0}
+        - {global: "2d_lidar", local: "2d_lidar"}
   - class: mp2p_icp::Matcher_Points_DistanceThreshold
     params:
       threshold: 0.15
@@ -47,7 +47,7 @@ matchers:
       #runFromIteration: 0  # "from 0 to 0" means "all"
       #runUpToIteration: 0
       pointLayerMatches:
-        - {global: "2d_lidar", local: "2d_lidar", weight: 1.0}
+        - {global: "2d_lidar", local: "2d_lidar"}
 
 quality:
   - class: mp2p_icp::QualityEvaluator_PairedRatio

--- a/mp2p_icp_core/demos/icp-settings-2d-lidar-example-point2point.yaml
+++ b/mp2p_icp_core/demos/icp-settings-2d-lidar-example-point2point.yaml
@@ -32,7 +32,7 @@ matchers:
       # If "pointLayerMatches" is not defined, layers will be matched against
       # those with the same name in both maps:
       #pointLayerMatches:
-      #  - {global: "2d_lidar", local: "2d_lidar", weight: 1.0}
+      #  - {global: "2d_lidar", local: "2d_lidar"}
 
 quality:
   - class: mp2p_icp::QualityEvaluator_PairedRatio

--- a/mp2p_icp_core/demos/icp-settings-example1.yaml
+++ b/mp2p_icp_core/demos/icp-settings-example1.yaml
@@ -32,7 +32,7 @@ matchers:
       runFromIteration: 0  # "from 0 to 0" means "all"
       runUpToIteration: 0
       pointLayerMatches:
-        - {global: "raw", local: "decimated", weight: 1.0}
+        - {global: "raw", local: "decimated"}
 #  - class: mp2p_icp::Matcher_Point2Plane
 #    params:
 #      distanceThreshold: 0.40
@@ -41,7 +41,7 @@ matchers:
 #      runFromIteration: 0  # "from 0 to 0" means "all"
 #      runUpToIteration: 0
 #      pointLayerMatches:
-#        - {global: "raw", local: "decimated", weight: 1.0}
+#        - {global: "raw", local: "decimated"}
 
 quality:
   - class: mp2p_icp::QualityEvaluator_PairedRatio

--- a/mp2p_icp_core/demos/icp-settings-kitti.yaml
+++ b/mp2p_icp_core/demos/icp-settings-kitti.yaml
@@ -45,7 +45,7 @@ matchers:
       runFromIteration: 0 # "from 0 to 0" means "all"
       runUpToIteration: 5
       pointLayerMatches:
-        - { global: "raw", local: "decimated", weight: 1.0 }
+        - { global: "raw", local: "decimated" }
 
   - class: mp2p_icp::Matcher_Adaptive
     params:
@@ -56,7 +56,7 @@ matchers:
       runFromIteration: 6 # "from 0 to 0" means "all"
       runUpToIteration: 0
       pointLayerMatches:
-        - { global: "raw", local: "decimated", weight: 1.0 }
+        - { global: "raw", local: "decimated" }
 
 quality:
   - class: mp2p_icp::QualityEvaluator_PairedRatio
@@ -64,7 +64,7 @@ quality:
       reuse_icp_pairings: true
       threshold: 0.25
       pointLayerMatches:
-        - { global: "raw", local: "decimated", weight: 1.0 }
+        - { global: "raw", local: "decimated" }
 
 # Filters for local and global point clouds:
 #

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Adaptive.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Adaptive.h
@@ -31,7 +31,7 @@ namespace mp2p_icp
  *
  * By default, each `local` point layer is matched against the layer with the
  * same name in the `global` map, unless specified otherwise in the base class
- * member `weight_pt2pt_layers`. Refer to example configuration YAML files for
+ * member `pt2pt_layer_matches`. Refer to example configuration YAML files for
  * example configurations.
  *
  * \ingroup mp2p_icp_grp

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Point2Line.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Point2Line.h
@@ -30,7 +30,7 @@ namespace mp2p_icp
  *
  * By default, each `local` point layer is matched against the layer with the
  * same name in the `global` map, unless specified otherwise in the base class
- * member `weight_pt2pt_layers`. Refer to example configuration YAML files for
+ * member `pt2pt_layer_matches`. Refer to example configuration YAML files for
  * example configurations.
  *
  * \ingroup mp2p_icp_grp

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Point2Plane.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Point2Plane.h
@@ -30,7 +30,7 @@ namespace mp2p_icp
  *
  * By default, each `local` point layer is matched against the layer with the
  * same name in the `global` map, unless specified otherwise in the base class
- * member `weight_pt2pt_layers`. Refer to example configuration YAML files for
+ * member `pt2pt_layer_matches`. Refer to example configuration YAML files for
  * example configurations.
  *
  * \ingroup mp2p_icp_grp

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Points_Base.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Points_Base.h
@@ -24,7 +24,10 @@
 
 #include <cstdlib>
 #include <limits>  // std::numeric_limits
+#include <map>
 #include <optional>
+#include <set>
+#include <string>
 #include <vector>
 
 namespace mp2p_icp
@@ -41,16 +44,15 @@ class Matcher_Points_Base : public Matcher
    public:
     Matcher_Points_Base() = default;
 
-    /** Weights for each potential Local->Global point layer matching.
-     * If empty, the output Pairings::point_weights
-     * will left empty (=all points have equal weight).
-     * \note Note: this field can be loaded from a configuration file via
-     * initializeLayerWeights().
+    /** Explicit set of local point layers to match against each global point
+     * layer. If empty, each `local` layer is matched against the `global`
+     * layer with the identical name.
+     * \note This field can be loaded from a configuration file, see
+     * initialize().
      *
-     * \note Map is: w["globalLayer"]["localLayer"]=weight;
-     *
+     * \note Map is: layers["globalLayer"] = {"localLayer1", "localLayer2", ...};
      */
-    std::map<std::string, std::map<std::string, double>> weight_pt2pt_layers;
+    std::map<std::string, std::set<std::string>> pt2pt_layer_matches;
 
     /** Whether to allow matching *local* points that have been already matched
      * by a former Matcher instance in the pipeline. */

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Points_Base.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Points_Base.h
@@ -71,8 +71,11 @@ class Matcher_Points_Base : public Matcher
 
     /** Common parameters to all derived classes:
      *
-     * - `pointLayerMatches`: Optional map of layer names to relative weights.
-     *  Refer to example YAML files.
+     * - `pointLayerMatches`: Optional sequence of explicit `{global, local}`
+     *  layer-name pairs to match against each other. Refer to example YAML
+     *  files. A legacy `weight` key is still accepted for backward
+     *  compatibility but is ignored; use the solver's `pair_weights.pt2pt`
+     *  instead.
      *
      * - `allowMatchAlreadyMatchedPoints`: Optional (Default=false). Whether to
      * find matches for local points which were already paired by other matcher

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Points_DistanceThreshold.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Points_DistanceThreshold.h
@@ -30,7 +30,7 @@ namespace mp2p_icp
  *
  * By default, each `local` point layer is matched against the layer with the
  * same name in the `global` map, unless especified otherwise in the base class
- * member `weight_pt2pt_layers`. Refer to example configuration YAML files for
+ * member `pt2pt_layer_matches`. Refer to example configuration YAML files for
  * example configurations.
  *
  * \ingroup mp2p_icp_grp

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Points_InlierRatio.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Matcher_Points_InlierRatio.h
@@ -30,7 +30,7 @@ namespace mp2p_icp
  *
  * By default, each `local` point layer is matched against the layer with the
  * same name in the `global` map, unless specified otherwise in the base class
- * member `weight_pt2pt_layers`. Refer to example configuration YAML files for
+ * member `pt2pt_layer_matches`. Refer to example configuration YAML files for
  * example configurations.
  *
  * \ingroup mp2p_icp_grp

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/PairWeights.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/PairWeights.h
@@ -33,11 +33,7 @@ namespace mp2p_icp
  */
 struct PairWeights
 {
-    /** Weight of point-to-point pairs. Note that finer control of weights
-     * can be achieved with `Pairings::point_weights`, so this `pt2pt` field
-     * will be honored only if `Pairings::point_weights` is empty.
-     */
-    double pt2pt = 1.0;
+    double pt2pt = 1.0;  //!< Weight of point-to-point pairs
 
     double pt2ln = 1.0;  //!< Weight of point-to-line pairs
     double pt2pl = 1.0;  //!< Weight of point-to-plane pairs

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Pairings.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Pairings.h
@@ -108,12 +108,6 @@ struct Pairings
     /// is `this->size() / double(potential_pairings)`.
     uint64_t potential_pairings = 0;
 
-    /** *Individual* weights for paired_pt2pt: each entry specifies how many
-     * points have the given (mapped second value) weight, in the same order as
-     * stored in paired_pt2pt. If empty, all points will have equal weights.
-     */
-    std::vector<std::pair<std::size_t, double>> point_weights;
-
     /** @} */
 
     /** @name Methods

--- a/mp2p_icp_core/mp2p_icp/src/Matcher_Points_Base.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/Matcher_Points_Base.cpp
@@ -41,40 +41,36 @@ bool Matcher_Points_Base::impl_match(
     {
         const auto& glLayerName = glLayerKV.first;
 
-        // List of local layers to match against (and optional weights)
-        std::map<std::string, std::optional<double>> localLayers;
+        // List of local layers to match against this global layer:
+        std::set<std::string> localLayers;
 
-        if (!weight_pt2pt_layers.empty())
+        if (!pt2pt_layer_matches.empty())
         {
-            const auto itGlob = weight_pt2pt_layers.find(glLayerName);
-            // If we have weights and this layer is not listed, Skip it:
-            if (itGlob == weight_pt2pt_layers.end())
+            const auto itGlob = pt2pt_layer_matches.find(glLayerName);
+            // If explicit matches are given and this layer is not listed,
+            // skip it:
+            if (itGlob == pt2pt_layer_matches.end())
             {
                 continue;
             }
 
-            for (const auto& kv : itGlob->second)
-            {
-                localLayers[kv.first] = kv.second;
-            }
+            localLayers = itGlob->second;
         }
         else
         {
             // Default: match by identical layer names:
-            localLayers[glLayerName] = {};
+            localLayers = {glLayerName};
         }
 
-        for (const auto& localWeight : localLayers)
+        for (const auto& localLayerName : localLayers)
         {
-            const auto& localLayerName = localWeight.first;
-            const bool  hasWeight      = localWeight.second.has_value();
-
             // Look for a matching layer in "local":
             auto itLocal = pcLocal.layers.find(localLayerName);
             if (itLocal == pcLocal.layers.end())
             {
-                // Silently ignore it:
-                if (!hasWeight)
+                // Silently ignore it when relying on the default (implicit)
+                // same-name matching; explicit entries must exist:
+                if (pt2pt_layer_matches.empty())
                 {
                     continue;
                 }
@@ -99,8 +95,6 @@ bool Matcher_Points_Base::impl_match(
                     lcLayerMap->GetRuntimeClass()->className);
             }
 
-            const size_t nBefore = out.paired_pt2pt.size();
-
             // Ensure we have the KD-tree parameters desired by the user:
             if (kdtree_leaf_max_points_.has_value())
             {
@@ -115,14 +109,6 @@ bool Matcher_Points_Base::impl_match(
 
             // matcher implementation:
             implMatchOneLayer(*glLayer, *lcLayer, localPose, ms, glLayerName, localLayerName, out);
-
-            const size_t nAfter = out.paired_pt2pt.size();
-
-            if (hasWeight && nAfter != nBefore)
-            {
-                const double w = localWeight.second.value();
-                out.point_weights.emplace_back(nAfter - nBefore, w);
-            }
         }
     }
     return true;
@@ -137,12 +123,15 @@ void Matcher_Points_Base::initialize(const mrpt::containers::yaml& params)
     {
         auto& p = params["pointLayerMatches"];
 
-        weight_pt2pt_layers.clear();
+        pt2pt_layer_matches.clear();
         ASSERT_(p.isSequence());
 
-        // - {global: "raw", local: "decimated", weight: 1.0}
-        // - {global: "raw", local: "decimated", weight: 1.0}
+        // - {global: "raw", local: "decimated"}
+        // - {global: "raw", local: "decimated"}
         // ...
+        // Note: a "weight" key is also accepted for backward compatibility
+        // with older configuration files, but is ignored: per-layer pt2pt
+        // weighting was removed, use PairWeights::pt2pt instead.
 
         for (const auto& entry : p.asSequence())
         {
@@ -154,9 +143,8 @@ void Matcher_Points_Base::initialize(const mrpt::containers::yaml& params)
 
             const std::string globalLayer = em.at("global").as<std::string>();
             const std::string localLayer  = em.at("local").as<std::string>();
-            const double      w = em.count("weight") != 0 ? em.at("weight").as<double>() : 1.0;
 
-            weight_pt2pt_layers[globalLayer][localLayer] = w;
+            pt2pt_layer_matches[globalLayer].insert(localLayer);
         }
     }
 

--- a/mp2p_icp_core/mp2p_icp/src/Pairings.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/Pairings.cpp
@@ -30,7 +30,7 @@
 
 using namespace mp2p_icp;
 
-static const uint8_t SERIALIZATION_VERSION = 2;
+static const uint8_t SERIALIZATION_VERSION = 3;
 
 Pairings::~Pairings() = default;
 
@@ -38,9 +38,10 @@ void Pairings::serializeTo(mrpt::serialization::CArchive& out) const
 {
     out.WriteAs<uint8_t>(SERIALIZATION_VERSION);
     out << paired_pt2pt;
-    out << paired_pt2ln << paired_pt2pl << paired_ln2ln << paired_pl2pl << point_weights;
+    out << paired_pt2ln << paired_pt2pl << paired_ln2ln << paired_pl2pl;
     out << potential_pairings;  // v1
     out << paired_cov2cov;  // v2
+    // v3: per-point weights removed (unused, superseded by PairWeights::pt2pt)
 }
 
 void Pairings::serializeFrom(mrpt::serialization::CArchive& in)
@@ -51,7 +52,14 @@ void Pairings::serializeFrom(mrpt::serialization::CArchive& in)
 
     ASSERT_LE_(readVersion, SERIALIZATION_VERSION);
     in >> paired_pt2pt;
-    in >> paired_pt2ln >> paired_pt2pl >> paired_ln2ln >> paired_pl2pl >> point_weights;
+    in >> paired_pt2ln >> paired_pt2pl >> paired_ln2ln >> paired_pl2pl;
+    if (readVersion < 3)
+    {
+        // Removed in v3: per-point weights. Read and discard, for backward
+        // compatibility with older serialized icplog files.
+        std::vector<std::pair<std::size_t, double>> unusedPointWeights;
+        in >> unusedPointWeights;
+    }
     if (readVersion >= 1)
     {
         in >> potential_pairings;

--- a/mp2p_icp_core/mp2p_icp/src/optimal_tf_gauss_newton.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/optimal_tf_gauss_newton.cpp
@@ -140,10 +140,6 @@ bool mp2p_icp::optimal_tf_gauss_newton(
 
     auto w = gnParams.pairWeights;
 
-    const bool  has_per_pt_weight       = !in.point_weights.empty();
-    auto        cur_point_block_weights = in.point_weights.begin();
-    std::size_t cur_point_block_start   = 0;
-
     for (size_t iter = 0; iter < gnParams.maxInnerLoopIterations; iter++)
     {
         // Note: Using Matrix<N,1> instead of Vector<N> for compatibility
@@ -202,18 +198,6 @@ bool mp2p_icp::optimal_tf_gauss_newton(
                     mrpt::math::CVectorFixedDouble<3>       ret =
                         mp2p_icp::error_point2point(p.local, p.global, result.optimalPose, J1);
 
-                    // Get point weight:
-                    if (has_per_pt_weight)
-                    {
-                        if (idx_pt >= cur_point_block_start + cur_point_block_weights->first)
-                        {
-                            ASSERT_(cur_point_block_weights != in.point_weights.end());
-                            ++cur_point_block_weights;  // move to next block
-                            cur_point_block_start = idx_pt;
-                        }
-                        w.pt2pt = cur_point_block_weights->second;
-                    }
-
                     // Apply robust kernel? (optionally prior-referenced)
                     double weight = w.pt2pt, retSqrNorm = ret.asEigen().squaredNorm();
                     double priorSqrNorm = retSqrNorm;
@@ -250,18 +234,6 @@ bool mp2p_icp::optimal_tf_gauss_newton(
             mrpt::math::CMatrixFixed<double, 3, 12> J1;
             mrpt::math::CVectorFixedDouble<3>       ret =
                 mp2p_icp::error_point2point(p.local, p.global, result.optimalPose, J1);
-
-            // Get point weight:
-            if (has_per_pt_weight)
-            {
-                if (idx_pt >= cur_point_block_start + cur_point_block_weights->first)
-                {
-                    ASSERT_(cur_point_block_weights != in.point_weights.end());
-                    ++cur_point_block_weights;  // move to next block
-                    cur_point_block_start = idx_pt;
-                }
-                w.pt2pt = cur_point_block_weights->second;
-            }
 
             // Apply robust kernel? (optionally prior-referenced)
             double weight = w.pt2pt, retSqrNorm = ret.asEigen().squaredNorm();

--- a/mp2p_icp_core/mp2p_icp/src/visit_correspondences.h
+++ b/mp2p_icp_core/mp2p_icp/src/visit_correspondences.h
@@ -58,17 +58,6 @@ void visit_correspondences(
 
     VisitCorrespondencesStats stats;
 
-    // weight of points, block by block:
-    auto point_weights = in.point_weights;
-    if (point_weights.empty())
-    {
-        // Default, equal weights:
-        point_weights.emplace_back(nPt2Pt, 1.0);
-    }
-
-    auto        cur_point_block_weights = point_weights.begin();
-    std::size_t cur_point_block_start   = 0;
-
     // Normalized weights for attitude "waXX":
     double waPoints, waLines, waPlanes;
     {
@@ -118,14 +107,6 @@ void visit_correspondences(
             // point-to-point pairing:  normalize(point-centroid)
             const auto& p = in.paired_pt2pt[i];
             wi            = waPoints;
-
-            if (i >= cur_point_block_start + cur_point_block_weights->first)
-            {
-                ASSERT_(cur_point_block_weights != point_weights.end());
-                ++cur_point_block_weights;  // move to next block
-                cur_point_block_start = i;
-            }
-            wi *= cur_point_block_weights->second;
             // (solution will be normalized via w_sum a the end)
 
             bi = p.global - ct_global;

--- a/mp2p_icp_core/tests/test-mp2p_Pairings.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_Pairings.cpp
@@ -30,6 +30,7 @@
 #include <mrpt/opengl/CTexturedPlane.h>
 #include <mrpt/poses/CPose3D.h>
 #include <mrpt/serialization/CArchive.h>
+#include <mrpt/serialization/stl_serialization.h>
 
 #include <iostream>
 
@@ -96,7 +97,6 @@ void test_Pairings_Serialization()
 
     // Metadata
     p1.potential_pairings = 100;
-    p1.point_weights.emplace_back(0, 1.5);  // Index 0 has weight 1.5
 
     // 2. Serialize
     // ---------------------------------------------------
@@ -119,7 +119,6 @@ void test_Pairings_Serialization()
     ASSERT_EQUAL_(p1.paired_pl2pl.size(), p2.paired_pl2pl.size());
 
     ASSERT_EQUAL_(p1.potential_pairings, p2.potential_pairings);
-    ASSERT_EQUAL_(p1.point_weights.size(), p2.point_weights.size());
 
     // Deep check one element
     const auto& pt1 = p1.paired_pt2pt[0];
@@ -127,12 +126,48 @@ void test_Pairings_Serialization()
     ASSERT_NEAR_(pt1.global.x, pt2.global.x, 1e-6);
     ASSERT_EQUAL_(pt1.globalIdx, pt2.globalIdx);
 
-    const auto& w1 = p1.point_weights[0];
-    const auto& w2 = p2.point_weights[0];
-    ASSERT_EQUAL_(w1.first, w2.first);
-    ASSERT_NEAR_(w1.second, w2.second, 1e-6);
-
     std::cout << "[Test Passed] Pairings Serialization\n";
+}
+
+void test_Pairings_BackwardCompatDeserialization()
+{
+    // Manually craft a v2-format stream (as produced before
+    // Pairings::point_weights was removed) to check that old serialized
+    // icplog files can still be read.
+    mrpt::io::CMemoryStream mem;
+    auto                    arch = mrpt::serialization::archiveFrom(mem);
+
+    mrpt::tfest::TMatchingPairList pt2pt;
+    {
+        mrpt::tfest::TMatchingPair pair;
+        pair.global = {1.0, 2.0, 3.0};
+        pair.local  = {1.1, 2.1, 3.1};
+        pt2pt.push_back(pair);
+    }
+    MatchedPointLineList  pt2ln;
+    MatchedPointPlaneList pt2pl;
+    MatchedLineList       ln2ln;
+    MatchedPlaneList      pl2pl;
+    // Old-format per-point weights block, no longer used by current code:
+    std::vector<std::pair<std::size_t, double>> point_weights;
+    point_weights.emplace_back(1, 2.5);
+    const uint64_t          potential_pairings = 42;
+    MatchedPointWithCovList cov2cov;
+
+    arch.WriteAs<uint8_t>(2);  // old SERIALIZATION_VERSION
+    arch << pt2pt;
+    arch << pt2ln << pt2pl << ln2ln << pl2pl << point_weights;
+    arch << potential_pairings;
+    arch << cov2cov;
+
+    mem.Seek(0);
+    Pairings p;
+    arch >> p;  // must not throw despite the now-removed point_weights block
+
+    ASSERT_EQUAL_(p.paired_pt2pt.size(), 1ULL);
+    ASSERT_EQUAL_(p.potential_pairings, 42ULL);
+
+    std::cout << "[Test Passed] Pairings backward-compat deserialization (v2)\n";
 }
 
 void test_Pairings_PushBack()
@@ -254,6 +289,7 @@ int main()
     try
     {
         test_Pairings_Serialization();
+        test_Pairings_BackwardCompatDeserialization();
         test_Pairings_PushBack();
         test_Pairings_Viz();
         return 0;


### PR DESCRIPTION
## Summary

`Pairings::point_weights` fed a sequential run-length-encoded "cursor" (a block of `(count, weight)` pairs, one block per matched point layer) that `optimal_tf_gauss_newton.cpp` consumed from **inside a `tbb::parallel_reduce` lambda captured by reference**. Multiple worker threads processed disjoint point-index sub-ranges concurrently while mutating the same shared cursor state (`cur_point_block_weights`, `cur_point_block_start`, `w.pt2pt`), causing a data race. The cursor was also never reset across the outer Gauss-Newton `maxInnerLoopIterations` loop, so with more than one inner iteration it would resume already exhausted.

Net effect: the per-layer `weight:` field under a matcher's `pointLayerMatches` (the only producer of `Pairings::point_weights`, via `Matcher_Points_Base.cpp`) was silently unreliable in any TBB build — verified empirically by sweeping the weight value across 5 orders of magnitude with no meaningful effect on the optimizer output, while the equivalent scalar channel (`PairWeights::pt2pt`, no cursor) produced the expected large swings.

`visit_correspondences.h` (used by the closed-form Horn/OLAE solvers) has the identical cursor pattern, but is safe there since it only ever runs as a plain sequential loop, never under TBB.

## Fix

Rather than making the cursor thread-safe, this drops per-point/per-layer pt2pt weighting entirely:
- Every `pointLayerMatches` block in every in-tree pipeline config pairs exactly one local/global layer with a single weight, so the finer-grained-than-`PairWeights::pt2pt` capability was never actually exercised.
- All pt2pt pairings now use the single `PairWeights::pt2pt` scalar weight, same as every other pairing type (pt2ln, pt2pl, ln2ln, pl2pl).
- `Matcher_Points_Base` keeps `pointLayerMatches` for selecting *which* local/global layers to pair (renamed internal member `weight_pt2pt_layers` → `pt2pt_layer_matches`, now a plain layer-name set), just without a per-entry weight. Existing YAML configs that still specify `weight: ...` continue to parse fine — the key is just ignored.
- `Pairings::point_weights` removed. Serialization version bumped 2 → 3; older archives (icplogs) still deserialize correctly, the now-removed field is read and discarded.

## Test plan
- [x] `colcon build --packages-select mp2p_icp_core` — clean build
- [x] Full `ctest` suite in `mp2p_icp_core`: 106/106 passed
- [x] Added `test_Pairings_BackwardCompatDeserialization` to `test-mp2p_Pairings.cpp`, manually crafting a v2-format byte stream (with a populated `point_weights` block) to confirm old serialized files still load correctly
- [x] `clang-format-14` clean on all touched files

https://claude.ai/code/session_018nDh7qanq9kVJc6asdRJze

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Point-layer matching now supports explicit global-to-local layer mappings.
  * Point-to-point correspondences use a single configured pair weight source (no longer per-correspondence block weights).

* **Bug Fixes**
  * Improved backward compatibility when loading older serialized pairing data.

* **Documentation**
  * Updated matcher configuration references and YAML examples to use the current `pt2pt_layer_matches` setting (and legacy `weight` usage guidance).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->