### PR TITLE
Record the GravityPrior in .icplog files

### DIFF
--- a/mp2p_icp_core/mp2p_icp/CMakeLists.txt
+++ b/mp2p_icp_core/mp2p_icp/CMakeLists.txt
@@ -7,6 +7,7 @@ set(lib_name mp2p_icp) # we cannot use PROJECT_NAME here, since catkin requires 
 set(LIB_SRCS
   src/covariance.cpp
   src/errorTerms.cpp
+  src/GravityPrior.cpp
   src/icp_pipeline_from_yaml.cpp
   src/ICP.cpp
   src/LogRecord.cpp

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/GravityPrior.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/GravityPrior.h
@@ -20,6 +20,8 @@
 #pragma once
 
 #include <mrpt/math/TPoint3D.h>  // TVector3D
+#include <mrpt/serialization/CArchive.h>
+#include <mrpt/typemeta/TTypeName.h>
 
 namespace mp2p_icp
 {
@@ -70,8 +72,23 @@ struct GravityPrior
     /** Standard deviation [rad] of the tilt observation. Smaller means a
      *  stronger, closer-to-mandatory leveling constraint. */
     double sigma_rad = 0.02;
+
+    DECLARE_TTYPENAME_CLASSNAME(mp2p_icp::GravityPrior)
 };
 
 /** @} */
 
 }  // namespace mp2p_icp
+
+namespace mrpt::serialization
+{
+/** Serialization of mp2p_icp::GravityPrior, so that the verticality
+ *  observation actually handed to the solver can be recovered from an
+ *  `.icplog` afterwards. Without it the only way to know the effective
+ *  `sigma_rad` (which `adaptive_sigma` changes at run time) is to re-run with
+ *  debug-level logging enabled.
+ */
+CArchive& operator<<(CArchive& out, const mp2p_icp::GravityPrior& obj);
+CArchive& operator>>(CArchive& in, mp2p_icp::GravityPrior& obj);
+
+}  // namespace mrpt::serialization

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/LogRecord.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/LogRecord.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 
+#include <mp2p_icp/GravityPrior.h>
 #include <mp2p_icp/Pairings.h>
 #include <mp2p_icp/Parameters.h>
 #include <mp2p_icp/Results.h>
@@ -56,6 +57,14 @@ class LogRecord : public mrpt::serialization::CSerializable
 
     /** Optional prior pose constraint passed to align(). */
     std::optional<mrpt::poses::CPose3DPDFGaussianInf> prior;
+
+    /** Optional gravity ("verticality") observation passed to align().
+     *  Recorded because its effective `sigma_rad` is not necessarily the
+     *  configured one: callers may widen it at run time (e.g. mola_lidar_odometry's
+     *  `adaptive_sigma`), so the strength the solver actually saw cannot be
+     *  reconstructed from the configuration alone.
+     */
+    std::optional<GravityPrior> gravityPrior;
 
     mp2p_icp::Parameters          icpParameters;
     mp2p_icp::Results             icpResult;

--- a/mp2p_icp_core/mp2p_icp/src/GravityPrior.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/GravityPrior.cpp
@@ -1,0 +1,46 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/**
+ * @file   GravityPrior.cpp
+ * @brief  Yaw-free, rank-2 gravity ("verticality") observation for solvers
+ * @author Jose Luis Blanco Claraco
+ */
+
+#include <mp2p_icp/GravityPrior.h>
+
+namespace mrpt::serialization
+{
+CArchive& operator<<(CArchive& out, const mp2p_icp::GravityPrior& obj)
+{
+    out.WriteAs<uint8_t>(0);  // serialization version
+    out << obj.up_body << obj.up_map << obj.sigma_rad;
+    return out;
+}
+
+CArchive& operator>>(CArchive& in, mp2p_icp::GravityPrior& obj)
+{
+    const auto version = in.ReadAs<uint8_t>();
+    switch (version)
+    {
+        case 0:
+            in >> obj.up_body >> obj.up_map >> obj.sigma_rad;
+            break;
+        default:
+            MRPT_THROW_UNKNOWN_SERIALIZATION_VERSION(version);
+    }
+    return in;
+}
+
+}  // namespace mrpt::serialization

--- a/mp2p_icp_core/mp2p_icp/src/ICP.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/ICP.cpp
@@ -77,6 +77,7 @@ void ICP::align(
         currentLog->pcLocal                    = pcLocal.get_shared_from_this_or_clone();
         currentLog->initialGuessLocalWrtGlobal = initialGuessLocalWrtGlobal;
         currentLog->prior                      = prior;
+        currentLog->gravityPrior               = gravityPrior;
         currentLog->icpParameters              = p;
     }
 

--- a/mp2p_icp_core/mp2p_icp/src/LogRecord.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/LogRecord.cpp
@@ -32,7 +32,7 @@ IMPLEMENTS_MRPT_OBJECT(LogRecord, mrpt::serialization::CSerializable, mp2p_icp)
 using namespace mp2p_icp;
 
 // Implementation of the CSerializable virtual interface:
-uint8_t LogRecord::serializeGetVersion() const { return 2; }
+uint8_t LogRecord::serializeGetVersion() const { return 3; }
 void    LogRecord::serializeTo(mrpt::serialization::CArchive& out) const
 {
     if (pcGlobal)
@@ -59,6 +59,7 @@ void    LogRecord::serializeTo(mrpt::serialization::CArchive& out) const
     out << iterationsDetails;
     out << dynamicVariables;  // added in v1
     out << prior;  // added in v2
+    out << gravityPrior;  // added in v3
 }
 void LogRecord::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version)
 {
@@ -69,6 +70,7 @@ void LogRecord::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version
         case 0:
         case 1:
         case 2:
+        case 3:
         {
             if (in.ReadAs<bool>())
             {
@@ -99,6 +101,15 @@ void LogRecord::serializeFrom(mrpt::serialization::CArchive& in, uint8_t version
             else
             {
                 prior.reset();
+            }
+
+            if (version >= 3)
+            {
+                in >> gravityPrior;
+            }
+            else
+            {
+                gravityPrior.reset();
             }
         }
         break;


### PR DESCRIPTION
### Problem

`mp2p_icp::GravityPrior` is passed to `ICP::align()` but never serialized into `LogRecord`, so the verticality observation the solver actually received cannot be recovered from an `.icplog`.

This is not just completeness: the effective `sigma_rad` is **not** necessarily the configured one. `mola_lidar_odometry` widens it at run time via `adaptive_sigma`, and on a real handheld sequence the value handed to the solver turned out to be 3.00 deg median (p90 4.11) against a configured 2.00 - a 2.2x difference in the prior's information. Today the only way to see that is to re-run the dataset with `-v DEBUG` and scrape the log line.

### Changes

- `CArchive` operators for `GravityPrior`, plus `DECLARE_TTYPENAME_CLASSNAME` (required by `optional_serialization.h`).
- New `LogRecord::gravityPrior`, serialization version **2 -> 3**. Backwards compatible: the field is read only when `version >= 3`, so existing logs still load.
- Populated in `ICP::align()` alongside the existing motion `prior`.

### Testing

Built and exercised end to end on Oxford Spires with `mola_lidar_odometry`: a small dumper reads back `up_body`, `up_map` and `sigma_deg` from fresh logs, including the "prior absent" case (which also made visible that the prior is inactive on ~46% of scans on that sequence - a separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wsds3kySAXdSQm8DKZKGcz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gravity-prior information to alignment logs when available.
  * Gravity-prior observations can now be saved and restored with log records.
* **Compatibility**
  * Existing log records remain supported; records created before this update load without gravity-prior data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->