### PR TITLE
Port mm-viewer and icp-log-viewer from nanogui to Dear ImGui

### DIFF
--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -1,7 +1,7 @@
 # Based on GTSAM file (by @ProfFan)
 name: CI Build colcon
 
-on: [ push ]
+on: [push]
 
 jobs:
   build_docker:
@@ -43,7 +43,7 @@ jobs:
             ros_distribution: jazzy
             use_ros_testing: true
             disable_tbb: true
-            
+
             # Rolling Ridley (No End-Of-Life)
             # TODO: migrate to ubuntu:resolute once rolling packages are published there.
             # Track: https://discourse.openrobotics.org/t/preparing-for-rolling-sync-2026-04-23/54223

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ install_manifest.txt
 !.vscode/settings.json
 **/.vscode
 .cache
+
+# Dear ImGui per-app docking layout, written next to the CWD the GUI apps are launched from
+*.imgui.ini

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "3rdparty/robin-map"]
 	path = mp2p_icp_core/3rdparty/robin-map
 	url = https://github.com/Tessil/robin-map.git
+[submodule "mp2p_icp_viz/3rdparty/imgui"]
+	path = mp2p_icp_viz/3rdparty/imgui
+	url = https://github.com/ocornut/imgui.git
+	branch = docking

--- a/agents.md
+++ b/agents.md
@@ -143,7 +143,8 @@ Exports WGS-84 lon/lat/alt with EPSG:4979 WKT2 CRS embedded as VLR.
 ## GUI apps: Dear ImGui port (in progress)
 
 `mm-viewer` and `icp-log-viewer` (`mp2p_icp_viz`) are being migrated from `mrpt::gui::CDisplayWindowGUI`
-+ nanogui to Dear ImGui (docking branch). See `~/plans/mp2p_icp_imgui_port.md` for the full plan/status.
++ nanogui to Dear ImGui (docking branch). The phased plan/status is tracked outside this repository
+by the maintainer.
 
 - Dear ImGui is vendored **once** as a git submodule at `mp2p_icp_viz/3rdparty/imgui` (docking
   branch), built as a private static lib (`mp2p_icp_viz/3rdparty/imgui_static/`, target
@@ -153,8 +154,10 @@ Exports WGS-84 lon/lat/alt with EPSG:4979 WKT2 CRS embedded as VLR.
   context/docking main-loop boilerplate, with a `setupDefaultLayout` hook so each app defines its
   own default panel arrangement) and `SimpleFileDialog` (self-contained ImGui file browser for
   Open/Export, no native/system dialog dependency).
-- 3D rendering goes through `mrpt::imgui::CImGuiSceneView` (ships with `mrpt::gui` &ge; 2.15.19),
-  which renders an `mrpt::opengl::Scene` into an ImGui panel with built-in orbit/pan/zoom.
+- 3D rendering goes through `mrpt::imgui::CImGuiSceneView` (part of `mrpt_imgui`, available since
+  MRPT &ge; 2.15.11), which renders an `mrpt::opengl::Scene` into an ImGui panel with built-in
+  orbit/pan/zoom. `mm-viewer`/`icp-log-viewer` include it unconditionally, so this is a hard
+  minimum for `mp2p_icp_viz` (higher than the `mp2p_icp_core` minimum above).
 
 **Known limitation, kept in the code on purpose:** the small axis-corner gizmo mini-viewports
 (`FIRST_MINI_VIEW_NAME`/`SECOND_MINI_VIEW_NAME` in `mm-viewer/main.cpp`, `MINI_VIEW_NAME` in

--- a/agents.md
+++ b/agents.md
@@ -156,11 +156,12 @@ Exports WGS-84 lon/lat/alt with EPSG:4979 WKT2 CRS embedded as VLR.
 - 3D rendering goes through `mrpt::imgui::CImGuiSceneView` (ships with `mrpt::gui` &ge; 2.15.19),
   which renders an `mrpt::opengl::Scene` into an ImGui panel with built-in orbit/pan/zoom.
 
-**Known limitation, kept in the code on purpose:** the small "Map frame"/"ENU frame" axis-corner
-gizmo mini-viewports (`FIRST_MINI_VIEW_NAME`/`SECOND_MINI_VIEW_NAME` in `mm-viewer/main.cpp`) are
-still created and kept in sync with the main camera every frame, but are **not currently visible**:
-under MRPT 2.x, `CImGuiSceneView::render()` only renders the scene's `"main"` viewport, not extra
-named ones. This project plans to move to MRPT 3.x soon, which is expected to support rendering
+**Known limitation, kept in the code on purpose:** the small axis-corner gizmo mini-viewports
+(`FIRST_MINI_VIEW_NAME`/`SECOND_MINI_VIEW_NAME` in `mm-viewer/main.cpp`, `MINI_VIEW_NAME` in
+`icp-log-viewer/main.cpp`) are still created and kept in sync with the main camera every frame in
+both apps, but are **not currently visible**: under MRPT 2.x, `CImGuiSceneView::render()` only
+renders the scene's `"main"` viewport, not extra named ones. This project plans to move to MRPT
+3.x soon, which is expected to support rendering
 arbitrary named viewports through the same mechanism — at that point this code should start working
 again unmodified. Do not remove it as dead code in the meantime.
 

--- a/agents.md
+++ b/agents.md
@@ -140,6 +140,32 @@ Exports WGS-84 lon/lat/alt with EPSG:4979 WKT2 CRS embedded as VLR.
 
 ---
 
+## GUI apps: Dear ImGui port (in progress)
+
+`mm-viewer` and `icp-log-viewer` (`mp2p_icp_viz`) are being migrated from `mrpt::gui::CDisplayWindowGUI`
++ nanogui to Dear ImGui (docking branch). See `~/plans/mp2p_icp_imgui_port.md` for the full plan/status.
+
+- Dear ImGui is vendored **once** as a git submodule at `mp2p_icp_viz/3rdparty/imgui` (docking
+  branch), built as a private static lib (`mp2p_icp_viz/3rdparty/imgui_static/`, target
+  `imgui::imgui`) that is never installed/exported — an internal build detail only, baked
+  statically into the app binaries.
+- Both apps share `mp2p_icp_viz/apps/imgui_app_common/`: `ImGuiAppShell` (GLFW window/GL
+  context/docking main-loop boilerplate, with a `setupDefaultLayout` hook so each app defines its
+  own default panel arrangement) and `SimpleFileDialog` (self-contained ImGui file browser for
+  Open/Export, no native/system dialog dependency).
+- 3D rendering goes through `mrpt::imgui::CImGuiSceneView` (ships with `mrpt::gui` &ge; 2.15.19),
+  which renders an `mrpt::opengl::Scene` into an ImGui panel with built-in orbit/pan/zoom.
+
+**Known limitation, kept in the code on purpose:** the small "Map frame"/"ENU frame" axis-corner
+gizmo mini-viewports (`FIRST_MINI_VIEW_NAME`/`SECOND_MINI_VIEW_NAME` in `mm-viewer/main.cpp`) are
+still created and kept in sync with the main camera every frame, but are **not currently visible**:
+under MRPT 2.x, `CImGuiSceneView::render()` only renders the scene's `"main"` viewport, not extra
+named ones. This project plans to move to MRPT 3.x soon, which is expected to support rendering
+arbitrary named viewports through the same mechanism — at that point this code should start working
+again unmodified. Do not remove it as dead code in the meantime.
+
+---
+
 ## ICP pipeline
 
 ```

--- a/agents.md
+++ b/agents.md
@@ -279,3 +279,11 @@ Tests use gtest. Each filter, matcher, solver, and serializer has its own test f
 
 - `mola_state_estimation/mola_georeferencing` — `mola-mm-add-geodetic` tool that adds per-point lat/lon/alt double fields to .mm layers (prerequisite for mm2las geodetic fast path)
 - `mola_lidar_odometry` — primary consumer of mp2p_icp for real-time SLAM
+
+---
+
+
+## MRPT3 to-do
+
+Once this package is ported to mrpt3, remove the dependency on glut / freeglut3-dev
+and remove this agents.md section entirely.

--- a/mp2p_icp_viz/3rdparty/imgui_static/CMakeLists.txt
+++ b/mp2p_icp_viz/3rdparty/imgui_static/CMakeLists.txt
@@ -1,0 +1,71 @@
+# ------------------------------------------------------------------------------
+# Static library target wrapping Dear ImGui (docking branch).
+#
+# Expected layout:
+#   <this file's parent>/../imgui/    <- git submodule (docking branch of
+#                                        https://github.com/ocornut/imgui)
+#
+# This target is purely an internal build detail of mp2p_icp_viz: it is
+# never install()'d or exported, and it is linked PRIVATE into the mm-viewer
+# and icp-log-viewer executables. "make install" only ships those two
+# binaries, never Dear ImGui's sources, headers, or this static library.
+# ------------------------------------------------------------------------------
+
+cmake_minimum_required(VERSION 3.22...3.31)
+project(imgui_static LANGUAGES CXX)
+
+get_filename_component(_IMGUI_ROOT
+    "${CMAKE_CURRENT_SOURCE_DIR}/../imgui" ABSOLUTE)
+
+if(NOT EXISTS "${_IMGUI_ROOT}/imgui.h")
+  message(FATAL_ERROR
+    "Dear ImGui submodule not found at ${_IMGUI_ROOT}.\n"
+    "Run:  git submodule update --init --recursive")
+endif()
+
+find_package(glfw3 REQUIRED)
+set(OpenGL_GL_PREFERENCE GLVND)
+find_package(OpenGL REQUIRED)
+
+set(_IMGUI_SRCS
+  ${_IMGUI_ROOT}/imgui.cpp
+  ${_IMGUI_ROOT}/imgui_draw.cpp
+  ${_IMGUI_ROOT}/imgui_tables.cpp
+  ${_IMGUI_ROOT}/imgui_widgets.cpp
+  ${_IMGUI_ROOT}/misc/cpp/imgui_stdlib.cpp  # std::string InputText support
+  ${_IMGUI_ROOT}/backends/imgui_impl_glfw.cpp
+  ${_IMGUI_ROOT}/backends/imgui_impl_opengl3.cpp
+)
+
+add_library(imgui_static STATIC ${_IMGUI_SRCS})
+set_target_properties(imgui_static PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+target_include_directories(imgui_static
+  PUBLIC
+    ${_IMGUI_ROOT}
+    ${_IMGUI_ROOT}/backends
+    ${_IMGUI_ROOT}/misc/cpp
+)
+
+# Enable the docking branch feature set.
+# No explicit loader macro: imgui_impl_opengl3 uses its bundled
+# imgui_impl_opengl3_loader.h (available since ImGui ~1.87), so we do not
+# need to find or link GLEW/GLAD/gl3w separately.
+target_compile_definitions(imgui_static
+  PUBLIC
+    IMGUI_ENABLE_DOCKING
+)
+
+target_link_libraries(imgui_static
+  PUBLIC
+    glfw
+    OpenGL::GL
+)
+
+# Suppress warnings from third-party code
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_compile_options(imgui_static PRIVATE -w)
+endif()
+
+# Export as an alias so parent CMake can use it as imgui::imgui
+add_library(imgui::imgui ALIAS imgui_static)

--- a/mp2p_icp_viz/CMakeLists.txt
+++ b/mp2p_icp_viz/CMakeLists.txt
@@ -24,6 +24,16 @@ find_package(mp2p_icp REQUIRED)
 
 find_package(Threads REQUIRED)
 
+# -- Dear ImGui static library (from 3rdparty submodule) ---------------------
+#
+# The submodule lives at:  3rdparty/imgui   (docking branch)
+# The helper CMakeLists that builds it as a static lib lives at:
+#   3rdparty/imgui_static/CMakeLists.txt
+#
+# Built here (once) and shared by both apps/mm-viewer and apps/icp-log-viewer.
+# Not installed: "imgui::imgui" is an internal build detail only.
+add_subdirectory(3rdparty/imgui_static imgui_static_build)
+
 #----
 # Extract version from package.xml
 file(READ package.xml contentPackageXML)

--- a/mp2p_icp_viz/apps/CMakeLists.txt
+++ b/mp2p_icp_viz/apps/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Shared Dear ImGui application shell (used by both apps below):
+add_subdirectory(imgui_app_common)
+
 # Apps:
 add_subdirectory(icp-log-viewer)
 add_subdirectory(mm-viewer)

--- a/mp2p_icp_viz/apps/icp-log-viewer/CMakeLists.txt
+++ b/mp2p_icp_viz/apps/icp-log-viewer/CMakeLists.txt
@@ -12,4 +12,5 @@ mola_add_executable(
     CLI11::CLI11
     mrpt::gui
     Threads::Threads
+    imgui_app_common
   )

--- a/mp2p_icp_viz/apps/icp-log-viewer/main.cpp
+++ b/mp2p_icp_viz/apps/icp-log-viewer/main.cpp
@@ -159,7 +159,7 @@ struct AppState
     bool        viewPairingsCov2Cov  = true;
     float       pairingsPl2PlSize    = -1.0f;
     float       pairingsPl2LnSize    = -1.0f;
-    float       pairingsCov2CovDecim = 500.0f;  // stored as log10, see slider range below
+    float       pairingsCov2CovDecim = 2.7f;  // stored as log10 (~500), see slider range below
     std::string pairingsSummary      = "None selected (mark one of the checkboxes below)";
 
     // Manual pose tweak (6-DoF):
@@ -186,6 +186,11 @@ struct AppState
     int                            exportWhich = 0;  // 0=local, 1=global
 
     std::optional<size_t> lastIdx;
+
+    // Set when DelayedLoadLog::get() throws for this index, so rebuild_3d_view()/onExport()/
+    // renderManualPanel() don't keep retrying (and re-logging) a load failure every single
+    // frame. Reset whenever the selected index changes.
+    std::optional<size_t> loadFailedIdx;
 };
 
 AppState app;
@@ -327,12 +332,29 @@ try
             app.logRecords.at(*app.lastIdx).dispose();
         }
         app.lastIdx = idx;
+        app.loadFailedIdx.reset();
+    }
+
+    if (app.loadFailedIdx.has_value() && *app.loadFailedIdx == idx)
+    {
+        return;  // already failed to load this record; don't retry (and re-log) every frame
     }
 
     app.glVizICP->clear();
 
     // lazy load from disk happens in the "get()":
     const auto& lr = app.logRecords.at(idx).get();
+
+    if (indexChanged)
+    {
+        // Seed the manual-nudge sliders from this record's own pose, instead of leaving
+        // whatever the previous record's edits left behind (or all-zeros on first load).
+        const auto p = lr.icpResult.optimal_tf.mean.asTPose();
+        for (int i = 0; i < 6; i++)
+        {
+            app.gtPose[i] = static_cast<float>(p[i]);
+        }
+    }
 
     app.statFileName = app.logRecords.at(idx).shortFileName();
 
@@ -626,10 +648,12 @@ try
 catch (const std::exception& e)
 {
     std::cerr << "[rebuild_3d_view] Exception: " << mrpt::exception_to_str(e) << std::endl;
-    app.statFileName = std::string("ERROR: ") + mrpt::exception_to_str(e).substr(0, 80);
+    app.statFileName  = std::string("ERROR: ") + mrpt::exception_to_str(e).substr(0, 80);
+    app.loadFailedIdx = static_cast<size_t>(app.selectorIdx);
 }
 
 void onExport(const std::string& outFile)
+try
 {
     const size_t idx = static_cast<size_t>(app.selectorIdx);
     auto&        lr  = app.logRecords.at(idx).get();
@@ -639,6 +663,10 @@ void onExport(const std::string& outFile)
     {
         std::cerr << "Error saving file: " << outFile << "\n";
     }
+}
+catch (const std::exception& e)
+{
+    std::cerr << "[onExport] Exception: " << mrpt::exception_to_str(e) << std::endl;
 }
 
 /** "Control" window: file selector, navigation, iteration slider, summary stat lines. */
@@ -751,11 +779,6 @@ void renderMapsPanel()
         app.exportDialog.open(
             mp2p_icp_viz::SimpleFileDialog::Mode::Save, {{"mm", "(*.mm)"}}, "Export global map");
     }
-    if (auto path = app.exportDialog.render(); path.has_value())
-    {
-        onExport(*path);
-    }
-
     ImGui::Separator();
     ImGui::TextUnformatted("[GLOBAL map] Visible layers:");
     ImGui::PushID("globalLayers");
@@ -844,20 +867,40 @@ void renderManualPanel()
         4.0f, 4.0f, 10.0f, 0.5f * static_cast<float>(M_PI), 0.25f * static_cast<float>(M_PI), 0.5f};
     constexpr const char* labels[6] = {"X", "Y", "Z", "Yaw", "Pitch", "Roll"};
 
-    const size_t idx = static_cast<size_t>(app.selectorIdx);
+    const size_t idx        = static_cast<size_t>(app.selectorIdx);
+    const bool   loadFailed = app.loadFailedIdx.has_value() && *app.loadFailedIdx == idx;
     for (int i = 0; i < 6; i++)
     {
         if (ImGui::SliderFloat(labels[i], &app.gtPose[i], -handTunedRange[i], handTunedRange[i]) &&
-            idx < app.logRecords.size())
+            idx < app.logRecords.size() && !loadFailed)
         {
-            auto& lr                     = app.logRecords.at(idx).get();
-            auto  p                      = lr.icpResult.optimal_tf.mean.asTPose();
-            p[i]                         = app.gtPose[i];
-            lr.icpResult.optimal_tf.mean = mrpt::poses::CPose3D(p);
+            try
+            {
+                auto& lr                     = app.logRecords.at(idx).get();
+                auto  p                      = lr.icpResult.optimal_tf.mean.asTPose();
+                p[i]                         = app.gtPose[i];
+                lr.icpResult.optimal_tf.mean = mrpt::poses::CPose3D(p);
+            }
+            catch (const std::exception& e)
+            {
+                std::cerr << "[renderManualPanel] Exception: " << mrpt::exception_to_str(e)
+                          << std::endl;
+            }
         }
     }
 
     ImGui::End();
+}
+
+/** Rendered at top level, outside any other window's Begin/End -- nesting it inside e.g. "Maps"
+ * would silently cancel an open dialog whenever that window is collapsed (BeginPopupModal()
+ * fails to start, which SimpleFileDialog::render() treats as a dismiss). */
+void renderFileDialogs()
+{
+    if (auto path = app.exportDialog.render(); path.has_value())
+    {
+        onExport(*path);
+    }
 }
 
 void renderSceneWindow()
@@ -880,6 +923,7 @@ void renderFrame()
     renderMapsPanel();
     renderPairingsPanel();
     renderViewPanel();
+    renderFileDialogs();
     renderManualPanel();
     renderSceneWindow();
 }
@@ -940,7 +984,7 @@ int mainShowGui()
         std::cout << "Quality filter: kept " << filteredFiles.size() << " / " << files.size()
                   << " files." << std::endl;
 
-        if (files.empty())
+        if (filteredFiles.empty())
         {
             THROW_EXCEPTION_FMT(
                 "No log files passed --min-quality=%.03f. Lower the threshold or check input logs.",
@@ -1029,6 +1073,11 @@ int mainShowGui()
     // Load/save persistent UI+camera state across sessions:
     char appCfgFile[1024];
     ::get_user_config_file(appCfgFile, sizeof(appCfgFile), APP_NAME);
+    if (appCfgFile[0] == '\0')
+    {
+        std::cerr << "Warning: could not determine a user config file path; "
+                     "UI/camera settings will not be persisted.\n";
+    }
     mrpt::config::CConfigFile appCfg(appCfgFile);
 
     auto& cam              = app.sceneView.camera();

--- a/mp2p_icp_viz/apps/icp-log-viewer/main.cpp
+++ b/mp2p_icp_viz/apps/icp-log-viewer/main.cpp
@@ -30,6 +30,10 @@
 #include <mrpt/imgui/CImGuiSceneView.h>
 
 // other deps:
+#include <imgui.h>
+#include <imgui_app_common/ImGuiAppShell.h>
+#include <imgui_app_common/SimpleFileDialog.h>
+#include <imgui_internal.h>  // DockBuilder* API (default docking layout)
 #include <mrpt/config.h>
 #include <mrpt/config/CConfigFile.h>
 #include <mrpt/core/Clock.h>
@@ -46,11 +50,6 @@
 #include <mrpt/system/os.h>
 #include <mrpt/system/progress.h>
 #include <mrpt/system/string_utils.h>  // unitsFormat()
-
-#include <imgui.h>
-#include <imgui_app_common/ImGuiAppShell.h>
-#include <imgui_app_common/SimpleFileDialog.h>
-#include <imgui_internal.h>  // DockBuilder* API (default docking layout)
 
 #include <CLI/CLI.hpp>
 #include <iostream>
@@ -77,116 +76,116 @@ CLI::Option* argMinQualityOpt  = nullptr;
 /** Lazily loads a *.icplog file on first access, and can drop it again to free memory. */
 class DelayedLoadLog
 {
- public:
-  DelayedLoadLog() = default;
-  DelayedLoadLog(const std::string& fileName, const std::string& shortFileName)
-      : filename_(fileName), shortFileName_(shortFileName)
-  {
-  }
-
-  mp2p_icp::LogRecord& get()
-  {
-    if (!log_)
+   public:
+    DelayedLoadLog() = default;
+    DelayedLoadLog(const std::string& fileName, const std::string& shortFileName)
+        : filename_(fileName), shortFileName_(shortFileName)
     {
-      log_.emplace();
-      if (!log_->load_from_file(filename_))
-      {
-        log_.reset();
-        THROW_EXCEPTION_FMT("Failed to load log file: '%s'", filename_.c_str());
-      }
     }
 
-    return log_.value();
-  }
+    mp2p_icp::LogRecord& get()
+    {
+        if (!log_)
+        {
+            log_.emplace();
+            if (!log_->load_from_file(filename_))
+            {
+                log_.reset();
+                THROW_EXCEPTION_FMT("Failed to load log file: '%s'", filename_.c_str());
+            }
+        }
 
-  void dispose() { log_.reset(); }
+        return log_.value();
+    }
 
-  const std::string& filename() const { return filename_; }
-  const std::string& shortFileName() const { return shortFileName_; }
+    void dispose() { log_.reset(); }
 
- private:
-  std::optional<mp2p_icp::LogRecord> log_;
-  std::string                        filename_;
-  std::string                        shortFileName_;
+    const std::string& filename() const { return filename_; }
+    const std::string& shortFileName() const { return shortFileName_; }
+
+   private:
+    std::optional<mp2p_icp::LogRecord> log_;
+    std::string                        filename_;
+    std::string                        shortFileName_;
 };
 
 /** All mutable application state (see the analogous struct in mm-viewer/main.cpp for the same
  *  immediate-mode-GUI rationale). */
 struct AppState
 {
-  mp2p_icp_viz::ImGuiAppShell  shell;
-  mrpt::imgui::CImGuiSceneView sceneView;
-  mrpt::opengl::Scene::Ptr     scene    = mrpt::opengl::COpenGLScene::Create();
-  mrpt::opengl::CSetOfObjects::Ptr glVizICP = mrpt::opengl::CSetOfObjects::Create();
+    mp2p_icp_viz::ImGuiAppShell      shell;
+    mrpt::imgui::CImGuiSceneView     sceneView;
+    mrpt::opengl::Scene::Ptr         scene    = mrpt::opengl::COpenGLScene::Create();
+    mrpt::opengl::CSetOfObjects::Ptr glVizICP = mrpt::opengl::CSetOfObjects::Create();
 
-  std::vector<DelayedLoadLog> logRecords;
+    std::vector<DelayedLoadLog> logRecords;
 
-  std::vector<std::string> layerNamesGlobal;
-  std::vector<std::string> layerNamesLocal;
+    std::vector<std::string> layerNamesGlobal;
+    std::vector<std::string> layerNamesLocal;
 
-  std::map<std::string, bool> layerVisibleGlobal;
-  std::map<std::string, bool> layerVisibleLocal;
+    std::map<std::string, bool> layerVisibleGlobal;
+    std::map<std::string, bool> layerVisibleLocal;
 
-  // Selector / navigation:
-  int    selectorIdx       = 0;
-  bool   isAutoPlayActive  = false;
-  double lastAutoPlayTime  = 0.0;
+    // Selector / navigation:
+    int    selectorIdx      = 0;
+    bool   isAutoPlayActive = false;
+    double lastAutoPlayTime = 0.0;
 
-  // ICP iteration slider:
-  bool  showInitialPose     = false;
-  float iterationValue      = 0.0f;
-  int   iterationMax         = 0;
-  bool  iterationEnabled     = false;
-  std::string iterationCaption = "Show ICP iteration:";
+    // ICP iteration slider:
+    bool        showInitialPose  = false;
+    float       iterationValue   = 0.0f;
+    int         iterationMax     = 0;
+    bool        iterationEnabled = false;
+    std::string iterationCaption = "Show ICP iteration:";
 
-  // View options:
-  bool  viewOrtho           = false;
-  bool  cameraFollowsLocal  = false;
-  bool  viewVoxelsAsPoints  = true;
-  bool  viewVoxelsFreeSpace = false;
-  bool  colorizeLocalMap    = false;
-  bool  colorizeGlobalMap   = false;
-  bool  viewPriorEllipsoid  = true;
-  float globalPointSize     = 2.0f;
-  float localPointSize      = 2.0f;
-  float midDepthField       = 1.0f;
-  float thicknessDepthField = 3.0f;
+    // View options:
+    bool  viewOrtho           = false;
+    bool  cameraFollowsLocal  = false;
+    bool  viewVoxelsAsPoints  = true;
+    bool  viewVoxelsFreeSpace = false;
+    bool  colorizeLocalMap    = false;
+    bool  colorizeGlobalMap   = false;
+    bool  viewPriorEllipsoid  = true;
+    float globalPointSize     = 2.0f;
+    float localPointSize      = 2.0f;
+    float midDepthField       = 1.0f;
+    float thicknessDepthField = 3.0f;
 
-  // Pairings:
-  bool  viewPairings           = false;
-  bool  viewPairingsPt2Pt      = true;
-  bool  viewPairingsPt2Pl      = true;
-  bool  viewPairingsPt2Ln      = true;
-  bool  viewPairingsCov2Cov    = true;
-  float pairingsPl2PlSize      = -1.0f;
-  float pairingsPl2LnSize      = -1.0f;
-  float pairingsCov2CovDecim   = 500.0f;  // stored as log10, see slider range below
-  std::string pairingsSummary  = "None selected (mark one of the checkboxes below)";
+    // Pairings:
+    bool        viewPairings         = false;
+    bool        viewPairingsPt2Pt    = true;
+    bool        viewPairingsPt2Pl    = true;
+    bool        viewPairingsPt2Ln    = true;
+    bool        viewPairingsCov2Cov  = true;
+    float       pairingsPl2PlSize    = -1.0f;
+    float       pairingsPl2LnSize    = -1.0f;
+    float       pairingsCov2CovDecim = 500.0f;  // stored as log10, see slider range below
+    std::string pairingsSummary      = "None selected (mark one of the checkboxes below)";
 
-  // Manual pose tweak (6-DoF):
-  float gtPose[6] = {0, 0, 0, 0, 0, 0};
+    // Manual pose tweak (6-DoF):
+    float gtPose[6] = {0, 0, 0, 0, 0, 0};
 
-  // Text/stat fields:
-  std::string statFileName;
-  std::string statLogSummary;
-  std::string statQuality;
-  std::string statGlobalSummary;
-  std::string statLocalSummary;
-  std::string statInitialGuess;
-  std::string statPriorMean       = "(none)";
-  std::string statPriorInfo       = "(none)";
-  std::string statLogPose;
-  std::string statInit2Final;
-  std::string statCovariance;
-  std::string statConditionNumber;
+    // Text/stat fields:
+    std::string statFileName;
+    std::string statLogSummary;
+    std::string statQuality;
+    std::string statGlobalSummary;
+    std::string statLocalSummary;
+    std::string statInitialGuess;
+    std::string statPriorMean = "(none)";
+    std::string statPriorInfo = "(none)";
+    std::string statLogPose;
+    std::string statInit2Final;
+    std::string statCovariance;
+    std::string statConditionNumber;
 
-  static constexpr size_t          kMaxDynVariables = 100;
-  std::vector<std::string>         dynVariableLines;
+    static constexpr size_t  kMaxDynVariables = 100;
+    std::vector<std::string> dynVariableLines;
 
-  mp2p_icp_viz::SimpleFileDialog exportDialog;
-  int                             exportWhich = 0;  // 0=local, 1=global
+    mp2p_icp_viz::SimpleFileDialog exportDialog;
+    int                            exportWhich = 0;  // 0=local, 1=global
 
-  std::optional<size_t> lastIdx;
+    std::optional<size_t> lastIdx;
 };
 
 AppState app;
@@ -194,30 +193,30 @@ AppState app;
 template <class MATRIX>
 double conditionNumber(const MATRIX& m)
 {
-  MATRIX              eVecs;
-  std::vector<double> eVals;
-  m.eig_symmetric(eVecs, eVals);
-  return eVals.back() / eVals.front();
+    MATRIX              eVecs;
+    std::vector<double> eVals;
+    m.eig_symmetric(eVecs, eVals);
+    return eVals.back() / eVals.front();
 }
 
 void processAutoPlay()
 {
-  if (!app.isAutoPlayActive)
-  {
-    return;
-  }
+    if (!app.isAutoPlayActive)
+    {
+        return;
+    }
 
-  const double tNow = mrpt::Clock::nowDouble();
-  if (tNow - app.lastAutoPlayTime < argAutoPlayPeriod)
-  {
-    return;
-  }
-  app.lastAutoPlayTime = tNow;
+    const double tNow = mrpt::Clock::nowDouble();
+    if (tNow - app.lastAutoPlayTime < argAutoPlayPeriod)
+    {
+        return;
+    }
+    app.lastAutoPlayTime = tNow;
 
-  if (app.selectorIdx < static_cast<int>(app.logRecords.size()) - 1)
-  {
-    app.selectorIdx++;
-  }
+    if (app.selectorIdx < static_cast<int>(app.logRecords.size()) - 1)
+    {
+        app.selectorIdx++;
+    }
 }
 
 /** Creates the small XYZ axis-corner overlay viewport once. See the note in agents.md: not
@@ -225,84 +224,84 @@ void processAutoPlay()
  * for when this project moves to MRPT 3.x. */
 void ensureMiniCornerViewport()
 {
-  if (app.scene->getViewport(MINI_VIEW_NAME))
-  {
-    return;
-  }
+    if (app.scene->getViewport(MINI_VIEW_NAME))
+    {
+        return;
+    }
 
-  auto gl_view = app.scene->createViewport(MINI_VIEW_NAME);
-  gl_view->setViewportPosition(0, 0, 0.1, 0.1 * 16.0 / 9.0);
-  gl_view->setTransparent(true);
-  {
-    mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("X");
-    obj->setLocation(1.1, 0, 0);
-    gl_view->insert(obj);
-  }
-  {
-    mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Y");
-    obj->setLocation(0, 1.1, 0);
-    gl_view->insert(obj);
-  }
-  {
-    mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Z");
-    obj->setLocation(0, 0, 1.1);
-    gl_view->insert(obj);
-  }
-  gl_view->insert(mrpt::opengl::stock_objects::CornerXYZ());
+    auto gl_view = app.scene->createViewport(MINI_VIEW_NAME);
+    gl_view->setViewportPosition(0, 0, 0.1, 0.1 * 16.0 / 9.0);
+    gl_view->setTransparent(true);
+    {
+        mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("X");
+        obj->setLocation(1.1, 0, 0);
+        gl_view->insert(obj);
+    }
+    {
+        mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Y");
+        obj->setLocation(0, 1.1, 0);
+        gl_view->insert(obj);
+    }
+    {
+        mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Z");
+        obj->setLocation(0, 0, 1.1);
+        gl_view->insert(obj);
+    }
+    gl_view->insert(mrpt::opengl::stock_objects::CornerXYZ());
 }
 
 void updateMiniCornerView()
 {
-  auto gl_view = app.scene->getViewport(MINI_VIEW_NAME);
-  if (!gl_view)
-  {
-    return;
-  }
-  mrpt::opengl::CCamera& view_cam = gl_view->getCamera();
-  view_cam.setAzimuthDegrees(app.sceneView.camera().getAzimuthDegrees());
-  view_cam.setElevationDegrees(app.sceneView.camera().getElevationDegrees());
-  view_cam.setZoomDistance(5);
+    auto gl_view = app.scene->getViewport(MINI_VIEW_NAME);
+    if (!gl_view)
+    {
+        return;
+    }
+    mrpt::opengl::CCamera& view_cam = gl_view->getCamera();
+    view_cam.setAzimuthDegrees(app.sceneView.camera().getAzimuthDegrees());
+    view_cam.setElevationDegrees(app.sceneView.camera().getElevationDegrees());
+    view_cam.setZoomDistance(5);
 }
 
 void handleKeyboard()
 {
-  ImGuiIO& io = ImGui::GetIO();
-  if (io.WantTextInput)
-  {
-    return;
-  }
+    ImGuiIO& io = ImGui::GetIO();
+    if (io.WantTextInput)
+    {
+        return;
+    }
 
-  int increment = 0;
-  if (ImGui::IsKeyPressed(ImGuiKey_LeftArrow, true))
-  {
-    increment = -1;
-  }
-  if (ImGui::IsKeyPressed(ImGuiKey_RightArrow, true))
-  {
-    increment = +1;
-  }
-  if (ImGui::IsKeyPressed(ImGuiKey_PageDown, true))
-  {
-    increment = +100;
-  }
-  if (ImGui::IsKeyPressed(ImGuiKey_PageUp, true))
-  {
-    increment = -100;
-  }
-  if (ImGui::IsKeyPressed(ImGuiKey_Space, false))
-  {
-    app.isAutoPlayActive = !app.isAutoPlayActive;
-  }
-  if (ImGui::IsKeyPressed(ImGuiKey_I, false))
-  {
-    app.showInitialPose = !app.showInitialPose;
-  }
+    int increment = 0;
+    if (ImGui::IsKeyPressed(ImGuiKey_LeftArrow, true))
+    {
+        increment = -1;
+    }
+    if (ImGui::IsKeyPressed(ImGuiKey_RightArrow, true))
+    {
+        increment = +1;
+    }
+    if (ImGui::IsKeyPressed(ImGuiKey_PageDown, true))
+    {
+        increment = +100;
+    }
+    if (ImGui::IsKeyPressed(ImGuiKey_PageUp, true))
+    {
+        increment = -100;
+    }
+    if (ImGui::IsKeyPressed(ImGuiKey_Space, false))
+    {
+        app.isAutoPlayActive = !app.isAutoPlayActive;
+    }
+    if (ImGui::IsKeyPressed(ImGuiKey_I, false))
+    {
+        app.showInitialPose = !app.showInitialPose;
+    }
 
-  if (increment != 0)
-  {
-    app.selectorIdx =
-        std::clamp(app.selectorIdx + increment, 0, static_cast<int>(app.logRecords.size()) - 1);
-  }
+    if (increment != 0)
+    {
+        app.selectorIdx =
+            std::clamp(app.selectorIdx + increment, 0, static_cast<int>(app.logRecords.size()) - 1);
+    }
 }
 
 /** Equivalent to the old `rebuild_3d_view(bool regenerateMaps)`: called unconditionally every
@@ -312,821 +311,833 @@ void handleKeyboard()
 void rebuild_3d_view()
 try
 {
-  using namespace std::string_literals;
+    using namespace std::string_literals;
 
-  const size_t idx = static_cast<size_t>(app.selectorIdx);
-  if (idx >= app.logRecords.size())
-  {
-    return;
-  }
-
-  const bool indexChanged = !app.lastIdx.has_value() || *app.lastIdx != idx;
-  if (indexChanged)
-  {
-    if (app.lastIdx.has_value())
+    const size_t idx = static_cast<size_t>(app.selectorIdx);
+    if (idx >= app.logRecords.size())
     {
-      app.logRecords.at(*app.lastIdx).dispose();
+        return;
     }
-    app.lastIdx = idx;
-  }
 
-  app.glVizICP->clear();
-
-  // lazy load from disk happens in the "get()":
-  const auto& lr = app.logRecords.at(idx).get();
-
-  app.statFileName = app.logRecords.at(idx).shortFileName();
-
-  app.statLogSummary = mrpt::format(
-      "ICP log #%zu | Local: ID:%u%s | Global: ID:%u%s", idx,
-      static_cast<unsigned int>(lr.pcLocal->id ? lr.pcLocal->id.value() : 0),
-      lr.pcLocal->label ? lr.pcLocal->label.value().c_str() : "",
-      static_cast<unsigned int>(lr.pcGlobal->id ? lr.pcGlobal->id.value() : 0),
-      lr.pcGlobal->label ? lr.pcGlobal->label.value().c_str() : "");
-
-  app.statQuality = mrpt::format(
-      "Quality: %.02f%% | Iters: %u | Term.Reason: %s", 100.0 * lr.icpResult.quality,
-      static_cast<unsigned int>(lr.icpResult.nIterations),
-      mrpt::typemeta::enum2str(lr.icpResult.terminationReason).c_str());
-
-  app.statGlobalSummary = "Global: "s + lr.pcGlobal->contents_summary();
-  app.statLocalSummary  = "Local: "s + lr.pcLocal->contents_summary();
-
-  app.statInitialGuess = lr.initialGuessLocalWrtGlobal.asString();
-
-  if (lr.prior.has_value())
-  {
-    app.statPriorMean = lr.prior->mean.asString();
-
-    std::string s;
-    const auto  cov = mrpt::math::CMatrixDouble66(lr.prior->cov_inv.inverse());
-    for (int i = 0; i < 6; i++)
+    const bool indexChanged = !app.lastIdx.has_value() || *app.lastIdx != idx;
+    if (indexChanged)
     {
-      const auto sigma = std::sqrt(cov(i, i));
-      s += (i < 3) ? mrpt::format("%.02fm ", sigma) : mrpt::format("%.02fd ", mrpt::RAD2DEG(sigma));
+        if (app.lastIdx.has_value())
+        {
+            app.logRecords.at(*app.lastIdx).dispose();
+        }
+        app.lastIdx = idx;
     }
-    app.statPriorInfo = s;
-  }
-  else
-  {
-    app.statPriorMean = "(none)";
-    app.statPriorInfo = "(none)";
-  }
 
-  app.statLogPose = lr.icpResult.optimal_tf.mean.asString();
+    app.glVizICP->clear();
 
-  // dyn variables:
-  app.dynVariableLines.clear();
-  for (const auto& [name, value] : lr.dynamicVariables)
-  {
-    app.dynVariableLines.push_back(mrpt::format("%s = %g", name.c_str(), value));
-    if (app.dynVariableLines.size() >= AppState::kMaxDynVariables)
+    // lazy load from disk happens in the "get()":
+    const auto& lr = app.logRecords.at(idx).get();
+
+    app.statFileName = app.logRecords.at(idx).shortFileName();
+
+    app.statLogSummary = mrpt::format(
+        "ICP log #%zu | Local: ID:%u%s | Global: ID:%u%s", idx,
+        static_cast<unsigned int>(lr.pcLocal->id ? lr.pcLocal->id.value() : 0),
+        lr.pcLocal->label ? lr.pcLocal->label.value().c_str() : "",
+        static_cast<unsigned int>(lr.pcGlobal->id ? lr.pcGlobal->id.value() : 0),
+        lr.pcGlobal->label ? lr.pcGlobal->label.value().c_str() : "");
+
+    app.statQuality = mrpt::format(
+        "Quality: %.02f%% | Iters: %u | Term.Reason: %s", 100.0 * lr.icpResult.quality,
+        static_cast<unsigned int>(lr.icpResult.nIterations),
+        mrpt::typemeta::enum2str(lr.icpResult.terminationReason).c_str());
+
+    app.statGlobalSummary = "Global: "s + lr.pcGlobal->contents_summary();
+    app.statLocalSummary  = "Local: "s + lr.pcLocal->contents_summary();
+
+    app.statInitialGuess = lr.initialGuessLocalWrtGlobal.asString();
+
+    if (lr.prior.has_value())
     {
-      break;
-    }
-  }
+        app.statPriorMean = lr.prior->mean.asString();
 
-  {
-    const auto poseChange =
-        lr.icpResult.optimal_tf.mean - mrpt::poses::CPose3D(lr.initialGuessLocalWrtGlobal);
-
-    app.statInit2Final = mrpt::format(
-        "|T|=%.03f [m]  |R|=%.03f [deg]", poseChange.norm(),
-        mrpt::RAD2DEG(mrpt::poses::Lie::SO<3>::log(poseChange.getRotationMatrix()).norm()));
-  }
-
-  const auto                      poseFromCorner = mrpt::poses::CPose3D::Identity();
-  mrpt::poses::CPose3DPDFGaussian relativePose;
-  const mp2p_icp::Pairings*       pairsToViz = nullptr;
-
-  if (!lr.iterationsDetails.has_value() || lr.iterationsDetails->empty())
-  {
-    app.iterationEnabled = false;
-
-    if (app.showInitialPose)
-    {
-      relativePose.mean  = mrpt::poses::CPose3D(lr.initialGuessLocalWrtGlobal);
-      app.iterationCaption = "Show ICP iteration: INITIAL";
+        std::string s;
+        const auto  cov = mrpt::math::CMatrixDouble66(lr.prior->cov_inv.inverse());
+        for (int i = 0; i < 6; i++)
+        {
+            const auto sigma = std::sqrt(cov(i, i));
+            s += (i < 3) ? mrpt::format("%.02fm ", sigma)
+                         : mrpt::format("%.02fd ", mrpt::RAD2DEG(sigma));
+        }
+        app.statPriorInfo = s;
     }
     else
     {
-      relativePose        = lr.icpResult.optimal_tf;
-      app.iterationCaption = "Show ICP iteration: FINAL";
+        app.statPriorMean = "(none)";
+        app.statPriorInfo = "(none)";
     }
 
-    if (app.viewPairings)
+    app.statLogPose = lr.icpResult.optimal_tf.mean.asString();
+
+    // dyn variables:
+    app.dynVariableLines.clear();
+    for (const auto& [name, value] : lr.dynamicVariables)
     {
-      pairsToViz = &lr.icpResult.finalPairings;
+        app.dynVariableLines.push_back(mrpt::format("%s = %g", name.c_str(), value));
+        if (app.dynVariableLines.size() >= AppState::kMaxDynVariables)
+        {
+            break;
+        }
     }
-  }
-  else
-  {
-    app.iterationEnabled = true;
-    app.iterationMax     = static_cast<int>(lr.iterationsDetails->size()) - 1;
 
-    if (indexChanged)
     {
-      app.iterationValue = app.showInitialPose ? 0.0f : static_cast<float>(app.iterationMax);
+        const auto poseChange =
+            lr.icpResult.optimal_tf.mean - mrpt::poses::CPose3D(lr.initialGuessLocalWrtGlobal);
+
+        app.statInit2Final = mrpt::format(
+            "|T|=%.03f [m]  |R|=%.03f [deg]", poseChange.norm(),
+            mrpt::RAD2DEG(mrpt::poses::Lie::SO<3>::log(poseChange.getRotationMatrix()).norm()));
     }
 
-    auto   it    = lr.iterationsDetails->begin();
-    size_t nIter = mrpt::round(app.iterationValue);
-    mrpt::keep_min(nIter, lr.iterationsDetails->size() - 1);
-    std::advance(it, static_cast<std::ptrdiff_t>(nIter));
+    const auto                      poseFromCorner = mrpt::poses::CPose3D::Identity();
+    mrpt::poses::CPose3DPDFGaussian relativePose;
+    const mp2p_icp::Pairings*       pairsToViz = nullptr;
 
-    relativePose.mean = it->second.optimalPose;
-    if (app.viewPairings)
+    if (!lr.iterationsDetails.has_value() || lr.iterationsDetails->empty())
     {
-      pairsToViz = &it->second.pairings;
+        app.iterationEnabled = false;
+
+        if (app.showInitialPose)
+        {
+            relativePose.mean    = mrpt::poses::CPose3D(lr.initialGuessLocalWrtGlobal);
+            app.iterationCaption = "Show ICP iteration: INITIAL";
+        }
+        else
+        {
+            relativePose         = lr.icpResult.optimal_tf;
+            app.iterationCaption = "Show ICP iteration: FINAL";
+        }
+
+        if (app.viewPairings)
+        {
+            pairsToViz = &lr.icpResult.finalPairings;
+        }
     }
-
-    app.iterationCaption = "Show ICP iteration: "s + std::to_string(it->first) + "/"s +
-                            std::to_string(lr.iterationsDetails->rbegin()->first);
-  }
-
-  {
-    std::string s;
-    for (int i = 0; i < 6; i++)
+    else
     {
-      const auto sigma = std::sqrt(relativePose.cov(i, i));
-      s += (i < 3) ? mrpt::format("%.02fm ", sigma) : mrpt::format("%.02fd ", mrpt::RAD2DEG(sigma));
+        app.iterationEnabled = true;
+        app.iterationMax     = static_cast<int>(lr.iterationsDetails->size()) - 1;
+
+        if (indexChanged)
+        {
+            app.iterationValue = app.showInitialPose ? 0.0f : static_cast<float>(app.iterationMax);
+        }
+
+        auto   it    = lr.iterationsDetails->begin();
+        size_t nIter = mrpt::round(app.iterationValue);
+        mrpt::keep_min(nIter, lr.iterationsDetails->size() - 1);
+        std::advance(it, static_cast<std::ptrdiff_t>(nIter));
+
+        relativePose.mean = it->second.optimalPose;
+        if (app.viewPairings)
+        {
+            pairsToViz = &it->second.pairings;
+        }
+
+        app.iterationCaption = "Show ICP iteration: "s + std::to_string(it->first) + "/"s +
+                               std::to_string(lr.iterationsDetails->rbegin()->first);
     }
-    s += mrpt::format(
-        " det(XYZ)=%.02e det(rot)=%.02e", relativePose.cov.blockCopy<3, 3>(0, 0).det(),
-        relativePose.cov.blockCopy<3, 3>(3, 3).det());
-    app.statCovariance = s;
-  }
 
-  const mrpt::poses::CPosePDFGaussian pose2D(relativePose);
-
-  app.statConditionNumber = mrpt::format(
-      " cn{XYZ}=%.02f cn{SO(3)}=%.02f cn{SE(2)}=%.02f cn{SE(3)}=%.02f",
-      conditionNumber(relativePose.cov.blockCopy<3, 3>(0, 0)),
-      conditionNumber(relativePose.cov.blockCopy<3, 3>(3, 3)), conditionNumber(pose2D.cov),
-      conditionNumber(relativePose.cov));
-
-  // 3D objects -------------------
-  auto glCornerFrom = mrpt::opengl::stock_objects::CornerXYZSimple(0.75f, 3.0f);
-  glCornerFrom->setPose(poseFromCorner);
-  app.glVizICP->insert(glCornerFrom);
-
-  auto glCornerLocal = mrpt::opengl::stock_objects::CornerXYZSimple(0.85f, 5.0f);
-  glCornerLocal->setPose(relativePose.mean);
-  glCornerLocal->setName("Local");
-  glCornerLocal->enableShowName(true);
-  app.glVizICP->insert(glCornerLocal);
-
-  auto glCornerToCov = mrpt::opengl::CEllipsoid3D::Create();
-  glCornerToCov->set3DsegmentsCount(16);
-  glCornerToCov->enableDrawSolid3D(true);
-  glCornerToCov->setColor_u8(0xff, 0x00, 0x00, 0x40);
-  glCornerToCov->setCovMatrixAndMean(
-      relativePose.cov.blockCopy<3, 3>(0, 0), relativePose.mean.asVectorVal().head<3>());
-  app.glVizICP->insert(glCornerToCov);
-
-  if (lr.prior.has_value() && app.viewPriorEllipsoid)
-  {
-    const auto priorCov = mrpt::math::CMatrixDouble66(lr.prior->cov_inv.inverse());
-
-    auto glPriorEllipsoid = mrpt::opengl::CEllipsoid3D::Create();
-    glPriorEllipsoid->set3DsegmentsCount(16);
-    glPriorEllipsoid->enableDrawSolid3D(true);
-    glPriorEllipsoid->setColor_u8(0xff, 0xff, 0x00, 0x50);
-    glPriorEllipsoid->setCovMatrixAndMean(
-        priorCov.blockCopy<3, 3>(0, 0), lr.prior->mean.asVectorVal().head<3>());
-    glPriorEllipsoid->setName("Prior");
-    glPriorEllipsoid->enableShowName(true);
-    app.glVizICP->insert(glPriorEllipsoid);
-  }
-
-  // GLOBAL PC:
-  mp2p_icp::render_params_t rpGlobal;
-  rpGlobal.points.visible = false;
-  for (const auto& lyName : app.layerNamesGlobal)
-  {
-    if (!app.layerVisibleGlobal[lyName])
     {
-      continue;
+        std::string s;
+        for (int i = 0; i < 6; i++)
+        {
+            const auto sigma = std::sqrt(relativePose.cov(i, i));
+            s += (i < 3) ? mrpt::format("%.02fm ", sigma)
+                         : mrpt::format("%.02fd ", mrpt::RAD2DEG(sigma));
+        }
+        s += mrpt::format(
+            " det(XYZ)=%.02e det(rot)=%.02e", relativePose.cov.blockCopy<3, 3>(0, 0).det(),
+            relativePose.cov.blockCopy<3, 3>(3, 3).det());
+        app.statCovariance = s;
     }
-    rpGlobal.points.visible = true;
 
-    auto& rpL                       = rpGlobal.points.perLayer[lyName];
-    rpL.pointSize                   = app.globalPointSize;
-    rpL.render_voxelmaps_as_points  = app.viewVoxelsAsPoints;
-    rpL.render_voxelmaps_free_space = app.viewVoxelsFreeSpace;
+    const mrpt::poses::CPosePDFGaussian pose2D(relativePose);
 
-    if (app.colorizeGlobalMap)
+    app.statConditionNumber = mrpt::format(
+        " cn{XYZ}=%.02f cn{SO(3)}=%.02f cn{SE(2)}=%.02f cn{SE(3)}=%.02f",
+        conditionNumber(relativePose.cov.blockCopy<3, 3>(0, 0)),
+        conditionNumber(relativePose.cov.blockCopy<3, 3>(3, 3)), conditionNumber(pose2D.cov),
+        conditionNumber(relativePose.cov));
+
+    // 3D objects -------------------
+    auto glCornerFrom = mrpt::opengl::stock_objects::CornerXYZSimple(0.75f, 3.0f);
+    glCornerFrom->setPose(poseFromCorner);
+    app.glVizICP->insert(glCornerFrom);
+
+    auto glCornerLocal = mrpt::opengl::stock_objects::CornerXYZSimple(0.85f, 5.0f);
+    glCornerLocal->setPose(relativePose.mean);
+    glCornerLocal->setName("Local");
+    glCornerLocal->enableShowName(true);
+    app.glVizICP->insert(glCornerLocal);
+
+    auto glCornerToCov = mrpt::opengl::CEllipsoid3D::Create();
+    glCornerToCov->set3DsegmentsCount(16);
+    glCornerToCov->enableDrawSolid3D(true);
+    glCornerToCov->setColor_u8(0xff, 0x00, 0x00, 0x40);
+    glCornerToCov->setCovMatrixAndMean(
+        relativePose.cov.blockCopy<3, 3>(0, 0), relativePose.mean.asVectorVal().head<3>());
+    app.glVizICP->insert(glCornerToCov);
+
+    if (lr.prior.has_value() && app.viewPriorEllipsoid)
     {
-      auto& cm             = rpL.colorMode.emplace();
-      cm.colorMap          = mrpt::img::TColormap::cmHOT;
-      cm.recolorizeByField = "z";
+        const auto priorCov = mrpt::math::CMatrixDouble66(lr.prior->cov_inv.inverse());
+
+        auto glPriorEllipsoid = mrpt::opengl::CEllipsoid3D::Create();
+        glPriorEllipsoid->set3DsegmentsCount(16);
+        glPriorEllipsoid->enableDrawSolid3D(true);
+        glPriorEllipsoid->setColor_u8(0xff, 0xff, 0x00, 0x50);
+        glPriorEllipsoid->setCovMatrixAndMean(
+            priorCov.blockCopy<3, 3>(0, 0), lr.prior->mean.asVectorVal().head<3>());
+        glPriorEllipsoid->setName("Prior");
+        glPriorEllipsoid->enableShowName(true);
+        app.glVizICP->insert(glPriorEllipsoid);
     }
-  }
-  for (auto& rpL : rpGlobal.points.perLayer)
-  {
-    rpL.second.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0xff);
-  }
-  rpGlobal.points.allLayers.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0xff);
 
-  static std::optional<mp2p_icp::render_params_t> prevRpGlobal;
-  static mrpt::opengl::CSetOfObjects::Ptr          lastGlobalPts;
-
-  if (indexChanged || !prevRpGlobal.has_value() || *prevRpGlobal != rpGlobal)
-  {
-    prevRpGlobal  = rpGlobal;
-    lastGlobalPts = lr.pcGlobal->get_visualization(rpGlobal);
-  }
-  app.glVizICP->insert(lastGlobalPts);
-
-  // LOCAL PC:
-  mp2p_icp::render_params_t rpLocal;
-  rpLocal.points.visible = false;
-  for (const auto& lyName : app.layerNamesLocal)
-  {
-    if (!app.layerVisibleLocal[lyName])
+    // GLOBAL PC:
+    mp2p_icp::render_params_t rpGlobal;
+    rpGlobal.points.visible = false;
+    for (const auto& lyName : app.layerNamesGlobal)
     {
-      continue;
+        if (!app.layerVisibleGlobal[lyName])
+        {
+            continue;
+        }
+        rpGlobal.points.visible = true;
+
+        auto& rpL                       = rpGlobal.points.perLayer[lyName];
+        rpL.pointSize                   = app.globalPointSize;
+        rpL.render_voxelmaps_as_points  = app.viewVoxelsAsPoints;
+        rpL.render_voxelmaps_free_space = app.viewVoxelsFreeSpace;
+
+        if (app.colorizeGlobalMap)
+        {
+            auto& cm             = rpL.colorMode.emplace();
+            cm.colorMap          = mrpt::img::TColormap::cmHOT;
+            cm.recolorizeByField = "z";
+        }
     }
-    rpLocal.points.visible = true;
-
-    auto& rpL                       = rpLocal.points.perLayer[lyName];
-    rpL.pointSize                   = app.localPointSize;
-    rpL.render_voxelmaps_as_points  = app.viewVoxelsAsPoints;
-    rpL.render_voxelmaps_free_space = app.viewVoxelsFreeSpace;
-
-    if (app.colorizeLocalMap)
+    for (auto& rpL : rpGlobal.points.perLayer)
     {
-      auto& cm             = rpL.colorMode.emplace();
-      cm.colorMap          = mrpt::img::TColormap::cmHOT;
-      cm.recolorizeByField = "z";
+        rpL.second.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0xff);
     }
-  }
-  for (auto& rpL : rpLocal.points.perLayer)
-  {
-    rpL.second.color = mrpt::img::TColor(0x00, 0x00, 0xff, 0xff);
-  }
+    rpGlobal.points.allLayers.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0xff);
 
-  static std::optional<mp2p_icp::render_params_t> prevRpLocal;
-  static mrpt::opengl::CSetOfObjects::Ptr          lastLocalPts;
+    static std::optional<mp2p_icp::render_params_t> prevRpGlobal;
+    static mrpt::opengl::CSetOfObjects::Ptr         lastGlobalPts;
 
-  if (indexChanged || !prevRpLocal.has_value() || *prevRpLocal != rpLocal)
-  {
-    prevRpLocal  = rpLocal;
-    lastLocalPts = lr.pcLocal->get_visualization(rpLocal);
-  }
-  app.glVizICP->insert(lastLocalPts);
-  lastLocalPts->setPose(relativePose.mean);
+    if (indexChanged || !prevRpGlobal.has_value() || *prevRpGlobal != rpGlobal)
+    {
+        prevRpGlobal  = rpGlobal;
+        lastGlobalPts = lr.pcGlobal->get_visualization(rpGlobal);
+    }
+    app.glVizICP->insert(lastGlobalPts);
 
-  // Global view options:
-  auto& cam = app.sceneView.camera();
-  cam.setProjectiveModel(!app.viewOrtho);
+    // LOCAL PC:
+    mp2p_icp::render_params_t rpLocal;
+    rpLocal.points.visible = false;
+    for (const auto& lyName : app.layerNamesLocal)
+    {
+        if (!app.layerVisibleLocal[lyName])
+        {
+            continue;
+        }
+        rpLocal.points.visible = true;
 
-  if (app.cameraFollowsLocal)
-  {
-    const auto camLoc = relativePose.mean.translation().cast<float>();
-    cam.setPointingAt(camLoc.x, camLoc.y, camLoc.z);
-  }
+        auto& rpL                       = rpLocal.points.perLayer[lyName];
+        rpL.pointSize                   = app.localPointSize;
+        rpL.render_voxelmaps_as_points  = app.viewVoxelsAsPoints;
+        rpL.render_voxelmaps_free_space = app.viewVoxelsFreeSpace;
 
-  const auto depthFieldMid       = std::pow(10.0, app.midDepthField);
-  const auto depthFieldThickness = std::pow(10.0, app.thicknessDepthField);
-  const auto clipNear            = std::max(1e-2, depthFieldMid - 0.5 * depthFieldThickness);
-  const auto clipFar             = depthFieldMid + 0.5 * depthFieldThickness;
+        if (app.colorizeLocalMap)
+        {
+            auto& cm             = rpL.colorMode.emplace();
+            cm.colorMap          = mrpt::img::TColormap::cmHOT;
+            cm.recolorizeByField = "z";
+        }
+    }
+    for (auto& rpL : rpLocal.points.perLayer)
+    {
+        rpL.second.color = mrpt::img::TColor(0x00, 0x00, 0xff, 0xff);
+    }
 
-  app.scene->getViewport("main")->setViewportClipDistances(
-      static_cast<float>(clipNear), static_cast<float>(clipFar));
+    static std::optional<mp2p_icp::render_params_t> prevRpLocal;
+    static mrpt::opengl::CSetOfObjects::Ptr         lastLocalPts;
 
-  // Pairings ------------------
-  if (pairsToViz)
-  {
-    const double planeCovScale = std::pow(10.0, app.pairingsPl2PlSize);
+    if (indexChanged || !prevRpLocal.has_value() || *prevRpLocal != rpLocal)
+    {
+        prevRpLocal  = rpLocal;
+        lastLocalPts = lr.pcLocal->get_visualization(rpLocal);
+    }
+    app.glVizICP->insert(lastLocalPts);
+    lastLocalPts->setPose(relativePose.mean);
 
-    mp2p_icp::pairings_render_params_t rp;
-    rp.pt2pt.visible        = app.viewPairingsPt2Pt;
-    rp.pt2pl.visible        = app.viewPairingsPt2Pl;
-    rp.pt2pl.planePatchSize = planeCovScale;
+    // Global view options:
+    auto& cam = app.sceneView.camera();
+    cam.setProjectiveModel(!app.viewOrtho);
 
-    rp.cov2cov.visible    = app.viewPairingsCov2Cov;
-    rp.cov2cov.decimation = static_cast<std::size_t>(std::pow(10.0, app.pairingsCov2CovDecim));
-    rp.cov2cov.covScale   = planeCovScale;
+    if (app.cameraFollowsLocal)
+    {
+        const auto camLoc = relativePose.mean.translation().cast<float>();
+        cam.setPointingAt(camLoc.x, camLoc.y, camLoc.z);
+    }
 
-    rp.pt2ln.visible    = app.viewPairingsPt2Ln;
-    rp.pt2ln.lineLength = std::pow(10.0, app.pairingsPl2LnSize);
+    const auto depthFieldMid       = std::pow(10.0, app.midDepthField);
+    const auto depthFieldThickness = std::pow(10.0, app.thicknessDepthField);
+    const auto clipNear            = std::max(1e-2, depthFieldMid - 0.5 * depthFieldThickness);
+    const auto clipFar             = depthFieldMid + 0.5 * depthFieldThickness;
 
-    app.glVizICP->insert(pairsToViz->get_visualization(relativePose.mean, rp));
-    app.pairingsSummary = pairsToViz->contents_summary();
-  }
-  else
-  {
-    app.pairingsSummary = "None selected (mark one of the checkboxes below)";
-  }
+    app.scene->getViewport("main")->setViewportClipDistances(
+        static_cast<float>(clipNear), static_cast<float>(clipFar));
 
-  ensureMiniCornerViewport();
+    // Pairings ------------------
+    if (pairsToViz)
+    {
+        const double planeCovScale = std::pow(10.0, app.pairingsPl2PlSize);
+
+        mp2p_icp::pairings_render_params_t rp;
+        rp.pt2pt.visible        = app.viewPairingsPt2Pt;
+        rp.pt2pl.visible        = app.viewPairingsPt2Pl;
+        rp.pt2pl.planePatchSize = planeCovScale;
+
+        rp.cov2cov.visible    = app.viewPairingsCov2Cov;
+        rp.cov2cov.decimation = static_cast<std::size_t>(std::pow(10.0, app.pairingsCov2CovDecim));
+        rp.cov2cov.covScale   = planeCovScale;
+
+        rp.pt2ln.visible    = app.viewPairingsPt2Ln;
+        rp.pt2ln.lineLength = std::pow(10.0, app.pairingsPl2LnSize);
+
+        app.glVizICP->insert(pairsToViz->get_visualization(relativePose.mean, rp));
+        app.pairingsSummary = pairsToViz->contents_summary();
+    }
+    else
+    {
+        app.pairingsSummary = "None selected (mark one of the checkboxes below)";
+    }
+
+    ensureMiniCornerViewport();
 }
 catch (const std::exception& e)
 {
-  std::cerr << "[rebuild_3d_view] Exception: " << mrpt::exception_to_str(e) << std::endl;
-  app.statFileName = std::string("ERROR: ") + mrpt::exception_to_str(e).substr(0, 80);
+    std::cerr << "[rebuild_3d_view] Exception: " << mrpt::exception_to_str(e) << std::endl;
+    app.statFileName = std::string("ERROR: ") + mrpt::exception_to_str(e).substr(0, 80);
 }
 
 void onExport(const std::string& outFile)
 {
-  const size_t idx = static_cast<size_t>(app.selectorIdx);
-  auto&        lr  = app.logRecords.at(idx).get();
+    const size_t idx = static_cast<size_t>(app.selectorIdx);
+    auto&        lr  = app.logRecords.at(idx).get();
 
-  const mp2p_icp::metric_map_t& m = (app.exportWhich == 0) ? *lr.pcLocal : *lr.pcGlobal;
-  if (bool ok = m.save_to_file(outFile); !ok)
-  {
-    std::cerr << "Error saving file: " << outFile << "\n";
-  }
+    const mp2p_icp::metric_map_t& m = (app.exportWhich == 0) ? *lr.pcLocal : *lr.pcGlobal;
+    if (bool ok = m.save_to_file(outFile); !ok)
+    {
+        std::cerr << "Error saving file: " << outFile << "\n";
+    }
 }
 
 /** "Control" window: file selector, navigation, iteration slider, summary stat lines. */
 void renderControlPanel()
 {
-  ImGui::Begin("Control");
+    ImGui::Begin("Control");
 
-  ImGui::Checkbox("Show at INITIAL GUESS pose", &app.showInitialPose);
+    ImGui::Checkbox("Show at INITIAL GUESS pose", &app.showInitialPose);
 
-  ImGui::BeginDisabled(!app.iterationEnabled);
-  ImGui::TextUnformatted(app.iterationCaption.c_str());
-  ImGui::SetNextItemWidth(-1);
-  ImGui::SliderFloat("##iterationSlider", &app.iterationValue, 0.0f, static_cast<float>(std::max(0, app.iterationMax)));
-  ImGui::EndDisabled();
+    ImGui::BeginDisabled(!app.iterationEnabled);
+    ImGui::TextUnformatted(app.iterationCaption.c_str());
+    ImGui::SetNextItemWidth(-1);
+    ImGui::SliderFloat(
+        "##iterationSlider", &app.iterationValue, 0.0f,
+        static_cast<float>(std::max(0, app.iterationMax)));
+    ImGui::EndDisabled();
 
-  ImGui::Separator();
-  ImGui::Text("Select ICP record file (N=%u)", static_cast<unsigned int>(app.logRecords.size()));
-  ImGui::SetNextItemWidth(-1);
-  ImGui::SliderInt("##selectorIdx", &app.selectorIdx, 0, static_cast<int>(app.logRecords.size()) - 1);
+    ImGui::Separator();
+    ImGui::Text("Select ICP record file (N=%u)", static_cast<unsigned int>(app.logRecords.size()));
+    ImGui::SetNextItemWidth(-1);
+    ImGui::SliderInt(
+        "##selectorIdx", &app.selectorIdx, 0, static_cast<int>(app.logRecords.size()) - 1);
 
-  ImGui::TextUnformatted(app.statFileName.c_str());
-  ImGui::TextUnformatted(app.statLogSummary.c_str());
-  ImGui::TextUnformatted(app.statQuality.c_str());
-  ImGui::TextWrapped("%s", app.statGlobalSummary.c_str());
-  ImGui::TextWrapped("%s", app.statLocalSummary.c_str());
+    ImGui::TextUnformatted(app.statFileName.c_str());
+    ImGui::TextUnformatted(app.statLogSummary.c_str());
+    ImGui::TextUnformatted(app.statQuality.c_str());
+    ImGui::TextWrapped("%s", app.statGlobalSummary.c_str());
+    ImGui::TextWrapped("%s", app.statLocalSummary.c_str());
 
-  ImGui::BeginDisabled(app.selectorIdx <= 0);
-  if (ImGui::Button("<<"))
-  {
-    app.selectorIdx--;
-  }
-  ImGui::EndDisabled();
-  ImGui::SameLine();
-  ImGui::BeginDisabled(app.selectorIdx >= static_cast<int>(app.logRecords.size()) - 1);
-  if (ImGui::Button(">>"))
-  {
-    app.selectorIdx++;
-  }
-  ImGui::EndDisabled();
-  ImGui::SameLine();
-  ImGui::Checkbox("Autoplay", &app.isAutoPlayActive);
+    ImGui::BeginDisabled(app.selectorIdx <= 0);
+    if (ImGui::Button("<<"))
+    {
+        app.selectorIdx--;
+    }
+    ImGui::EndDisabled();
+    ImGui::SameLine();
+    ImGui::BeginDisabled(app.selectorIdx >= static_cast<int>(app.logRecords.size()) - 1);
+    if (ImGui::Button(">>"))
+    {
+        app.selectorIdx++;
+    }
+    ImGui::EndDisabled();
+    ImGui::SameLine();
+    ImGui::Checkbox("Autoplay", &app.isAutoPlayActive);
 
-  ImGui::End();
+    ImGui::End();
 }
 
 /** "Summary" window: ICP result pose, deltas, covariance, prior. */
 void renderSummaryPanel()
 {
-  ImGui::Begin("Summary");
+    ImGui::Begin("Summary");
 
-  ImGui::TextUnformatted("ICP result pose [x y z yaw(deg) pitch(deg) roll(deg)]:");
-  ImGui::TextWrapped("%s", app.statLogPose.c_str());
+    ImGui::TextUnformatted("ICP result pose [x y z yaw(deg) pitch(deg) roll(deg)]:");
+    ImGui::TextWrapped("%s", app.statLogPose.c_str());
 
-  ImGui::TextUnformatted("Initial -> final pose change:");
-  ImGui::TextWrapped("%s", app.statInit2Final.c_str());
+    ImGui::TextUnformatted("Initial -> final pose change:");
+    ImGui::TextWrapped("%s", app.statInit2Final.c_str());
 
-  ImGui::TextUnformatted("Uncertainty: diagonal sigmas (x y z [m] yaw pitch roll [deg])");
-  ImGui::TextWrapped("%s", app.statCovariance.c_str());
+    ImGui::TextUnformatted("Uncertainty: diagonal sigmas (x y z [m] yaw pitch roll [deg])");
+    ImGui::TextWrapped("%s", app.statCovariance.c_str());
 
-  ImGui::TextUnformatted("Uncertainty: Covariance condition numbers");
-  ImGui::TextWrapped("%s", app.statConditionNumber.c_str());
+    ImGui::TextUnformatted("Uncertainty: Covariance condition numbers");
+    ImGui::TextWrapped("%s", app.statConditionNumber.c_str());
 
-  ImGui::Separator();
-  ImGui::TextUnformatted("Initial guess pose:");
-  ImGui::TextWrapped("%s", app.statInitialGuess.c_str());
+    ImGui::Separator();
+    ImGui::TextUnformatted("Initial guess pose:");
+    ImGui::TextWrapped("%s", app.statInitialGuess.c_str());
 
-  ImGui::TextUnformatted("Prior mean pose (if any):");
-  ImGui::TextWrapped("%s", app.statPriorMean.c_str());
+    ImGui::TextUnformatted("Prior mean pose (if any):");
+    ImGui::TextWrapped("%s", app.statPriorMean.c_str());
 
-  ImGui::TextUnformatted("Prior: diagonal sigmas (x y z [m] yaw pitch roll [deg])");
-  ImGui::TextWrapped("%s", app.statPriorInfo.c_str());
+    ImGui::TextUnformatted("Prior: diagonal sigmas (x y z [m] yaw pitch roll [deg])");
+    ImGui::TextWrapped("%s", app.statPriorInfo.c_str());
 
-  ImGui::End();
+    ImGui::End();
 }
 
 /** "Variables" window: dynamic (YAML-expression) variables active in this ICP record. */
 void renderVariablesPanel()
 {
-  ImGui::Begin("Variables");
-  ImGui::TextUnformatted("Dynamic variables:");
-  if (ImGui::BeginChild("##dynVars", ImVec2(0, 0), true))
-  {
-    for (const auto& line : app.dynVariableLines)
+    ImGui::Begin("Variables");
+    ImGui::TextUnformatted("Dynamic variables:");
+    if (ImGui::BeginChild("##dynVars", ImVec2(0, 0), true))
     {
-      ImGui::TextUnformatted(line.c_str());
+        for (const auto& line : app.dynVariableLines)
+        {
+            ImGui::TextUnformatted(line.c_str());
+        }
     }
-  }
-  ImGui::EndChild();
-  ImGui::End();
+    ImGui::EndChild();
+    ImGui::End();
 }
 
 /** "Maps" window: global/local layer visibility + export buttons. */
 void renderMapsPanel()
 {
-  ImGui::Begin("Maps");
+    ImGui::Begin("Maps");
 
-  if (ImGui::Button("Export 'local' map..."))
-  {
-    app.exportWhich = 0;
-    app.exportDialog.open(mp2p_icp_viz::SimpleFileDialog::Mode::Save, {{"mm", "(*.mm)"}}, "Export local map");
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Export 'global' map..."))
-  {
-    app.exportWhich = 1;
-    app.exportDialog.open(mp2p_icp_viz::SimpleFileDialog::Mode::Save, {{"mm", "(*.mm)"}}, "Export global map");
-  }
-  if (auto path = app.exportDialog.render(); path.has_value())
-  {
-    onExport(*path);
-  }
+    if (ImGui::Button("Export 'local' map..."))
+    {
+        app.exportWhich = 0;
+        app.exportDialog.open(
+            mp2p_icp_viz::SimpleFileDialog::Mode::Save, {{"mm", "(*.mm)"}}, "Export local map");
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Export 'global' map..."))
+    {
+        app.exportWhich = 1;
+        app.exportDialog.open(
+            mp2p_icp_viz::SimpleFileDialog::Mode::Save, {{"mm", "(*.mm)"}}, "Export global map");
+    }
+    if (auto path = app.exportDialog.render(); path.has_value())
+    {
+        onExport(*path);
+    }
 
-  ImGui::Separator();
-  ImGui::TextUnformatted("[GLOBAL map] Visible layers:");
-  ImGui::PushID("globalLayers");
-  for (const auto& lyName : app.layerNamesGlobal)
-  {
-    ImGui::Checkbox(lyName.c_str(), &app.layerVisibleGlobal[lyName]);
-  }
-  ImGui::PopID();
+    ImGui::Separator();
+    ImGui::TextUnformatted("[GLOBAL map] Visible layers:");
+    ImGui::PushID("globalLayers");
+    for (const auto& lyName : app.layerNamesGlobal)
+    {
+        ImGui::Checkbox(lyName.c_str(), &app.layerVisibleGlobal[lyName]);
+    }
+    ImGui::PopID();
 
-  ImGui::Separator();
-  ImGui::TextUnformatted("[LOCAL map] Visible layers:");
-  ImGui::PushID("localLayers");
-  for (const auto& lyName : app.layerNamesLocal)
-  {
-    ImGui::Checkbox(lyName.c_str(), &app.layerVisibleLocal[lyName]);
-  }
-  ImGui::PopID();
+    ImGui::Separator();
+    ImGui::TextUnformatted("[LOCAL map] Visible layers:");
+    ImGui::PushID("localLayers");
+    for (const auto& lyName : app.layerNamesLocal)
+    {
+        ImGui::Checkbox(lyName.c_str(), &app.layerVisibleLocal[lyName]);
+    }
+    ImGui::PopID();
 
-  ImGui::End();
+    ImGui::End();
 }
 
 /** "Pairings" window: pairing type toggles, sizes/decimation, summary. */
 void renderPairingsPanel()
 {
-  ImGui::Begin("Pairings");
+    ImGui::Begin("Pairings");
 
-  ImGui::TextWrapped("%s", app.pairingsSummary.c_str());
+    ImGui::TextWrapped("%s", app.pairingsSummary.c_str());
 
-  ImGui::Checkbox("View pairings", &app.viewPairings);
+    ImGui::Checkbox("View pairings", &app.viewPairings);
 
-  ImGui::Checkbox("View: point-to-point", &app.viewPairingsPt2Pt);
+    ImGui::Checkbox("View: point-to-point", &app.viewPairingsPt2Pt);
 
-  ImGui::Checkbox("View: cov-to-cov", &app.viewPairingsCov2Cov);
-  ImGui::SameLine();
-  ImGui::SetNextItemWidth(140);
-  ImGui::SliderFloat("Decimation", &app.pairingsCov2CovDecim, 0.0f, 3.0f);
+    ImGui::Checkbox("View: cov-to-cov", &app.viewPairingsCov2Cov);
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(140);
+    ImGui::SliderFloat("Decimation", &app.pairingsCov2CovDecim, 0.0f, 3.0f);
 
-  ImGui::Checkbox("View: point-to-plane", &app.viewPairingsPt2Pl);
-  ImGui::SameLine();
-  ImGui::SetNextItemWidth(140);
-  ImGui::SliderFloat("Plane size", &app.pairingsPl2PlSize, -4.0f, 2.0f);
+    ImGui::Checkbox("View: point-to-plane", &app.viewPairingsPt2Pl);
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(140);
+    ImGui::SliderFloat("Plane size", &app.pairingsPl2PlSize, -4.0f, 2.0f);
 
-  ImGui::Checkbox("View: point-to-line", &app.viewPairingsPt2Ln);
-  ImGui::SameLine();
-  ImGui::SetNextItemWidth(140);
-  ImGui::SliderFloat("Line length", &app.pairingsPl2LnSize, -2.0f, 2.0f);
+    ImGui::Checkbox("View: point-to-line", &app.viewPairingsPt2Ln);
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(140);
+    ImGui::SliderFloat("Line length", &app.pairingsPl2LnSize, -2.0f, 2.0f);
 
-  ImGui::End();
+    ImGui::End();
 }
 
 /** "View" window: point sizes, depth clip, ortho, camera-follow, voxel/colorize options. */
 void renderViewPanel()
 {
-  ImGui::Begin("View");
+    ImGui::Begin("View");
 
-  ImGui::SliderFloat("Global map point size", &app.globalPointSize, 1.0f, 10.0f);
-  ImGui::SliderFloat("Local map point size", &app.localPointSize, 1.0f, 10.0f);
+    ImGui::SliderFloat("Global map point size", &app.globalPointSize, 1.0f, 10.0f);
+    ImGui::SliderFloat("Local map point size", &app.localPointSize, 1.0f, 10.0f);
 
-  ImGui::SliderFloat("Center depth clip plane", &app.midDepthField, -2.0f, 3.0f);
-  ImGui::SliderFloat("Max-Min depth thickness", &app.thicknessDepthField, -2.0f, 6.0f);
+    ImGui::SliderFloat("Center depth clip plane", &app.midDepthField, -2.0f, 3.0f);
+    ImGui::SliderFloat("Max-Min depth thickness", &app.thicknessDepthField, -2.0f, 6.0f);
 
-  const auto depthFieldMid       = std::pow(10.0, app.midDepthField);
-  const auto depthFieldThickness = std::pow(10.0, app.thicknessDepthField);
-  const auto clipNear            = std::max(1e-2, depthFieldMid - 0.5 * depthFieldThickness);
-  const auto clipFar             = depthFieldMid + 0.5 * depthFieldThickness;
-  ImGui::Text("Frustum: near=%.02f far=%.02f", clipNear, clipFar);
+    const auto depthFieldMid       = std::pow(10.0, app.midDepthField);
+    const auto depthFieldThickness = std::pow(10.0, app.thicknessDepthField);
+    const auto clipNear            = std::max(1e-2, depthFieldMid - 0.5 * depthFieldThickness);
+    const auto clipFar             = depthFieldMid + 0.5 * depthFieldThickness;
+    ImGui::Text("Frustum: near=%.02f far=%.02f", clipNear, clipFar);
 
-  ImGui::Checkbox("Orthogonal view", &app.viewOrtho);
-  ImGui::Checkbox("Camera follows 'local'", &app.cameraFollowsLocal);
-  ImGui::Checkbox("Render voxel maps as point clouds", &app.viewVoxelsAsPoints);
-  ImGui::Checkbox("Render free space of voxel maps", &app.viewVoxelsFreeSpace);
-  ImGui::Checkbox("Recolorize local map", &app.colorizeLocalMap);
-  ImGui::Checkbox("Recolorize global map", &app.colorizeGlobalMap);
-  ImGui::Checkbox("View prior ellipsoid", &app.viewPriorEllipsoid);
+    ImGui::Checkbox("Orthogonal view", &app.viewOrtho);
+    ImGui::Checkbox("Camera follows 'local'", &app.cameraFollowsLocal);
+    ImGui::Checkbox("Render voxel maps as point clouds", &app.viewVoxelsAsPoints);
+    ImGui::Checkbox("Render free space of voxel maps", &app.viewVoxelsFreeSpace);
+    ImGui::Checkbox("Recolorize local map", &app.colorizeLocalMap);
+    ImGui::Checkbox("Recolorize global map", &app.colorizeGlobalMap);
+    ImGui::Checkbox("View prior ellipsoid", &app.viewPriorEllipsoid);
 
-  ImGui::End();
+    ImGui::End();
 }
 
 /** "Manual" window: 6-DoF manual nudge of the current record's optimal_tf pose. */
 void renderManualPanel()
 {
-  ImGui::Begin("Manual");
-  ImGui::TextUnformatted("Manual solution modification:");
+    ImGui::Begin("Manual");
+    ImGui::TextUnformatted("Manual solution modification:");
 
-  constexpr float           handTunedRange[6] = {4.0f, 4.0f, 10.0f, 0.5f * static_cast<float>(M_PI),
-                                        0.25f * static_cast<float>(M_PI), 0.5f};
-  constexpr const char*     labels[6]         = {"X", "Y", "Z", "Yaw", "Pitch", "Roll"};
+    constexpr float handTunedRange[6] = {
+        4.0f, 4.0f, 10.0f, 0.5f * static_cast<float>(M_PI), 0.25f * static_cast<float>(M_PI), 0.5f};
+    constexpr const char* labels[6] = {"X", "Y", "Z", "Yaw", "Pitch", "Roll"};
 
-  const size_t idx = static_cast<size_t>(app.selectorIdx);
-  for (int i = 0; i < 6; i++)
-  {
-    if (ImGui::SliderFloat(labels[i], &app.gtPose[i], -handTunedRange[i], handTunedRange[i]) &&
-        idx < app.logRecords.size())
+    const size_t idx = static_cast<size_t>(app.selectorIdx);
+    for (int i = 0; i < 6; i++)
     {
-      auto& lr = app.logRecords.at(idx).get();
-      auto  p  = lr.icpResult.optimal_tf.mean.asTPose();
-      p[i]     = app.gtPose[i];
-      lr.icpResult.optimal_tf.mean = mrpt::poses::CPose3D(p);
+        if (ImGui::SliderFloat(labels[i], &app.gtPose[i], -handTunedRange[i], handTunedRange[i]) &&
+            idx < app.logRecords.size())
+        {
+            auto& lr                     = app.logRecords.at(idx).get();
+            auto  p                      = lr.icpResult.optimal_tf.mean.asTPose();
+            p[i]                         = app.gtPose[i];
+            lr.icpResult.optimal_tf.mean = mrpt::poses::CPose3D(p);
+        }
     }
-  }
 
-  ImGui::End();
+    ImGui::End();
 }
 
 void renderSceneWindow()
 {
-  ImGui::Begin("3D View");
-  app.sceneView.render();
-  ImGui::End();
+    ImGui::Begin("3D View");
+    app.sceneView.render();
+    ImGui::End();
 }
 
 void renderFrame()
 {
-  handleKeyboard();
-  processAutoPlay();
-  rebuild_3d_view();
-  updateMiniCornerView();
+    handleKeyboard();
+    processAutoPlay();
+    rebuild_3d_view();
+    updateMiniCornerView();
 
-  renderControlPanel();
-  renderSummaryPanel();
-  renderVariablesPanel();
-  renderMapsPanel();
-  renderPairingsPanel();
-  renderViewPanel();
-  renderManualPanel();
-  renderSceneWindow();
+    renderControlPanel();
+    renderSummaryPanel();
+    renderVariablesPanel();
+    renderMapsPanel();
+    renderPairingsPanel();
+    renderViewPanel();
+    renderManualPanel();
+    renderSceneWindow();
 }
 
 int mainShowGui()
 {
-  mrpt::system::CDirectoryExplorer::TFileInfoList files;
+    mrpt::system::CDirectoryExplorer::TFileInfoList files;
 
-  if (argSingleFile.empty())
-  {
-    const std::string searchDir = argSearchDir;
-    ASSERT_DIRECTORY_EXISTS_(searchDir);
-
-    std::cout << "Searching in: '" << searchDir << "' for files with extension '" << argExtension
-               << "'" << std::endl;
-
-    mrpt::system::CDirectoryExplorer::explore(searchDir, FILE_ATTRIB_ARCHIVE, files);
-    mrpt::system::CDirectoryExplorer::filterByExtension(files, argExtension);
-    mrpt::system::CDirectoryExplorer::sortByName(files);
-
-    std::cout << "Found " << files.size() << " ICP records." << std::endl;
-  }
-  else
-  {
-    std::cout << "Loading one single log file: " << argSingleFile << std::endl;
-    files.resize(1);
-    files[0].wholePath = argSingleFile;
-  }
-
-  if (argMinQualityOpt && argMinQualityOpt->count() > 0)
-  {
-    const double minQ = argMinQuality;
-    if (minQ < 0.0 || minQ > 1.0)
+    if (argSingleFile.empty())
     {
-      THROW_EXCEPTION_FMT("--min-quality must be in [0,1]. Got: %.03f", minQ);
-    }
-    std::cout << "Applying minimum quality filter: q >= " << minQ << std::endl;
+        const std::string searchDir = argSearchDir;
+        ASSERT_DIRECTORY_EXISTS_(searchDir);
 
-    mrpt::system::CDirectoryExplorer::TFileInfoList filteredFiles;
+        std::cout << "Searching in: '" << searchDir << "' for files with extension '"
+                  << argExtension << "'" << std::endl;
+
+        mrpt::system::CDirectoryExplorer::explore(searchDir, FILE_ATTRIB_ARCHIVE, files);
+        mrpt::system::CDirectoryExplorer::filterByExtension(files, argExtension);
+        mrpt::system::CDirectoryExplorer::sortByName(files);
+
+        std::cout << "Found " << files.size() << " ICP records." << std::endl;
+    }
+    else
+    {
+        std::cout << "Loading one single log file: " << argSingleFile << std::endl;
+        files.resize(1);
+        files[0].wholePath = argSingleFile;
+    }
+
+    if (argMinQualityOpt && argMinQualityOpt->count() > 0)
+    {
+        const double minQ = argMinQuality;
+        if (minQ < 0.0 || minQ > 1.0)
+        {
+            THROW_EXCEPTION_FMT("--min-quality must be in [0,1]. Got: %.03f", minQ);
+        }
+        std::cout << "Applying minimum quality filter: q >= " << minQ << std::endl;
+
+        mrpt::system::CDirectoryExplorer::TFileInfoList filteredFiles;
+        for (const auto& file : files)
+        {
+            mp2p_icp::LogRecord lr;
+            if (!lr.load_from_file(file.wholePath))
+            {
+                std::cerr << "  Warning: could not load '" << file.wholePath << "'" << std::endl;
+                continue;
+            }
+            if (lr.icpResult.quality >= minQ)
+            {
+                filteredFiles.push_back(file);
+            }
+            else
+            {
+                std::cout << "  Skipping (quality=" << lr.icpResult.quality << " < " << minQ
+                          << "): " << file.name << std::endl;
+            }
+        }
+        std::cout << "Quality filter: kept " << filteredFiles.size() << " / " << files.size()
+                  << " files." << std::endl;
+
+        if (files.empty())
+        {
+            THROW_EXCEPTION_FMT(
+                "No log files passed --min-quality=%.03f. Lower the threshold or check input logs.",
+                minQ);
+        }
+        files = std::move(filteredFiles);
+    }
+
     for (const auto& file : files)
     {
-      mp2p_icp::LogRecord lr;
-      if (!lr.load_from_file(file.wholePath))
-      {
-        std::cerr << "  Warning: could not load '" << file.wholePath << "'" << std::endl;
-        continue;
-      }
-      if (lr.icpResult.quality >= minQ)
-      {
-        filteredFiles.push_back(file);
-      }
-      else
-      {
-        std::cout << "  Skipping (quality=" << lr.icpResult.quality << " < " << minQ
-                   << "): " << file.name << std::endl;
-      }
+        app.logRecords.emplace_back(file.wholePath, file.name);
     }
-    std::cout << "Quality filter: kept " << filteredFiles.size() << " / " << files.size()
-               << " files." << std::endl;
+    ASSERT_(!app.logRecords.empty());
 
-    if (files.empty())
     {
-      THROW_EXCEPTION_FMT(
-          "No log files passed --min-quality=%.03f. Lower the threshold or check input logs.",
-          minQ);
+        const auto& lr = app.logRecords.front().get();
+        if (app.layerNamesGlobal.empty() && lr.pcGlobal)
+        {
+            for (const auto& layer : lr.pcGlobal->layers)
+            {
+                app.layerNamesGlobal.push_back(layer.first);
+                app.layerVisibleGlobal[layer.first] = true;
+                std::cout << "Global point cloud: Found point layer='" << layer.first << "'\n";
+            }
+        }
+        if (app.layerNamesLocal.empty() && lr.pcLocal)
+        {
+            for (const auto& layer : lr.pcLocal->layers)
+            {
+                app.layerNamesLocal.push_back(layer.first);
+                app.layerVisibleLocal[layer.first] = true;
+                std::cout << "Local point cloud: Found point layer='" << layer.first << "'\n";
+            }
+        }
     }
-    files = std::move(filteredFiles);
-  }
 
-  for (const auto& file : files)
-  {
-    app.logRecords.emplace_back(file.wholePath, file.name);
-  }
-  ASSERT_(!app.logRecords.empty());
-
-  {
-    const auto& lr = app.logRecords.front().get();
-    if (app.layerNamesGlobal.empty() && lr.pcGlobal)
+    if (!app.shell.init(APP_NAME, 1280, 800))
     {
-      for (const auto& layer : lr.pcGlobal->layers)
-      {
-        app.layerNamesGlobal.push_back(layer.first);
-        app.layerVisibleGlobal[layer.first] = true;
-        std::cout << "Global point cloud: Found point layer='" << layer.first << "'\n";
-      }
+        return 1;
     }
-    if (app.layerNamesLocal.empty() && lr.pcLocal)
+
+    // Default docking layout (only applied once, when no imgui.ini layout exists yet):
+    // "Control" as a thin left strip, the option panels tabbed below it, "3D View" filling the
+    // remaining (background) area.
+    app.shell.setupDefaultLayout = [](unsigned int dockspaceId)
     {
-      for (const auto& layer : lr.pcLocal->layers)
-      {
-        app.layerNamesLocal.push_back(layer.first);
-        app.layerVisibleLocal[layer.first] = true;
-        std::cout << "Local point cloud: Found point layer='" << layer.first << "'\n";
-      }
+        ImGuiID rightId = 0;
+        ImGuiID leftId =
+            ImGui::DockBuilderSplitNode(dockspaceId, ImGuiDir_Left, 0.30f, nullptr, &rightId);
+
+        ImGuiID leftBottomId = 0;
+        ImGuiID leftTopId =
+            ImGui::DockBuilderSplitNode(leftId, ImGuiDir_Up, 0.4f, nullptr, &leftBottomId);
+
+        ImGui::DockBuilderDockWindow("Control", leftTopId);
+        ImGui::DockBuilderDockWindow("Summary", leftBottomId);
+        ImGui::DockBuilderDockWindow("Variables", leftBottomId);
+        ImGui::DockBuilderDockWindow("Maps", leftBottomId);
+        ImGui::DockBuilderDockWindow("Pairings", leftBottomId);
+        ImGui::DockBuilderDockWindow("View", leftBottomId);
+        ImGui::DockBuilderDockWindow("Manual", leftBottomId);
+        ImGui::DockBuilderDockWindow("3D View", rightId);
+    };
+
+    // Background scene:
+    {
+        auto glGrid = mrpt::opengl::CGridPlaneXY::Create();
+        glGrid->setColor_u8(0xff, 0xff, 0xff, 0x10);
+        app.scene->insert(glGrid);
     }
-  }
 
-  if (!app.shell.init(APP_NAME, 1280, 800))
-  {
-    return 1;
-  }
+    auto glBase = mrpt::opengl::stock_objects::CornerXYZ(1.0f);
+    glBase->setName("Global");
+    glBase->enableShowName();
+    app.scene->insert(glBase);
 
-  // Default docking layout (only applied once, when no imgui.ini layout exists yet):
-  // "Control" as a thin left strip, the option panels tabbed below it, "3D View" filling the
-  // remaining (background) area.
-  app.shell.setupDefaultLayout = [](unsigned int dockspaceId)
-  {
-    ImGuiID rightId = 0;
-    ImGuiID leftId  = ImGui::DockBuilderSplitNode(dockspaceId, ImGuiDir_Left, 0.30f, nullptr, &rightId);
+    app.scene->insert(app.glVizICP);
 
-    ImGuiID leftBottomId = 0;
-    ImGuiID leftTopId =
-        ImGui::DockBuilderSplitNode(leftId, ImGuiDir_Up, 0.4f, nullptr, &leftBottomId);
+    app.sceneView.setScene(app.scene);
 
-    ImGui::DockBuilderDockWindow("Control", leftTopId);
-    ImGui::DockBuilderDockWindow("Summary", leftBottomId);
-    ImGui::DockBuilderDockWindow("Variables", leftBottomId);
-    ImGui::DockBuilderDockWindow("Maps", leftBottomId);
-    ImGui::DockBuilderDockWindow("Pairings", leftBottomId);
-    ImGui::DockBuilderDockWindow("View", leftBottomId);
-    ImGui::DockBuilderDockWindow("Manual", leftBottomId);
-    ImGui::DockBuilderDockWindow("3D View", rightId);
-  };
+    app.sceneView.camera().setPointingAt(8.0f, 0.0f, 0.0f);
+    app.sceneView.camera().setAzimuthDegrees(110.0f);
+    app.sceneView.camera().setElevationDegrees(15.0f);
+    app.sceneView.camera().setZoomDistance(30.0f);
 
-  // Background scene:
-  {
-    auto glGrid = mrpt::opengl::CGridPlaneXY::Create();
-    glGrid->setColor_u8(0xff, 0xff, 0xff, 0x10);
-    app.scene->insert(glGrid);
-  }
+    // Load/save persistent UI+camera state across sessions:
+    char appCfgFile[1024];
+    ::get_user_config_file(appCfgFile, sizeof(appCfgFile), APP_NAME);
+    mrpt::config::CConfigFile appCfg(appCfgFile);
 
-  auto glBase = mrpt::opengl::stock_objects::CornerXYZ(1.0f);
-  glBase->setName("Global");
-  glBase->enableShowName();
-  app.scene->insert(glBase);
+    auto& cam              = app.sceneView.camera();
+    app.colorizeLocalMap   = appCfg.read_bool("", "cbColorizeLocalMap", app.colorizeLocalMap);
+    app.colorizeGlobalMap  = appCfg.read_bool("", "cbColorizeGlobalMap", app.colorizeGlobalMap);
+    app.showInitialPose    = appCfg.read_bool("", "cbShowInitialPose", app.showInitialPose);
+    app.viewOrtho          = appCfg.read_bool("", "cbViewOrtho", app.viewOrtho);
+    app.cameraFollowsLocal = appCfg.read_bool("", "cbCameraFollowsLocal", app.cameraFollowsLocal);
+    app.viewVoxelsAsPoints = appCfg.read_bool("", "cbViewVoxelsAsPoints", app.viewVoxelsAsPoints);
+    app.viewPairings       = appCfg.read_bool("", "cbViewPairings", app.viewPairings);
+    app.viewPairingsPt2Pt  = appCfg.read_bool("", "cbViewPairings_pt2pt", app.viewPairingsPt2Pt);
+    app.viewPairingsPt2Pl  = appCfg.read_bool("", "cbViewPairings_pt2pl", app.viewPairingsPt2Pl);
+    app.viewPairingsPt2Ln  = appCfg.read_bool("", "cbViewPairings_pt2ln", app.viewPairingsPt2Ln);
+    app.viewPairingsCov2Cov =
+        appCfg.read_bool("", "cbViewPairings_cov2cov", app.viewPairingsCov2Cov);
+    app.viewPriorEllipsoid = appCfg.read_bool("", "cbViewPriorEllipsoid", app.viewPriorEllipsoid);
 
-  app.scene->insert(app.glVizICP);
+    app.pairingsPl2PlSize = appCfg.read_float("", "slPairingsPl2PlSize", app.pairingsPl2PlSize);
+    app.pairingsPl2LnSize = appCfg.read_float("", "slPairingsPl2LnSize", app.pairingsPl2LnSize);
+    app.pairingsCov2CovDecim =
+        appCfg.read_float("", "slPairingsCov2CovDecimation", app.pairingsCov2CovDecim);
+    app.globalPointSize = appCfg.read_float("", "slGlobalPointSize", app.globalPointSize);
+    app.localPointSize  = appCfg.read_float("", "slLocalPointSize", app.localPointSize);
+    app.midDepthField   = appCfg.read_float("", "slMidDepthField", app.midDepthField);
+    app.thicknessDepthField =
+        appCfg.read_float("", "slThicknessDepthField", app.thicknessDepthField);
 
-  app.sceneView.setScene(app.scene);
+    cam.setPointingAt(
+        appCfg.read_float("", "cam_x", cam.getPointingAtX()),
+        appCfg.read_float("", "cam_y", cam.getPointingAtY()),
+        appCfg.read_float("", "cam_z", cam.getPointingAtZ()));
+    cam.setAzimuthDegrees(appCfg.read_float("", "cam_az", cam.getAzimuthDegrees()));
+    cam.setElevationDegrees(appCfg.read_float("", "cam_el", cam.getElevationDegrees()));
+    cam.setZoomDistance(appCfg.read_float("", "cam_d", cam.getZoomDistance()));
 
-  app.sceneView.camera().setPointingAt(8.0f, 0.0f, 0.0f);
-  app.sceneView.camera().setAzimuthDegrees(110.0f);
-  app.sceneView.camera().setElevationDegrees(15.0f);
-  app.sceneView.camera().setZoomDistance(30.0f);
+    app.shell.run(&renderFrame);
 
-  // Load/save persistent UI+camera state across sessions:
-  char appCfgFile[1024];
-  ::get_user_config_file(appCfgFile, sizeof(appCfgFile), APP_NAME);
-  mrpt::config::CConfigFile appCfg(appCfgFile);
+    appCfg.write("", "cbColorizeLocalMap", app.colorizeLocalMap);
+    appCfg.write("", "cbColorizeGlobalMap", app.colorizeGlobalMap);
+    appCfg.write("", "cbShowInitialPose", app.showInitialPose);
+    appCfg.write("", "cbViewOrtho", app.viewOrtho);
+    appCfg.write("", "cbCameraFollowsLocal", app.cameraFollowsLocal);
+    appCfg.write("", "cbViewVoxelsAsPoints", app.viewVoxelsAsPoints);
+    appCfg.write("", "cbViewPairings", app.viewPairings);
+    appCfg.write("", "cbViewPairings_pt2pt", app.viewPairingsPt2Pt);
+    appCfg.write("", "cbViewPairings_pt2pl", app.viewPairingsPt2Pl);
+    appCfg.write("", "cbViewPairings_pt2ln", app.viewPairingsPt2Ln);
+    appCfg.write("", "cbViewPairings_cov2cov", app.viewPairingsCov2Cov);
+    appCfg.write("", "cbViewPriorEllipsoid", app.viewPriorEllipsoid);
 
-  auto& cam                = app.sceneView.camera();
-  app.colorizeLocalMap     = appCfg.read_bool("", "cbColorizeLocalMap", app.colorizeLocalMap);
-  app.colorizeGlobalMap    = appCfg.read_bool("", "cbColorizeGlobalMap", app.colorizeGlobalMap);
-  app.showInitialPose      = appCfg.read_bool("", "cbShowInitialPose", app.showInitialPose);
-  app.viewOrtho            = appCfg.read_bool("", "cbViewOrtho", app.viewOrtho);
-  app.cameraFollowsLocal   = appCfg.read_bool("", "cbCameraFollowsLocal", app.cameraFollowsLocal);
-  app.viewVoxelsAsPoints   = appCfg.read_bool("", "cbViewVoxelsAsPoints", app.viewVoxelsAsPoints);
-  app.viewPairings         = appCfg.read_bool("", "cbViewPairings", app.viewPairings);
-  app.viewPairingsPt2Pt    = appCfg.read_bool("", "cbViewPairings_pt2pt", app.viewPairingsPt2Pt);
-  app.viewPairingsPt2Pl    = appCfg.read_bool("", "cbViewPairings_pt2pl", app.viewPairingsPt2Pl);
-  app.viewPairingsPt2Ln    = appCfg.read_bool("", "cbViewPairings_pt2ln", app.viewPairingsPt2Ln);
-  app.viewPairingsCov2Cov  = appCfg.read_bool("", "cbViewPairings_cov2cov", app.viewPairingsCov2Cov);
-  app.viewPriorEllipsoid   = appCfg.read_bool("", "cbViewPriorEllipsoid", app.viewPriorEllipsoid);
+    appCfg.write("", "slPairingsPl2PlSize", app.pairingsPl2PlSize);
+    appCfg.write("", "slPairingsPl2LnSize", app.pairingsPl2LnSize);
+    appCfg.write("", "slPairingsCov2CovDecimation", app.pairingsCov2CovDecim);
+    appCfg.write("", "slGlobalPointSize", app.globalPointSize);
+    appCfg.write("", "slLocalPointSize", app.localPointSize);
+    appCfg.write("", "slMidDepthField", app.midDepthField);
+    appCfg.write("", "slThicknessDepthField", app.thicknessDepthField);
 
-  app.pairingsPl2PlSize    = appCfg.read_float("", "slPairingsPl2PlSize", app.pairingsPl2PlSize);
-  app.pairingsPl2LnSize    = appCfg.read_float("", "slPairingsPl2LnSize", app.pairingsPl2LnSize);
-  app.pairingsCov2CovDecim = appCfg.read_float("", "slPairingsCov2CovDecimation", app.pairingsCov2CovDecim);
-  app.globalPointSize      = appCfg.read_float("", "slGlobalPointSize", app.globalPointSize);
-  app.localPointSize       = appCfg.read_float("", "slLocalPointSize", app.localPointSize);
-  app.midDepthField        = appCfg.read_float("", "slMidDepthField", app.midDepthField);
-  app.thicknessDepthField  = appCfg.read_float("", "slThicknessDepthField", app.thicknessDepthField);
+    appCfg.write("", "cam_x", cam.getPointingAtX());
+    appCfg.write("", "cam_y", cam.getPointingAtY());
+    appCfg.write("", "cam_z", cam.getPointingAtZ());
+    appCfg.write("", "cam_az", cam.getAzimuthDegrees());
+    appCfg.write("", "cam_el", cam.getElevationDegrees());
+    appCfg.write("", "cam_d", cam.getZoomDistance());
 
-  cam.setPointingAt(
-      appCfg.read_float("", "cam_x", cam.getPointingAtX()),
-      appCfg.read_float("", "cam_y", cam.getPointingAtY()),
-      appCfg.read_float("", "cam_z", cam.getPointingAtZ()));
-  cam.setAzimuthDegrees(appCfg.read_float("", "cam_az", cam.getAzimuthDegrees()));
-  cam.setElevationDegrees(appCfg.read_float("", "cam_el", cam.getElevationDegrees()));
-  cam.setZoomDistance(appCfg.read_float("", "cam_d", cam.getZoomDistance()));
-
-  app.shell.run(&renderFrame);
-
-  appCfg.write("", "cbColorizeLocalMap", app.colorizeLocalMap);
-  appCfg.write("", "cbColorizeGlobalMap", app.colorizeGlobalMap);
-  appCfg.write("", "cbShowInitialPose", app.showInitialPose);
-  appCfg.write("", "cbViewOrtho", app.viewOrtho);
-  appCfg.write("", "cbCameraFollowsLocal", app.cameraFollowsLocal);
-  appCfg.write("", "cbViewVoxelsAsPoints", app.viewVoxelsAsPoints);
-  appCfg.write("", "cbViewPairings", app.viewPairings);
-  appCfg.write("", "cbViewPairings_pt2pt", app.viewPairingsPt2Pt);
-  appCfg.write("", "cbViewPairings_pt2pl", app.viewPairingsPt2Pl);
-  appCfg.write("", "cbViewPairings_pt2ln", app.viewPairingsPt2Ln);
-  appCfg.write("", "cbViewPairings_cov2cov", app.viewPairingsCov2Cov);
-  appCfg.write("", "cbViewPriorEllipsoid", app.viewPriorEllipsoid);
-
-  appCfg.write("", "slPairingsPl2PlSize", app.pairingsPl2PlSize);
-  appCfg.write("", "slPairingsPl2LnSize", app.pairingsPl2LnSize);
-  appCfg.write("", "slPairingsCov2CovDecimation", app.pairingsCov2CovDecim);
-  appCfg.write("", "slGlobalPointSize", app.globalPointSize);
-  appCfg.write("", "slLocalPointSize", app.localPointSize);
-  appCfg.write("", "slMidDepthField", app.midDepthField);
-  appCfg.write("", "slThicknessDepthField", app.thicknessDepthField);
-
-  appCfg.write("", "cam_x", cam.getPointingAtX());
-  appCfg.write("", "cam_y", cam.getPointingAtY());
-  appCfg.write("", "cam_z", cam.getPointingAtZ());
-  appCfg.write("", "cam_az", cam.getAzimuthDegrees());
-  appCfg.write("", "cam_el", cam.getElevationDegrees());
-  appCfg.write("", "cam_d", cam.getZoomDistance());
-
-  app.shell.shutdown();
-  return 0;
+    app.shell.shutdown();
+    return 0;
 }
 
 }  // namespace
 
 int main(int argc, char** argv)
 {
-  cmd.add_option(
-      "-e,--file-extension", argExtension, "Filename extension to look for. Default is `icplog`");
-  cmd.add_option(
-      "-d,--directory", argSearchDir, "Directory in which to search for *.icplog files.");
-  cmd.add_option("-f,--file", argSingleFile, "Load just this one single log *.icplog file.");
-  cmd.add_option(
-      "-l,--load-plugins", arg_plugins, "One or more (comma separated) *.so files to load as plugins");
-  cmd.add_option(
-      "--autoplay-period", argAutoPlayPeriod,
-      "The period (in seconds) between timestamps to load and show in autoplay mode.");
-  argMinQualityOpt = cmd.add_option(
-      "-q,--min-quality", argMinQuality,
-      "Minimum ICP quality (range [0,1], i.e. 0%-100%) to load a log file. "
-      "Files whose ICP result quality is below this threshold are skipped.");
+    cmd.add_option(
+        "-e,--file-extension", argExtension, "Filename extension to look for. Default is `icplog`");
+    cmd.add_option(
+        "-d,--directory", argSearchDir, "Directory in which to search for *.icplog files.");
+    cmd.add_option("-f,--file", argSingleFile, "Load just this one single log *.icplog file.");
+    cmd.add_option(
+        "-l,--load-plugins", arg_plugins,
+        "One or more (comma separated) *.so files to load as plugins");
+    cmd.add_option(
+        "--autoplay-period", argAutoPlayPeriod,
+        "The period (in seconds) between timestamps to load and show in autoplay mode.");
+    argMinQualityOpt = cmd.add_option(
+        "-q,--min-quality", argMinQuality,
+        "Minimum ICP quality (range [0,1], i.e. 0%-100%) to load a log file. "
+        "Files whose ICP result quality is below this threshold are skipped.");
 
-  CLI11_PARSE(cmd, argc, argv);
+    CLI11_PARSE(cmd, argc, argv);
 
-  try
-  {
-    if (!arg_plugins.empty())
+    try
     {
-      std::string errMsg;
-      std::cout << "Loading plugin(s): " << arg_plugins << std::endl;
-      if (!mrpt::system::loadPluginModules(arg_plugins, errMsg))
-      {
-        std::cerr << errMsg << std::endl;
-        return 1;
-      }
-    }
+        if (!arg_plugins.empty())
+        {
+            std::string errMsg;
+            std::cout << "Loading plugin(s): " << arg_plugins << std::endl;
+            if (!mrpt::system::loadPluginModules(arg_plugins, errMsg))
+            {
+                std::cerr << errMsg << std::endl;
+                return 1;
+            }
+        }
 
-    return mainShowGui();
-  }
-  catch (std::exception& e)
-  {
-    std::cerr << "Exit due to exception:\n" << mrpt::exception_to_str(e) << std::endl;
-    return 1;
-  }
+        return mainShowGui();
+    }
+    catch (std::exception& e)
+    {
+        std::cerr << "Exit due to exception:\n" << mrpt::exception_to_str(e) << std::endl;
+        return 1;
+    }
 }

--- a/mp2p_icp_viz/apps/icp-log-viewer/main.cpp
+++ b/mp2p_icp_viz/apps/icp-log-viewer/main.cpp
@@ -1,4 +1,4 @@
-﻿/*               _
+/*               _
  _ __ ___   ___ | | __ _
 | '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
 | | | | | | (_) | | (_| | Localization and mApping (MOLA)
@@ -19,10 +19,15 @@
  * @date   Sep 15, 2021
  */
 
+// Must come before the MRPT math headers below: without nanogui (which used to pull this in
+// transitively), MatrixVectorBase::head<N>() otherwise instantiates against an incomplete
+// Eigen::Map forward declaration.
+#include <Eigen/Dense>
+
 // The goal is to visualize these guys:
 #include <mp2p_icp/LogRecord.h>
 // using this:
-#include <mrpt/gui/CDisplayWindowGUI.h>
+#include <mrpt/imgui/CImGuiSceneView.h>
 
 // other deps:
 #include <mrpt/config.h>
@@ -32,6 +37,7 @@
 #include <mrpt/opengl/CEllipsoid3D.h>
 #include <mrpt/opengl/CGridPlaneXY.h>
 #include <mrpt/opengl/COpenGLScene.h>
+#include <mrpt/opengl/CText.h>
 #include <mrpt/opengl/stock_objects.h>
 #include <mrpt/poses/CPosePDFGaussian.h>
 #include <mrpt/poses/Lie/SO.h>
@@ -41,19 +47,23 @@
 #include <mrpt/system/progress.h>
 #include <mrpt/system/string_utils.h>  // unitsFormat()
 
+#include <imgui.h>
+#include <imgui_app_common/ImGuiAppShell.h>
+#include <imgui_app_common/SimpleFileDialog.h>
+#include <imgui_internal.h>  // DockBuilder* API (default docking layout)
+
 #include <CLI/CLI.hpp>
 #include <iostream>
 
 #include "../libcfgpath/cfgpath.h"
 
-constexpr const char* APP_NAME           = "icp-log-viewer";
-constexpr int         MID_FONT_SIZE      = 14;
-constexpr int         SMALL_FONT_SIZE    = 12;
-constexpr int         WINDOW_FIXED_WIDTH = 400;
-
-// =========== Declare supported cli switches ===========
 namespace
 {
+constexpr const char* APP_NAME = "icp-log-viewer";
+
+constexpr const char* MINI_VIEW_NAME = "small-view";
+
+// =========== Declare supported cli switches ===========
 CLI::App cmd{APP_NAME};
 
 std::string  argExtension = "icplog";
@@ -63,1376 +73,1060 @@ std::string  arg_plugins;
 double       argAutoPlayPeriod = 0.1;
 double       argMinQuality     = 0.0;
 CLI::Option* argMinQualityOpt  = nullptr;
-}  // namespace
 
-// =========== Declare global variables ===========
-#if MRPT_HAS_NANOGUI
-
-namespace
-{
-auto                              glVizICP = mrpt::opengl::CSetOfObjects::Create();
-mrpt::gui::CDisplayWindowGUI::Ptr win;
-
-nanogui::Slider* slSelectorICP   = nullptr;
-nanogui::Button *btnSelectorBack = nullptr, *btnSelectorForw = nullptr;
-nanogui::Button* btnSelectorAutoplay = nullptr;
-bool             isAutoPlayActive    = false;
-double           lastAutoPlayTime    = .0;
-
-std::array<nanogui::TextBox*, 5> lbICPStats         = {nullptr, nullptr, nullptr, nullptr, nullptr};
-nanogui::CheckBox*               cbShowInitialPose  = nullptr;
-nanogui::Label*                  lbICPIteration     = nullptr;
-nanogui::Slider*                 slIterationDetails = nullptr;
-
-const size_t                   MAX_VARIABLE_LIST = 100;
-std::vector<nanogui::TextBox*> lbDynVariables;
-
-nanogui::CheckBox* cbViewOrtho           = nullptr;
-nanogui::CheckBox* cbCameraFollowsLocal  = nullptr;
-nanogui::CheckBox* cbViewVoxelsAsPoints  = nullptr;
-nanogui::CheckBox* cbViewVoxelsFreeSpace = nullptr;
-nanogui::CheckBox* cbColorizeLocalMap    = nullptr;
-nanogui::CheckBox* cbColorizeGlobalMap   = nullptr;
-
-nanogui::CheckBox* cbViewPairings = nullptr;
-
-nanogui::CheckBox* cbViewPairings_pt2pt   = nullptr;
-nanogui::CheckBox* cbViewPairings_pt2pl   = nullptr;
-nanogui::CheckBox* cbViewPairings_pt2ln   = nullptr;
-nanogui::CheckBox* cbViewPairings_cov2cov = nullptr;
-
-nanogui::CheckBox* cbViewPriorEllipsoid = nullptr;
-
-nanogui::TextBox *tbLogPose = nullptr, *tbInitialGuess = nullptr, *tbInit2Final = nullptr,
-                 *tbCovariance = nullptr, *tbConditionNumber = nullptr, *tbPairings = nullptr,
-                 *tbPriorMean = nullptr, *tbPriorInfo = nullptr;
-
-nanogui::Slider* slPairingsPl2PlSize         = nullptr;
-nanogui::Slider* slPairingsPl2LnSize         = nullptr;
-nanogui::Slider* slPairingsCov2CovDecimation = nullptr;
-nanogui::Slider* slGlobalPointSize           = nullptr;
-nanogui::Slider* slLocalPointSize            = nullptr;
-nanogui::Slider* slMidDepthField             = nullptr;
-nanogui::Slider* slThicknessDepthField       = nullptr;
-nanogui::Label * lbDepthFieldValues = nullptr, *lbDepthFieldMid = nullptr,
-               *lbDepthFieldThickness = nullptr;
-
-nanogui::Slider* slGTPose[6] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
-
-std::vector<std::string> layerNames_global, layerNames_local;
-
-std::map<std::string, nanogui::CheckBox*> cbLayersByName_global;
-std::map<std::string, nanogui::CheckBox*> cbLayersByName_local;
-
+/** Lazily loads a *.icplog file on first access, and can drop it again to free memory. */
 class DelayedLoadLog
 {
-   public:
-    DelayedLoadLog() = default;
-    DelayedLoadLog(const std::string& fileName, const std::string& shortFileName)
-        : filename_(fileName), shortFileName_(shortFileName)
+ public:
+  DelayedLoadLog() = default;
+  DelayedLoadLog(const std::string& fileName, const std::string& shortFileName)
+      : filename_(fileName), shortFileName_(shortFileName)
+  {
+  }
+
+  mp2p_icp::LogRecord& get()
+  {
+    if (!log_)
     {
+      log_.emplace();
+      if (!log_->load_from_file(filename_))
+      {
+        log_.reset();
+        THROW_EXCEPTION_FMT("Failed to load log file: '%s'", filename_.c_str());
+      }
     }
 
-    mp2p_icp::LogRecord& get()
-    {
-        if (!log_)
-        {
-            log_.emplace();
-            if (!log_->load_from_file(filename_))
-            {
-                log_.reset();
-                THROW_EXCEPTION_FMT("Failed to load log file: '%s'", filename_.c_str());
-            }
-        }
+    return log_.value();
+  }
 
-        return log_.value();
-    }
+  void dispose() { log_.reset(); }
 
-    void dispose() { log_.reset(); }
+  const std::string& filename() const { return filename_; }
+  const std::string& shortFileName() const { return shortFileName_; }
 
-    const std::string& filename() const { return filename_; }
-    const std::string& shortFileName() const { return shortFileName_; }
-
-   private:
-    std::optional<mp2p_icp::LogRecord> log_;
-    std::string                        filename_, shortFileName_;
+ private:
+  std::optional<mp2p_icp::LogRecord> log_;
+  std::string                        filename_;
+  std::string                        shortFileName_;
 };
 
-std::vector<DelayedLoadLog> logRecords;
-
-}  // namespace
-
-void rebuild_3d_view(bool regenerateMaps = true);
-
-namespace
+/** All mutable application state (see the analogous struct in mm-viewer/main.cpp for the same
+ *  immediate-mode-GUI rationale). */
+struct AppState
 {
-void rebuild_3d_view_fast() { rebuild_3d_view(false); }
+  mp2p_icp_viz::ImGuiAppShell  shell;
+  mrpt::imgui::CImGuiSceneView sceneView;
+  mrpt::opengl::Scene::Ptr     scene    = mrpt::opengl::COpenGLScene::Create();
+  mrpt::opengl::CSetOfObjects::Ptr glVizICP = mrpt::opengl::CSetOfObjects::Create();
+
+  std::vector<DelayedLoadLog> logRecords;
+
+  std::vector<std::string> layerNamesGlobal;
+  std::vector<std::string> layerNamesLocal;
+
+  std::map<std::string, bool> layerVisibleGlobal;
+  std::map<std::string, bool> layerVisibleLocal;
+
+  // Selector / navigation:
+  int    selectorIdx       = 0;
+  bool   isAutoPlayActive  = false;
+  double lastAutoPlayTime  = 0.0;
+
+  // ICP iteration slider:
+  bool  showInitialPose     = false;
+  float iterationValue      = 0.0f;
+  int   iterationMax         = 0;
+  bool  iterationEnabled     = false;
+  std::string iterationCaption = "Show ICP iteration:";
+
+  // View options:
+  bool  viewOrtho           = false;
+  bool  cameraFollowsLocal  = false;
+  bool  viewVoxelsAsPoints  = true;
+  bool  viewVoxelsFreeSpace = false;
+  bool  colorizeLocalMap    = false;
+  bool  colorizeGlobalMap   = false;
+  bool  viewPriorEllipsoid  = true;
+  float globalPointSize     = 2.0f;
+  float localPointSize      = 2.0f;
+  float midDepthField       = 1.0f;
+  float thicknessDepthField = 3.0f;
+
+  // Pairings:
+  bool  viewPairings           = false;
+  bool  viewPairingsPt2Pt      = true;
+  bool  viewPairingsPt2Pl      = true;
+  bool  viewPairingsPt2Ln      = true;
+  bool  viewPairingsCov2Cov    = true;
+  float pairingsPl2PlSize      = -1.0f;
+  float pairingsPl2LnSize      = -1.0f;
+  float pairingsCov2CovDecim   = 500.0f;  // stored as log10, see slider range below
+  std::string pairingsSummary  = "None selected (mark one of the checkboxes below)";
+
+  // Manual pose tweak (6-DoF):
+  float gtPose[6] = {0, 0, 0, 0, 0, 0};
+
+  // Text/stat fields:
+  std::string statFileName;
+  std::string statLogSummary;
+  std::string statQuality;
+  std::string statGlobalSummary;
+  std::string statLocalSummary;
+  std::string statInitialGuess;
+  std::string statPriorMean       = "(none)";
+  std::string statPriorInfo       = "(none)";
+  std::string statLogPose;
+  std::string statInit2Final;
+  std::string statCovariance;
+  std::string statConditionNumber;
+
+  static constexpr size_t          kMaxDynVariables = 100;
+  std::vector<std::string>         dynVariableLines;
+
+  mp2p_icp_viz::SimpleFileDialog exportDialog;
+  int                             exportWhich = 0;  // 0=local, 1=global
+
+  std::optional<size_t> lastIdx;
+};
+
+AppState app;
+
+template <class MATRIX>
+double conditionNumber(const MATRIX& m)
+{
+  MATRIX              eVecs;
+  std::vector<double> eVals;
+  m.eig_symmetric(eVecs, eVals);
+  return eVals.back() / eVals.front();
+}
 
 void processAutoPlay()
 {
-    if (!isAutoPlayActive)
-    {
-        return;
-    }
+  if (!app.isAutoPlayActive)
+  {
+    return;
+  }
 
-    const double tNow = mrpt::Clock::nowDouble();
-    if (tNow - lastAutoPlayTime < argAutoPlayPeriod)
-    {
-        return;
-    }
+  const double tNow = mrpt::Clock::nowDouble();
+  if (tNow - app.lastAutoPlayTime < argAutoPlayPeriod)
+  {
+    return;
+  }
+  app.lastAutoPlayTime = tNow;
 
-    lastAutoPlayTime = tNow;
+  if (app.selectorIdx < static_cast<int>(app.logRecords.size()) - 1)
+  {
+    app.selectorIdx++;
+  }
+}
 
-    if (slSelectorICP->value() < slSelectorICP->range().second - 0.01f)
-    {
-        slSelectorICP->setValue(slSelectorICP->value() + 1);
-        rebuild_3d_view();
-    }
+/** Creates the small XYZ axis-corner overlay viewport once. See the note in agents.md: not
+ * currently rendered under MRPT 2.x (`CImGuiSceneView` only renders the "main" viewport), kept
+ * for when this project moves to MRPT 3.x. */
+void ensureMiniCornerViewport()
+{
+  if (app.scene->getViewport(MINI_VIEW_NAME))
+  {
+    return;
+  }
+
+  auto gl_view = app.scene->createViewport(MINI_VIEW_NAME);
+  gl_view->setViewportPosition(0, 0, 0.1, 0.1 * 16.0 / 9.0);
+  gl_view->setTransparent(true);
+  {
+    mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("X");
+    obj->setLocation(1.1, 0, 0);
+    gl_view->insert(obj);
+  }
+  {
+    mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Y");
+    obj->setLocation(0, 1.1, 0);
+    gl_view->insert(obj);
+  }
+  {
+    mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Z");
+    obj->setLocation(0, 0, 1.1);
+    gl_view->insert(obj);
+  }
+  gl_view->insert(mrpt::opengl::stock_objects::CornerXYZ());
 }
 
 void updateMiniCornerView()
 {
-    auto gl_view = win->background_scene->getViewport("small-view");
-    if (!gl_view)
-    {
-        return;
-    }
-
-    mrpt::opengl::CCamera& view_cam = gl_view->getCamera();
-
-    view_cam.setAzimuthDegrees(win->camera().getAzimuthDegrees());
-    view_cam.setElevationDegrees(win->camera().getElevationDegrees());
-    view_cam.setZoomDistance(5);
+  auto gl_view = app.scene->getViewport(MINI_VIEW_NAME);
+  if (!gl_view)
+  {
+    return;
+  }
+  mrpt::opengl::CCamera& view_cam = gl_view->getCamera();
+  view_cam.setAzimuthDegrees(app.sceneView.camera().getAzimuthDegrees());
+  view_cam.setElevationDegrees(app.sceneView.camera().getElevationDegrees());
+  view_cam.setZoomDistance(5);
 }
 
-void main_show_gui()
+void handleKeyboard()
 {
-    using namespace std::string_literals;
-
-    mrpt::system::CDirectoryExplorer::TFileInfoList files;
-
-    if (argSingleFile.empty())
-    {
-        const std::string searchDir = argSearchDir;
-        ASSERT_DIRECTORY_EXISTS_(searchDir);
-
-        std::cout << "Searching in: '" << searchDir << "' for files with extension '"
-                  << argExtension << "'" << std::endl;
-
-        mrpt::system::CDirectoryExplorer::explore(searchDir, FILE_ATTRIB_ARCHIVE, files);
-        mrpt::system::CDirectoryExplorer::filterByExtension(files, argExtension);
-        mrpt::system::CDirectoryExplorer::sortByName(files);
-
-        std::cout << "Found " << files.size() << " ICP records." << std::endl;
-    }
-    else
-    {
-        // Load one single file:
-        std::cout << "Loading one single log file: " << argSingleFile << std::endl;
-
-        files.resize(1);
-        files[0].wholePath = argSingleFile;
-    }
-
-    // Apply minimum quality filter if requested:
-    if (argMinQualityOpt && argMinQualityOpt->count() > 0)
-    {
-        const double minQ = argMinQuality;
-        if (minQ < 0.0 || minQ > 1.0)
-        {
-            THROW_EXCEPTION_FMT("--min-quality must be in [0,1]. Got: %.03f", minQ);
-        }
-        std::cout << "Applying minimum quality filter: q >= " << minQ << std::endl;
-
-        mrpt::system::CDirectoryExplorer::TFileInfoList filteredFiles;
-        for (const auto& file : files)
-        {
-            mp2p_icp::LogRecord lr;
-            if (!lr.load_from_file(file.wholePath))
-            {
-                std::cerr << "  Warning: could not load '" << file.wholePath << "'" << std::endl;
-                continue;
-            }
-            if (lr.icpResult.quality >= minQ)
-            {
-                filteredFiles.push_back(file);
-            }
-            else
-            {
-                std::cout << "  Skipping (quality=" << lr.icpResult.quality << " < " << minQ
-                          << "): " << file.name << std::endl;
-            }
-        }
-        std::cout << "Quality filter: kept " << filteredFiles.size() << " / " << files.size()
-                  << " files." << std::endl;
-
-        if (files.empty())
-        {
-            THROW_EXCEPTION_FMT(
-                "No log files passed --min-quality=%.03f. Lower the threshold or check input logs.",
-                minQ);
-        }
-
-        files = std::move(filteredFiles);
-    }
-
-    // load files:
-    for (const auto& file : files)
-    {
-        logRecords.emplace_back(file.wholePath, file.name);
-    }
-
-    ASSERT_(!logRecords.empty());
-
-    // Obtain layer info from first entry:
-    {
-        const auto& lr = logRecords.front().get();
-        if (layerNames_global.empty() && lr.pcGlobal)
-        {
-            for (const auto& layer : lr.pcGlobal->layers)
-            {
-                layerNames_global.push_back(layer.first);
-                std::cout << "Global point cloud: Found point layer='" << layer.first << "'\n";
-            }
-        }
-        if (layerNames_local.empty() && lr.pcLocal)
-        {
-            for (const auto& layer : lr.pcLocal->layers)
-            {
-                layerNames_local.push_back(layer.first);
-                std::cout << "Local point cloud: Found point layer='" << layer.first << "'\n";
-            }
-        }
-    }
-
-    // Get user app config file
-    char appCfgFile[1024];
-    ::get_user_config_file(appCfgFile, sizeof(appCfgFile), APP_NAME);
-    mrpt::config::CConfigFile appCfg(appCfgFile);
-
-    /*
-     * -------------------------------------------------------------------
-     * GUI
-     * --------------------------------------------------------------------
-     */
-    nanogui::init();
-
-    mrpt::gui::CDisplayWindowGUI_Params cp;
-    cp.maximized = true;
-    win          = mrpt::gui::CDisplayWindowGUI::Create(APP_NAME, 1024, 800, cp);
-
-    // Add a background scene:
-    auto scene = mrpt::opengl::COpenGLScene::Create();
-    {
-        auto glGrid = mrpt::opengl::CGridPlaneXY::Create();
-        glGrid->setColor_u8(0xff, 0xff, 0xff, 0x10);
-        scene->insert(glGrid);
-    }
-
-    auto gl_base = mrpt::opengl::stock_objects::CornerXYZ(1.0f);
-    gl_base->setName("Global");
-    gl_base->enableShowName();
-    scene->insert(gl_base);
-
-    scene->insert(glVizICP);
-
-    {
-        std::lock_guard<std::mutex> lck(win->background_scene_mtx);
-        win->background_scene = std::move(scene);
-    }
-
-    // Control GUI sub-window:
-    auto w = win->createManagedSubWindow("Control");
-    w->setPosition({5, 25});
-    w->requestFocus();
-    w->setLayout(
-        new nanogui::BoxLayout(nanogui::Orientation::Vertical, nanogui::Alignment::Fill, 5, 2));
-    w->setFixedWidth(WINDOW_FIXED_WIDTH);
-
-    cbShowInitialPose = w->add<nanogui::CheckBox>("Show at INITIAL GUESS pose");
-    cbShowInitialPose->setCallback(
-        [=](bool v)
-        {
-            if (slIterationDetails->enabled())
-            {
-                const auto& r = slIterationDetails->range();
-                slIterationDetails->setValue(v ? r.first : r.second);
-            }
-            rebuild_3d_view_fast();
-        });
-    lbICPIteration     = w->add<nanogui::Label>("Show ICP iteration:");
-    slIterationDetails = w->add<nanogui::Slider>();
-    slIterationDetails->setRange({.0f, 1.0f});
-    slIterationDetails->setCallback([](float) { rebuild_3d_view_fast(); });
-
-    //
-    w->add<nanogui::Label>(" ");  // separator
-    w->add<nanogui::Label>(mrpt::format(
-        "Select ICP record file (N=%u)", static_cast<unsigned int>(logRecords.size())));
-    slSelectorICP = w->add<nanogui::Slider>();
-    slSelectorICP->setRange({.0f, logRecords.size() - 1});
-    slSelectorICP->setValue(0);
-    slSelectorICP->setCallback([&](float /*v*/) { rebuild_3d_view(); });
-
-    for (auto& lb : lbICPStats)
-    {
-        lb = w->add<nanogui::TextBox>("  ");
-        lb->setFontSize(MID_FONT_SIZE);
-        lb->setAlignment(nanogui::TextBox::Alignment::Left);
-        lb->setEditable(true);
-    }
-
-    // navigation panel:
-    {
-        auto pn = w->add<nanogui::Widget>();
-        pn->setLayout(new nanogui::BoxLayout(nanogui::Orientation::Horizontal));
-
-        // shortcut:
-        auto s = slSelectorICP;
-
-        btnSelectorBack = pn->add<nanogui::Button>("", ENTYPO_ICON_CONTROLLER_FAST_BACKWARD);
-        btnSelectorBack->setCallback(
-            [=]()
-            {
-                if (s->value() > 0)
-                {
-                    s->setValue(s->value() - 1);
-                    s->callback()(s->value());
-                }
-            });
-
-        btnSelectorForw = pn->add<nanogui::Button>("", ENTYPO_ICON_CONTROLLER_FAST_FORWARD);
-        btnSelectorForw->setCallback(
-            [=]()
-            {
-                if (s->value() < s->range().second - 0.01f)
-                {
-                    s->setValue(s->value() + 1);
-                    rebuild_3d_view();
-                }
-            });
-
-        pn->add<nanogui::Label>(" ");  // separator
-
-        btnSelectorAutoplay = pn->add<nanogui::Button>("", ENTYPO_ICON_CONTROLLER_PLAY);
-        btnSelectorAutoplay->setFlags(nanogui::Button::ToggleButton);
-
-        btnSelectorAutoplay->setChangeCallback([&](bool active) { isAutoPlayActive = active; });
-    }
-
-    //
-    w->add<nanogui::Label>(" ");  // separator
-
-    auto tabWidget = w->add<nanogui::TabWidget>();
-
-    auto* tab1 = tabWidget->createTab("Summary");
-    tab1->setLayout(
-        new nanogui::BoxLayout(nanogui::Orientation::Vertical, nanogui::Alignment::Fill));
-
-    auto* tab2 = tabWidget->createTab("Variables");
-    tab2->setLayout(
-        new nanogui::BoxLayout(nanogui::Orientation::Vertical, nanogui::Alignment::Fill));
-
-    auto* tab3 = tabWidget->createTab("Maps");
-    tab3->setLayout(new nanogui::GroupLayout());
-
-    auto* tab4 = tabWidget->createTab("Pairings");
-    tab4->setLayout(new nanogui::GroupLayout());
-
-    auto* tab5 = tabWidget->createTab("View");
-    tab5->setLayout(new nanogui::GroupLayout());
-
-    auto* tab6 = tabWidget->createTab("Manual");
-    tab6->setLayout(new nanogui::GroupLayout());
-
-    tabWidget->setActiveTab(0);
-
-    tab1->add<nanogui::Label>(" ")->setFontSize(SMALL_FONT_SIZE);
-    tab1->add<nanogui::Label>("ICP result pose [x y z yaw(deg) pitch(deg) roll(deg)]:")
-        ->setFontSize(MID_FONT_SIZE);
-    tbLogPose = tab1->add<nanogui::TextBox>();
-    tbLogPose->setFontSize(MID_FONT_SIZE);
-    tbLogPose->setEditable(true);
-    tbLogPose->setAlignment(nanogui::TextBox::Alignment::Left);
-    tab1->add<nanogui::Label>(" ")->setFontSize(SMALL_FONT_SIZE);
-
-    tab1->add<nanogui::Label>("Initial -> final pose change:")->setFontSize(MID_FONT_SIZE);
-    tbInit2Final = tab1->add<nanogui::TextBox>();
-    tbInit2Final->setFontSize(MID_FONT_SIZE);
-    tbInit2Final->setEditable(false);
-    tab1->add<nanogui::Label>(" ")->setFontSize(SMALL_FONT_SIZE);
-
-    tab1->add<nanogui::Label>("Uncertainty: diagonal sigmas (x y z [m] yaw pitch roll [deg])")
-        ->setFontSize(MID_FONT_SIZE);
-    tbCovariance = tab1->add<nanogui::TextBox>();
-    tbCovariance->setFontSize(MID_FONT_SIZE);
-    tbCovariance->setEditable(false);
-    tab1->add<nanogui::Label>(" ")->setFontSize(SMALL_FONT_SIZE);
-
-    tab1->add<nanogui::Label>("Uncertainty: Covariance condition numbers")
-        ->setFontSize(MID_FONT_SIZE);
-    tbConditionNumber = tab1->add<nanogui::TextBox>();
-    tbConditionNumber->setFontSize(MID_FONT_SIZE);
-    tbConditionNumber->setEditable(false);
-    tab1->add<nanogui::Label>(" ");
-
-    tab6->add<nanogui::Label>("Manual solution modification:");
-    const float handTunedRange[6] = {4.0, 4.0, 10.0, 0.5 * M_PI, 0.25 * M_PI, 0.5};
-
-    for (int i = 0; i < 6; i++)
-    {
-        slGTPose[i] = tab6->add<nanogui::Slider>();
-        slGTPose[i]->setRange({-handTunedRange[i], handTunedRange[i]});
-        slGTPose[i]->setValue(0.0f);
-
-        slGTPose[i]->setCallback(
-            [=](float v)
-            {
-                const size_t idx = mrpt::round(slSelectorICP->value());
-                auto&        lr  = logRecords.at(idx).get();
-
-                auto p                       = lr.icpResult.optimal_tf.mean.asTPose();
-                p[i]                         = v;
-                lr.icpResult.optimal_tf.mean = mrpt::poses::CPose3D(p);
-
-                rebuild_3d_view_fast();
-            });
-    }
-
-    tab1->add<nanogui::Label>("Initial guess pose:");
-    tbInitialGuess = tab1->add<nanogui::TextBox>();
-    tbInitialGuess->setFontSize(14);
-    tbInitialGuess->setEditable(true);
-    tbInitialGuess->setAlignment(nanogui::TextBox::Alignment::Left);
-    tab1->add<nanogui::Label>(" ")->setFontSize(SMALL_FONT_SIZE);
-
-    tab1->add<nanogui::Label>("Prior mean pose (if any):")->setFontSize(MID_FONT_SIZE);
-    tbPriorMean = tab1->add<nanogui::TextBox>();
-    tbPriorMean->setFontSize(MID_FONT_SIZE);
-    tbPriorMean->setEditable(false);
-    tbPriorMean->setAlignment(nanogui::TextBox::Alignment::Left);
-
-    tab1->add<nanogui::Label>("Prior: diagonal sigmas (x y z [m] yaw pitch roll [deg])")
-        ->setFontSize(MID_FONT_SIZE);
-    tbPriorInfo = tab1->add<nanogui::TextBox>();
-    tbPriorInfo->setFontSize(MID_FONT_SIZE);
-    tbPriorInfo->setEditable(false);
-    tbPriorInfo->setAlignment(nanogui::TextBox::Alignment::Left);
-    tab1->add<nanogui::Label>(" ")->setFontSize(SMALL_FONT_SIZE);
-
-    // Save map buttons:
-    auto lambdaSave = [&](const mp2p_icp::metric_map_t& m)
-    {
-        const std::string outFile = nanogui::file_dialog(
-            {{"mm", "mp2p_icp::metric_map_t binary serialized object (*.mm)"}}, true /*save*/);
-        if (outFile.empty())
-        {
-            return;
-        }
-        if (bool ok = m.save_to_file(outFile); !ok)
-        {
-            std::cerr << "Error saving file: " << outFile << "\n";
-        }
-    };
-
-    // tab 2: variables
-    {
-        tab2->add<nanogui::Label>("Dynamic variables:");
-
-        auto vscroll = tab2->add<nanogui::VScrollPanel>();
-        vscroll->setFixedSize({WINDOW_FIXED_WIDTH - 15, 300});
-
-        auto wrapper = vscroll->add<nanogui::Widget>();
-
-        wrapper->setFixedSize({WINDOW_FIXED_WIDTH - 30, 300});
-        wrapper->setLayout(
-            new nanogui::BoxLayout(nanogui::Orientation::Vertical, nanogui::Alignment::Fill));
-
-        for (size_t i = 0; i < MAX_VARIABLE_LIST; i++)
-        {
-            auto* tb = wrapper->add<nanogui::TextBox>("aaaa");
-            tb->setAlignment(nanogui::TextBox::Alignment::Left);
-            tb->setEditable(true);
-            tb->setFontSize(MID_FONT_SIZE);
-            lbDynVariables.push_back(tb);
-        }
-    }
-
-    // tab 3: maps
-    {
-        auto pn = tab3->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::BoxLayout(nanogui::Orientation::Horizontal, nanogui::Alignment::Fill));
-        pn->add<nanogui::Button>("Export 'local' map...")
-            ->setCallback(
-                [&]()
-                {
-                    const size_t idx = mrpt::round(slSelectorICP->value());
-                    auto&        lr  = logRecords.at(idx).get();
-                    ASSERT_(lr.pcLocal);
-                    lambdaSave(*lr.pcLocal);
-                });
-        pn->add<nanogui::Button>("Export 'global' map...")
-            ->setCallback(
-                [&]()
-                {
-                    const size_t idx = mrpt::round(slSelectorICP->value());
-                    auto&        lr  = logRecords.at(idx).get();
-                    ASSERT_(lr.pcGlobal);
-                    lambdaSave(*lr.pcGlobal);
-                });
-    }
-
-    tab3->add<nanogui::Label>("[GLOBAL map] Visible layers:");
-
-    for (size_t i = 0; i < layerNames_global.size(); i++)
-    {
-        auto cb = tab3->add<nanogui::CheckBox>(layerNames_global.at(i));
-        cb->setChecked(true);
-        cb->setCallback([](bool) { rebuild_3d_view(); });
-        cb->setFontSize(13);
-
-        cbLayersByName_global[layerNames_global.at(i)] = cb;
-    }
-
-    tab3->add<nanogui::Label>("[LOCAL map] Visible layers:");
-    for (size_t i = 0; i < layerNames_local.size(); i++)
-    {
-        auto cb = tab3->add<nanogui::CheckBox>(layerNames_local.at(i));
-        cb->setChecked(true);
-        cb->setCallback([](bool) { rebuild_3d_view(); });
-        cb->setFontSize(13);
-
-        cbLayersByName_local[layerNames_local.at(i)] = cb;
-    }
-
-    // tab4: pairings:
-    tbPairings = tab4->add<nanogui::TextBox>();
-    tbPairings->setFontSize(16);
-    tbPairings->setEditable(false);
-
-    cbViewPairings = tab4->add<nanogui::CheckBox>("View pairings");
-    cbViewPairings->setCallback([](bool) { rebuild_3d_view_fast(); });
-
-    cbViewPairings_pt2pt = tab4->add<nanogui::CheckBox>("View: point-to-point");
-    cbViewPairings_pt2pt->setChecked(true);
-    cbViewPairings_pt2pt->setCallback([](bool) { rebuild_3d_view_fast(); });
-
-    {
-        auto pn = tab4->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 3, nanogui::Alignment::Fill));
-
-        cbViewPairings_cov2cov = pn->add<nanogui::CheckBox>("View: cov-to-cov");
-        cbViewPairings_cov2cov->setChecked(true);
-        cbViewPairings_cov2cov->setCallback([](bool) { rebuild_3d_view_fast(); });
-
-        pn->add<nanogui::Label>("Decimation:");
-        slPairingsCov2CovDecimation = pn->add<nanogui::Slider>();
-        slPairingsCov2CovDecimation->setRange({0.0f, 3.0f});
-        slPairingsCov2CovDecimation->setValue(500.0f);
-        slPairingsCov2CovDecimation->setCallback([&](float) { rebuild_3d_view_fast(); });
-    }
-
-    {
-        auto pn = tab4->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 3, nanogui::Alignment::Fill));
-
-        cbViewPairings_pt2pl = pn->add<nanogui::CheckBox>("View: point-to-plane");
-        cbViewPairings_pt2pl->setChecked(true);
-        cbViewPairings_pt2pl->setCallback([](bool) { rebuild_3d_view_fast(); });
-
-        pn->add<nanogui::Label>("Plane size:");
-        slPairingsPl2PlSize = pn->add<nanogui::Slider>();
-        slPairingsPl2PlSize->setRange({-4.0f, 2.0f});
-        slPairingsPl2PlSize->setValue(-1.0f);
-        slPairingsPl2PlSize->setCallback([&](float) { rebuild_3d_view_fast(); });
-    }
-
-    {
-        auto pn = tab4->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 3, nanogui::Alignment::Fill));
-
-        cbViewPairings_pt2ln = pn->add<nanogui::CheckBox>("View: point-to-line");
-        cbViewPairings_pt2ln->setChecked(true);
-        cbViewPairings_pt2ln->setCallback([](bool) { rebuild_3d_view_fast(); });
-
-        pn->add<nanogui::Label>("Line length:");
-        slPairingsPl2LnSize = pn->add<nanogui::Slider>();
-        slPairingsPl2LnSize->setRange({-2.0f, 2.0f});
-        slPairingsPl2LnSize->setValue(-1.0f);
-        slPairingsPl2LnSize->setCallback([&](float) { rebuild_3d_view_fast(); });
-    }
-
-    // tab5: view
-    {
-        auto pn = tab5->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 2, nanogui::Alignment::Fill));
-
-        pn->add<nanogui::Label>("Global map point size");
-
-        slGlobalPointSize = pn->add<nanogui::Slider>();
-        slGlobalPointSize->setRange({1.0f, 10.0f});
-        slGlobalPointSize->setValue(2.0f);
-        slGlobalPointSize->setCallback([&](float) { rebuild_3d_view(); });
-    }
-    {
-        auto pn = tab5->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 2, nanogui::Alignment::Fill));
-
-        pn->add<nanogui::Label>("Local map point size");
-
-        slLocalPointSize = pn->add<nanogui::Slider>();
-        slLocalPointSize->setRange({1.0f, 10.0f});
-        slLocalPointSize->setValue(2.0f);
-        slLocalPointSize->setCallback([&](float) { rebuild_3d_view(); });
-    }
-    {
-        auto pn = tab5->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 2, nanogui::Alignment::Fill));
-
-        lbDepthFieldMid = pn->add<nanogui::Label>("Center depth clip plane:");
-        slMidDepthField = pn->add<nanogui::Slider>();
-    }
-    slMidDepthField->setRange({-2.0, 3.0});
-    slMidDepthField->setValue(1.0f);
-    slMidDepthField->setCallback([&](float) { rebuild_3d_view_fast(); });
-
-    {
-        auto pn = tab5->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 2, nanogui::Alignment::Fill));
-
-        lbDepthFieldThickness = pn->add<nanogui::Label>("Max-Min depth thickness:");
-        slThicknessDepthField = pn->add<nanogui::Slider>();
-    }
-    slThicknessDepthField->setRange({-2.0, 6.0});
-    slThicknessDepthField->setValue(3.0);
-    slThicknessDepthField->setCallback([&](float) { rebuild_3d_view_fast(); });
-    lbDepthFieldValues = tab5->add<nanogui::Label>(" ");
-
-    cbViewOrtho = tab5->add<nanogui::CheckBox>("Orthogonal view");
-    cbViewOrtho->setCallback([&](bool) { rebuild_3d_view_fast(); });
-
-    cbCameraFollowsLocal = tab5->add<nanogui::CheckBox>("Camera follows 'local'");
-    cbCameraFollowsLocal->setCallback([&](bool) { rebuild_3d_view_fast(); });
-
-    cbViewVoxelsAsPoints = tab5->add<nanogui::CheckBox>("Render voxel maps as point clouds");
-    cbViewVoxelsAsPoints->setChecked(true);
-    cbViewVoxelsAsPoints->setCallback([&](bool) { rebuild_3d_view(); });
-
-    cbViewVoxelsFreeSpace = tab5->add<nanogui::CheckBox>("Render free space of voxel maps");
-    cbViewVoxelsFreeSpace->setChecked(false);
-    cbViewVoxelsFreeSpace->setCallback([&](bool) { rebuild_3d_view(); });
-
-    cbColorizeLocalMap = tab5->add<nanogui::CheckBox>("Recolorize local map");
-    cbColorizeLocalMap->setCallback([&](bool) { rebuild_3d_view(); });
-
-    cbColorizeGlobalMap = tab5->add<nanogui::CheckBox>("Recolorize global map");
-    cbColorizeGlobalMap->setCallback([&](bool) { rebuild_3d_view(); });
-
-    cbViewPriorEllipsoid = tab5->add<nanogui::CheckBox>("View prior ellipsoid");
-    cbViewPriorEllipsoid->setChecked(true);
-    cbViewPriorEllipsoid->setCallback([&](bool) { rebuild_3d_view(); });
-
-    // ----
-    w->add<nanogui::Label>(" ");  // separator
-    w->add<nanogui::Button>("Quit", ENTYPO_ICON_ARROW_BOLD_LEFT)
-        ->setCallback([]() { win->setVisible(false); });
-
-    win->setKeyboardCallback(
-        [&](int key, [[maybe_unused]] int scancode, int action, [[maybe_unused]] int modifiers)
-        {
-            if (action != GLFW_PRESS && action != GLFW_REPEAT)
-            {
-                return false;
-            }
-
-            int increment = 0;
-            switch (key)
-            {
-                case GLFW_KEY_LEFT:
-                    increment = -1;
-                    break;
-                case GLFW_KEY_RIGHT:
-                    increment = +1;
-                    break;
-                case GLFW_KEY_PAGE_DOWN:
-                    increment = +100;
-                    break;
-                case GLFW_KEY_PAGE_UP:
-                    increment = -100;
-                    break;
-                case GLFW_KEY_SPACE:
-                    isAutoPlayActive = !isAutoPlayActive;
-                    btnSelectorAutoplay->setPushed(isAutoPlayActive);
-                    break;
-                case 'i':
-                case 'I':
-                    cbShowInitialPose->setChecked(!cbShowInitialPose->checked());
-                    cbShowInitialPose->callback()(cbShowInitialPose->checked());
-                    break;
-                default:
-                    // do nothing
-                    break;
-            };
-
-            if (increment != 0)
-            {
-                nanogui::Slider* sl = slSelectorICP;  // shortcut
-                sl->setValue(sl->value() + static_cast<float>(increment));
-                if (sl->value() < 0)
-                {
-                    sl->setValue(0);
-                }
-                if (sl->value() > sl->range().second)
-                {
-                    sl->setValue(sl->range().second);
-                }
-                rebuild_3d_view();
-            }
-
-            return false;
-        });
-
-    win->performLayout();
-    win->camera().setCameraPointing(8.0f, .0f, .0f);
-    win->camera().setAzimuthDegrees(110.0f);
-    win->camera().setElevationDegrees(15.0f);
-    win->camera().setZoomDistance(30.0f);
-
-    // save and load UI state:
-#define LOAD_CB_STATE(CB_NAME__) do_cb(CB_NAME__, #CB_NAME__)
-#define SAVE_CB_STATE(CB_NAME__) appCfg.write("", #CB_NAME__, (CB_NAME__)->checked())
-
-#define LOAD_SL_STATE(SL_NAME__) do_sl(SL_NAME__, #SL_NAME__)
-#define SAVE_SL_STATE(SL_NAME__) appCfg.write("", #SL_NAME__, (SL_NAME__)->value())
-
-    auto load_UI_state_from_user_config = [&]()
-    {
-        auto do_cb = [&](nanogui::CheckBox* cb, const std::string& name)
-        { cb->setChecked(appCfg.read_bool("", name, cb->checked())); };
-        auto do_sl = [&](nanogui::Slider* sl, const std::string& name)
-        { sl->setValue(appCfg.read_float("", name, sl->value())); };
-
-        LOAD_CB_STATE(cbColorizeLocalMap);
-        LOAD_CB_STATE(cbColorizeGlobalMap);
-        LOAD_CB_STATE(cbShowInitialPose);
-        LOAD_CB_STATE(cbViewOrtho);
-        LOAD_CB_STATE(cbCameraFollowsLocal);
-        LOAD_CB_STATE(cbViewVoxelsAsPoints);
-        LOAD_CB_STATE(cbViewPairings);
-        LOAD_CB_STATE(cbViewPairings_pt2pt);
-        LOAD_CB_STATE(cbViewPairings_pt2pl);
-        LOAD_CB_STATE(cbViewPairings_pt2ln);
-        LOAD_CB_STATE(cbViewPairings_cov2cov);
-        LOAD_CB_STATE(cbViewPriorEllipsoid);
-
-        LOAD_SL_STATE(slPairingsPl2PlSize);
-        LOAD_SL_STATE(slPairingsPl2LnSize);
-        LOAD_SL_STATE(slPairingsCov2CovDecimation);
-        LOAD_SL_STATE(slGlobalPointSize);
-        LOAD_SL_STATE(slLocalPointSize);
-        LOAD_SL_STATE(slMidDepthField);
-        LOAD_SL_STATE(slThicknessDepthField);
-
-        win->camera().setCameraPointing(
-            appCfg.read_float("", "cam_x", win->camera().getCameraPointingX()),
-            appCfg.read_float("", "cam_y", win->camera().getCameraPointingY()),
-            appCfg.read_float("", "cam_z", win->camera().getCameraPointingZ()));
-        win->camera().setAzimuthDegrees(
-            appCfg.read_float("", "cam_az", win->camera().getAzimuthDegrees()));
-        win->camera().setElevationDegrees(
-            appCfg.read_float("", "cam_el", win->camera().getElevationDegrees()));
-        win->camera().setZoomDistance(
-            appCfg.read_float("", "cam_d", win->camera().getZoomDistance()));
-    };
-    auto save_UI_state_to_user_config = [&]()
-    {
-        SAVE_CB_STATE(cbColorizeLocalMap);
-        SAVE_CB_STATE(cbColorizeGlobalMap);
-        SAVE_CB_STATE(cbShowInitialPose);
-        SAVE_CB_STATE(cbViewOrtho);
-        SAVE_CB_STATE(cbCameraFollowsLocal);
-        SAVE_CB_STATE(cbViewVoxelsAsPoints);
-        SAVE_CB_STATE(cbViewPairings);
-        SAVE_CB_STATE(cbViewPairings_pt2pt);
-        SAVE_CB_STATE(cbViewPairings_cov2cov);
-        SAVE_CB_STATE(cbViewPairings_pt2pl);
-        SAVE_CB_STATE(cbViewPairings_pt2ln);
-        SAVE_CB_STATE(cbViewPriorEllipsoid);
-
-        SAVE_SL_STATE(slPairingsPl2PlSize);
-        SAVE_SL_STATE(slPairingsPl2LnSize);
-        SAVE_SL_STATE(slPairingsCov2CovDecimation);
-        SAVE_SL_STATE(slGlobalPointSize);
-        SAVE_SL_STATE(slLocalPointSize);
-        SAVE_SL_STATE(slMidDepthField);
-        SAVE_SL_STATE(slThicknessDepthField);
-
-        appCfg.write("", "cam_x", win->camera().getCameraPointingX());
-        appCfg.write("", "cam_y", win->camera().getCameraPointingY());
-        appCfg.write("", "cam_z", win->camera().getCameraPointingZ());
-        appCfg.write("", "cam_az", win->camera().getAzimuthDegrees());
-        appCfg.write("", "cam_el", win->camera().getElevationDegrees());
-        appCfg.write("", "cam_d", win->camera().getZoomDistance());
-    };
-
-    // load UI state from last session:
-    load_UI_state_from_user_config();
-
-    rebuild_3d_view();
-
-    // Main loop
-    // ---------------------
-    win->drawAll();
-    win->setVisible(true);
-
-    win->addLoopCallback(
-        [&]()
-        {
-            processAutoPlay();
-            updateMiniCornerView();
-        });
-
-    nanogui::mainloop(1000 /*idleLoopPeriod ms*/, 25 /* minRepaintPeriod ms */);
-
-    nanogui::shutdown();
-
-    // save UI state:
-    save_UI_state_to_user_config();
+  ImGuiIO& io = ImGui::GetIO();
+  if (io.WantTextInput)
+  {
+    return;
+  }
+
+  int increment = 0;
+  if (ImGui::IsKeyPressed(ImGuiKey_LeftArrow, true))
+  {
+    increment = -1;
+  }
+  if (ImGui::IsKeyPressed(ImGuiKey_RightArrow, true))
+  {
+    increment = +1;
+  }
+  if (ImGui::IsKeyPressed(ImGuiKey_PageDown, true))
+  {
+    increment = +100;
+  }
+  if (ImGui::IsKeyPressed(ImGuiKey_PageUp, true))
+  {
+    increment = -100;
+  }
+  if (ImGui::IsKeyPressed(ImGuiKey_Space, false))
+  {
+    app.isAutoPlayActive = !app.isAutoPlayActive;
+  }
+  if (ImGui::IsKeyPressed(ImGuiKey_I, false))
+  {
+    app.showInitialPose = !app.showInitialPose;
+  }
+
+  if (increment != 0)
+  {
+    app.selectorIdx =
+        std::clamp(app.selectorIdx + increment, 0, static_cast<int>(app.logRecords.size()) - 1);
+  }
 }
 
-}  // namespace
-
-template <class MATRIX>  //
-double conditionNumber(const MATRIX& m)
-{
-    MATRIX              eVecs;
-    std::vector<double> eVals;
-    m.eig_symmetric(eVecs, eVals);
-    return eVals.back() / eVals.front();
-}
-
-// ==============================
-// rebuild_3d_view
-// ==============================
-void rebuild_3d_view(bool regenerateMaps)
+/** Equivalent to the old `rebuild_3d_view(bool regenerateMaps)`: called unconditionally every
+ * frame; regeneration of the (expensive) point-cloud OpenGL representations is only actually
+ * performed when the selected record or the relevant render params changed since the last call
+ * (see `indexChanged`/`regenGlobal`/`regenLocal` below), mirroring mm-viewer's approach. */
+void rebuild_3d_view()
 try
 {
-    using namespace std::string_literals;
+  using namespace std::string_literals;
 
-    const size_t idx = mrpt::round(slSelectorICP->value());
+  const size_t idx = static_cast<size_t>(app.selectorIdx);
+  if (idx >= app.logRecords.size())
+  {
+    return;
+  }
 
-    btnSelectorBack->setEnabled(!logRecords.empty() && idx > 0);
-    btnSelectorForw->setEnabled(!logRecords.empty() && idx < logRecords.size() - 1);
-
-    if (idx >= logRecords.size())
+  const bool indexChanged = !app.lastIdx.has_value() || *app.lastIdx != idx;
+  if (indexChanged)
+  {
+    if (app.lastIdx.has_value())
     {
-        return;
+      app.logRecords.at(*app.lastIdx).dispose();
     }
+    app.lastIdx = idx;
+  }
 
-    glVizICP->clear();
+  app.glVizICP->clear();
 
-    // Free memory
-    static std::optional<size_t> lastIdx;
-    bool                         mustResetIterationSlider = false;
+  // lazy load from disk happens in the "get()":
+  const auto& lr = app.logRecords.at(idx).get();
 
-    if (!lastIdx || (lastIdx && idx != *lastIdx))
+  app.statFileName = app.logRecords.at(idx).shortFileName();
+
+  app.statLogSummary = mrpt::format(
+      "ICP log #%zu | Local: ID:%u%s | Global: ID:%u%s", idx,
+      static_cast<unsigned int>(lr.pcLocal->id ? lr.pcLocal->id.value() : 0),
+      lr.pcLocal->label ? lr.pcLocal->label.value().c_str() : "",
+      static_cast<unsigned int>(lr.pcGlobal->id ? lr.pcGlobal->id.value() : 0),
+      lr.pcGlobal->label ? lr.pcGlobal->label.value().c_str() : "");
+
+  app.statQuality = mrpt::format(
+      "Quality: %.02f%% | Iters: %u | Term.Reason: %s", 100.0 * lr.icpResult.quality,
+      static_cast<unsigned int>(lr.icpResult.nIterations),
+      mrpt::typemeta::enum2str(lr.icpResult.terminationReason).c_str());
+
+  app.statGlobalSummary = "Global: "s + lr.pcGlobal->contents_summary();
+  app.statLocalSummary  = "Local: "s + lr.pcLocal->contents_summary();
+
+  app.statInitialGuess = lr.initialGuessLocalWrtGlobal.asString();
+
+  if (lr.prior.has_value())
+  {
+    app.statPriorMean = lr.prior->mean.asString();
+
+    std::string s;
+    const auto  cov = mrpt::math::CMatrixDouble66(lr.prior->cov_inv.inverse());
+    for (int i = 0; i < 6; i++)
     {
-        // free memory:
-        if (lastIdx)
-        {
-            logRecords.at(*lastIdx).dispose();
-        }
-
-        // and note that we should show the first/last ICP iteration:
-        mustResetIterationSlider = true;
+      const auto sigma = std::sqrt(cov(i, i));
+      s += (i < 3) ? mrpt::format("%.02fm ", sigma) : mrpt::format("%.02fd ", mrpt::RAD2DEG(sigma));
     }
-    lastIdx = idx;
+    app.statPriorInfo = s;
+  }
+  else
+  {
+    app.statPriorMean = "(none)";
+    app.statPriorInfo = "(none)";
+  }
 
-    // lazy load from disk happens in the "get()":
-    const auto& lr = logRecords.at(idx).get();
+  app.statLogPose = lr.icpResult.optimal_tf.mean.asString();
 
-    lbICPStats[0]->setValue(logRecords.at(idx).shortFileName());
-
-    lbICPStats[1]->setValue(mrpt::format(
-        "ICP log #%zu | Local: ID:%u%s | Global: ID:%u%s", idx,
-        static_cast<unsigned int>(lr.pcLocal->id ? lr.pcLocal->id.value() : 0),
-        lr.pcLocal->label ? lr.pcLocal->label.value().c_str() : "",
-        static_cast<unsigned int>(lr.pcGlobal->id ? lr.pcGlobal->id.value() : 0),
-        lr.pcGlobal->label ? lr.pcGlobal->label.value().c_str() : ""));
-
-    lbICPStats[2]->setValue(mrpt::format(
-        "Quality: %.02f%% | Iters: %u | Term.Reason: %s", 100.0 * lr.icpResult.quality,
-        static_cast<unsigned int>(lr.icpResult.nIterations),
-        mrpt::typemeta::enum2str(lr.icpResult.terminationReason).c_str()));
-
-    lbICPStats[3]->setValue("Global: "s + lr.pcGlobal->contents_summary());
-    lbICPStats[4]->setValue("Local: "s + lr.pcLocal->contents_summary());
-
-    tbInitialGuess->setValue(lr.initialGuessLocalWrtGlobal.asString());
-
-    // Prior:
-    if (lr.prior.has_value())
+  // dyn variables:
+  app.dynVariableLines.clear();
+  for (const auto& [name, value] : lr.dynamicVariables)
+  {
+    app.dynVariableLines.push_back(mrpt::format("%s = %g", name.c_str(), value));
+    if (app.dynVariableLines.size() >= AppState::kMaxDynVariables)
     {
-        tbPriorMean->setValue(lr.prior->mean.asString());
-
-        std::string s;
-        const auto  cov = mrpt::math::CMatrixDouble66(lr.prior->cov_inv.inverse());
-        for (int i = 0; i < 6; i++)
-        {
-            const auto sigma = std::sqrt(cov(i, i));
-            if (i < 3)
-            {
-                s += mrpt::format("%.02fm ", sigma);
-            }
-            else
-            {
-                s += mrpt::format("%.02fd ", mrpt::RAD2DEG(sigma));
-            }
-        }
-        tbPriorInfo->setValue(s);
+      break;
     }
-    else
+  }
+
+  {
+    const auto poseChange =
+        lr.icpResult.optimal_tf.mean - mrpt::poses::CPose3D(lr.initialGuessLocalWrtGlobal);
+
+    app.statInit2Final = mrpt::format(
+        "|T|=%.03f [m]  |R|=%.03f [deg]", poseChange.norm(),
+        mrpt::RAD2DEG(mrpt::poses::Lie::SO<3>::log(poseChange.getRotationMatrix()).norm()));
+  }
+
+  const auto                      poseFromCorner = mrpt::poses::CPose3D::Identity();
+  mrpt::poses::CPose3DPDFGaussian relativePose;
+  const mp2p_icp::Pairings*       pairsToViz = nullptr;
+
+  if (!lr.iterationsDetails.has_value() || lr.iterationsDetails->empty())
+  {
+    app.iterationEnabled = false;
+
+    if (app.showInitialPose)
     {
-        tbPriorMean->setValue("(none)");
-        tbPriorInfo->setValue("(none)");
-    }
-
-    tbLogPose->setValue(lr.icpResult.optimal_tf.mean.asString());
-
-    // dyn variables:
-    {
-        for (auto* lb : lbDynVariables)
-        {
-            lb->setValue("");
-        }
-
-        size_t lbIdx = 0;
-        for (const auto& [name, value] : lr.dynamicVariables)
-        {
-            lbDynVariables[lbIdx++]->setValue(mrpt::format("%s = %g", name.c_str(), value));
-            if (lbIdx >= MAX_VARIABLE_LIST)
-            {
-                break;
-            }
-        }
-    }
-
-    {
-        const auto poseChange =
-            lr.icpResult.optimal_tf.mean - mrpt::poses::CPose3D(lr.initialGuessLocalWrtGlobal);
-
-        tbInit2Final->setValue(mrpt::format(
-            "|T|=%.03f [m]  |R|=%.03f [deg]", poseChange.norm(),
-            mrpt::RAD2DEG(mrpt::poses::Lie::SO<3>::log(poseChange.getRotationMatrix()).norm())));
-    }
-
-    const auto                      poseFromCorner = mrpt::poses::CPose3D::Identity();
-    mrpt::poses::CPose3DPDFGaussian relativePose;
-    const mp2p_icp::Pairings*       pairsToViz = nullptr;
-
-    if (!lr.iterationsDetails.has_value() || lr.iterationsDetails->empty())
-    {
-        slIterationDetails->setEnabled(false);
-
-        if (cbShowInitialPose->checked())
-        {
-            relativePose.mean = mrpt::poses::CPose3D(lr.initialGuessLocalWrtGlobal);
-            lbICPIteration->setCaption("Show ICP iteration: INITIAL");
-        }
-        else
-        {
-            relativePose = lr.icpResult.optimal_tf;
-            lbICPIteration->setCaption("Show ICP iteration: FINAL");
-        }
-
-        if (cbViewPairings->checked())
-        {
-            pairsToViz = &lr.icpResult.finalPairings;
-        }
+      relativePose.mean  = mrpt::poses::CPose3D(lr.initialGuessLocalWrtGlobal);
+      app.iterationCaption = "Show ICP iteration: INITIAL";
     }
     else
     {
-        slIterationDetails->setEnabled(true);
-        slIterationDetails->setRange({.0f, static_cast<float>(lr.iterationsDetails->size() - 1)});
-
-        if (mustResetIterationSlider)
-        {
-            slIterationDetails->setValue(
-                cbShowInitialPose->checked() ? slIterationDetails->range().first
-                                             : slIterationDetails->range().second);
-        }
-
-        // final or partial solution?
-        auto it = lr.iterationsDetails->begin();
-
-        size_t nIter = mrpt::round(slIterationDetails->value());
-        mrpt::keep_min(nIter, lr.iterationsDetails->size() - 1);
-
-        std::advance(it, nIter);
-
-        relativePose.mean = it->second.optimalPose;
-        if (cbViewPairings->checked())
-        {
-            pairsToViz = &it->second.pairings;
-        }
-
-        lbICPIteration->setCaption(
-            "Show ICP iteration: "s + std::to_string(it->first) + "/"s +
-            std::to_string(lr.iterationsDetails->rbegin()->first));
+      relativePose        = lr.icpResult.optimal_tf;
+      app.iterationCaption = "Show ICP iteration: FINAL";
     }
 
+    if (app.viewPairings)
     {
-        std::string s;
-        for (int i = 0; i < 6; i++)
-        {
-            auto sigma = std::sqrt(relativePose.cov(i, i));
-            if (i < 3)
-            {
-                s += mrpt::format("%.02fm ", sigma);
-            }
-            else
-            {
-                s += mrpt::format("%.02fd ", mrpt::RAD2DEG(sigma));
-            }
-        }
-
-        s += mrpt::format(
-            " det(XYZ)=%.02e det(rot)=%.02e", relativePose.cov.blockCopy<3, 3>(0, 0).det(),
-            relativePose.cov.blockCopy<3, 3>(3, 3).det());
-
-        tbCovariance->setValue(s);
+      pairsToViz = &lr.icpResult.finalPairings;
     }
+  }
+  else
+  {
+    app.iterationEnabled = true;
+    app.iterationMax     = static_cast<int>(lr.iterationsDetails->size()) - 1;
 
-    // Extract SE(2) covariance:
-    const mrpt::poses::CPosePDFGaussian pose2D(relativePose);
-
-    // Condition numbers:
-    tbConditionNumber->setValue(mrpt::format(
-        " cn{XYZ}=%.02f cn{SO(3)}=%.02f cn{SE(2)}=%.02f "
-        "cn{SE(3)}=%.02f",
-        conditionNumber(relativePose.cov.blockCopy<3, 3>(0, 0)),
-        conditionNumber(relativePose.cov.blockCopy<3, 3>(3, 3)), conditionNumber(pose2D.cov),
-        conditionNumber(relativePose.cov)));
-
-    // 3D objects -------------------
-    auto glCornerFrom = mrpt::opengl::stock_objects::CornerXYZSimple(0.75f, 3.0f);
-    glCornerFrom->setPose(poseFromCorner);
-    glVizICP->insert(glCornerFrom);
-
-    auto glCornerLocal = mrpt::opengl::stock_objects::CornerXYZSimple(0.85f, 5.0f);
-    glCornerLocal->setPose(relativePose.mean);
-    glCornerLocal->setName("Local");
-    glCornerLocal->enableShowName(true);
-    glVizICP->insert(glCornerLocal);
-
-    auto glCornerToCov = mrpt::opengl::CEllipsoid3D::Create();
-    glCornerToCov->set3DsegmentsCount(16);
-    glCornerToCov->enableDrawSolid3D(true);
-    glCornerToCov->setColor_u8(0xff, 0x00, 0x00, 0x40);
-    //  std::cout << "cov:\n" << relativePose.cov << "\n";
-    glCornerToCov->setCovMatrixAndMean(
-        relativePose.cov.blockCopy<3, 3>(0, 0), relativePose.mean.asVectorVal().head<3>());
-    glVizICP->insert(glCornerToCov);
-
-    // Prior ellipsoid (yellow, at prior mean, translational part only):
-    if (lr.prior.has_value() && cbViewPriorEllipsoid->checked())
+    if (indexChanged)
     {
-        const auto priorCov = mrpt::math::CMatrixDouble66(lr.prior->cov_inv.inverse());
-
-        auto glPriorEllipsoid = mrpt::opengl::CEllipsoid3D::Create();
-        glPriorEllipsoid->set3DsegmentsCount(16);
-        glPriorEllipsoid->enableDrawSolid3D(true);
-        glPriorEllipsoid->setColor_u8(0xff, 0xff, 0x00, 0x50);
-        glPriorEllipsoid->setCovMatrixAndMean(
-            priorCov.blockCopy<3, 3>(0, 0), lr.prior->mean.asVectorVal().head<3>());
-        glPriorEllipsoid->setName("Prior");
-        glPriorEllipsoid->enableShowName(true);
-        glVizICP->insert(glPriorEllipsoid);
+      app.iterationValue = app.showInitialPose ? 0.0f : static_cast<float>(app.iterationMax);
     }
 
-    // GLOBAL PC:
-    mp2p_icp::render_params_t rpGlobal;
+    auto   it    = lr.iterationsDetails->begin();
+    size_t nIter = mrpt::round(app.iterationValue);
+    mrpt::keep_min(nIter, lr.iterationsDetails->size() - 1);
+    std::advance(it, static_cast<std::ptrdiff_t>(nIter));
 
-    rpGlobal.points.visible = false;
-    for (const auto& [lyName, cb] : cbLayersByName_global)
+    relativePose.mean = it->second.optimalPose;
+    if (app.viewPairings)
     {
-        // Update stats in the cb label:
-        cb->setCaption(lyName);  // default
-        if (auto itL = lr.pcGlobal->layers.find(lyName); itL != lr.pcGlobal->layers.end())
-        {
-            if (auto pc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itL->second); pc)
-            {
-                cb->setCaption(
-                    lyName + " | "s + mrpt::system::unitsFormat(static_cast<double>(pc->size())) +
-                    " points"s + " | class="s + pc->GetRuntimeClass()->className);
-            }
-            else
-            {
-                cb->setCaption(lyName + " | class="s + itL->second->GetRuntimeClass()->className);
-            }
-        }
-
-        // show/hide:
-        if (!cb->checked())
-        {
-            continue;  // hidden
-        }
-        rpGlobal.points.visible = true;
-
-        auto& rpL                       = rpGlobal.points.perLayer[lyName];
-        rpL.pointSize                   = slGlobalPointSize->value();
-        rpL.render_voxelmaps_as_points  = cbViewVoxelsAsPoints->checked();
-        rpL.render_voxelmaps_free_space = cbViewVoxelsFreeSpace->checked();
-
-        if (cbColorizeGlobalMap->checked())
-        {
-            auto& cm             = rpL.colorMode.emplace();
-            cm.colorMap          = mrpt::img::TColormap::cmHOT;
-            cm.recolorizeByField = "z";
-        }
+      pairsToViz = &it->second.pairings;
     }
 
-    static mrpt::opengl::CSetOfObjects::Ptr lastGlobalPts;
+    app.iterationCaption = "Show ICP iteration: "s + std::to_string(it->first) + "/"s +
+                            std::to_string(lr.iterationsDetails->rbegin()->first);
+  }
 
-    if (!lastGlobalPts || regenerateMaps)
+  {
+    std::string s;
+    for (int i = 0; i < 6; i++)
     {
-        // Show all or selected layers:
-        for (auto& rpL : rpGlobal.points.perLayer)
-        {
-            rpL.second.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0xff);
-        }
-
-        auto glPts    = lr.pcGlobal->get_visualization(rpGlobal);
-        lastGlobalPts = glPts;
-
-        // Show all or selected layers:
-        rpGlobal.points.allLayers.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0xff);
-
-        glVizICP->insert(glPts);
+      const auto sigma = std::sqrt(relativePose.cov(i, i));
+      s += (i < 3) ? mrpt::format("%.02fm ", sigma) : mrpt::format("%.02fd ", mrpt::RAD2DEG(sigma));
     }
-    else
+    s += mrpt::format(
+        " det(XYZ)=%.02e det(rot)=%.02e", relativePose.cov.blockCopy<3, 3>(0, 0).det(),
+        relativePose.cov.blockCopy<3, 3>(3, 3).det());
+    app.statCovariance = s;
+  }
+
+  const mrpt::poses::CPosePDFGaussian pose2D(relativePose);
+
+  app.statConditionNumber = mrpt::format(
+      " cn{XYZ}=%.02f cn{SO(3)}=%.02f cn{SE(2)}=%.02f cn{SE(3)}=%.02f",
+      conditionNumber(relativePose.cov.blockCopy<3, 3>(0, 0)),
+      conditionNumber(relativePose.cov.blockCopy<3, 3>(3, 3)), conditionNumber(pose2D.cov),
+      conditionNumber(relativePose.cov));
+
+  // 3D objects -------------------
+  auto glCornerFrom = mrpt::opengl::stock_objects::CornerXYZSimple(0.75f, 3.0f);
+  glCornerFrom->setPose(poseFromCorner);
+  app.glVizICP->insert(glCornerFrom);
+
+  auto glCornerLocal = mrpt::opengl::stock_objects::CornerXYZSimple(0.85f, 5.0f);
+  glCornerLocal->setPose(relativePose.mean);
+  glCornerLocal->setName("Local");
+  glCornerLocal->enableShowName(true);
+  app.glVizICP->insert(glCornerLocal);
+
+  auto glCornerToCov = mrpt::opengl::CEllipsoid3D::Create();
+  glCornerToCov->set3DsegmentsCount(16);
+  glCornerToCov->enableDrawSolid3D(true);
+  glCornerToCov->setColor_u8(0xff, 0x00, 0x00, 0x40);
+  glCornerToCov->setCovMatrixAndMean(
+      relativePose.cov.blockCopy<3, 3>(0, 0), relativePose.mean.asVectorVal().head<3>());
+  app.glVizICP->insert(glCornerToCov);
+
+  if (lr.prior.has_value() && app.viewPriorEllipsoid)
+  {
+    const auto priorCov = mrpt::math::CMatrixDouble66(lr.prior->cov_inv.inverse());
+
+    auto glPriorEllipsoid = mrpt::opengl::CEllipsoid3D::Create();
+    glPriorEllipsoid->set3DsegmentsCount(16);
+    glPriorEllipsoid->enableDrawSolid3D(true);
+    glPriorEllipsoid->setColor_u8(0xff, 0xff, 0x00, 0x50);
+    glPriorEllipsoid->setCovMatrixAndMean(
+        priorCov.blockCopy<3, 3>(0, 0), lr.prior->mean.asVectorVal().head<3>());
+    glPriorEllipsoid->setName("Prior");
+    glPriorEllipsoid->enableShowName(true);
+    app.glVizICP->insert(glPriorEllipsoid);
+  }
+
+  // GLOBAL PC:
+  mp2p_icp::render_params_t rpGlobal;
+  rpGlobal.points.visible = false;
+  for (const auto& lyName : app.layerNamesGlobal)
+  {
+    if (!app.layerVisibleGlobal[lyName])
     {
-        // avoid the costly method of re-rendering maps, if possible:
-        glVizICP->insert(lastGlobalPts);
+      continue;
     }
+    rpGlobal.points.visible = true;
 
-    // LOCAL PC:
-    mp2p_icp::render_params_t rpLocal;
+    auto& rpL                       = rpGlobal.points.perLayer[lyName];
+    rpL.pointSize                   = app.globalPointSize;
+    rpL.render_voxelmaps_as_points  = app.viewVoxelsAsPoints;
+    rpL.render_voxelmaps_free_space = app.viewVoxelsFreeSpace;
 
-    rpLocal.points.visible = false;
-    for (const auto& [lyName, cb] : cbLayersByName_local)
+    if (app.colorizeGlobalMap)
     {
-        // Update stats in the cb label:
-        cb->setCaption(lyName);  // default
-        if (auto itL = lr.pcLocal->layers.find(lyName); itL != lr.pcLocal->layers.end())
-        {
-            if (auto pc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itL->second); pc)
-            {
-                cb->setCaption(
-                    lyName + " | "s +
-                    mrpt::system::unitsFormat(static_cast<double>(pc->size()), 2, false) +
-                    " points"s + " | class="s + pc->GetRuntimeClass()->className);
-            }
-            else
-            {
-                cb->setCaption(lyName + " | class="s + itL->second->GetRuntimeClass()->className);
-            }
-        }
-
-        // show/hide:
-        if (!cb->checked())
-        {
-            continue;  // hidden
-        }
-        rpLocal.points.visible = true;
-
-        auto& rpL                       = rpLocal.points.perLayer[lyName];
-        rpL.pointSize                   = slLocalPointSize->value();
-        rpL.render_voxelmaps_as_points  = cbViewVoxelsAsPoints->checked();
-        rpL.render_voxelmaps_free_space = cbViewVoxelsFreeSpace->checked();
-        if (cbColorizeLocalMap->checked())
-        {
-            auto& cm             = rpL.colorMode.emplace();
-            cm.colorMap          = mrpt::img::TColormap::cmHOT;
-            cm.recolorizeByField = "z";
-        }
+      auto& cm             = rpL.colorMode.emplace();
+      cm.colorMap          = mrpt::img::TColormap::cmHOT;
+      cm.recolorizeByField = "z";
     }
+  }
+  for (auto& rpL : rpGlobal.points.perLayer)
+  {
+    rpL.second.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0xff);
+  }
+  rpGlobal.points.allLayers.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0xff);
 
-    static mrpt::opengl::CSetOfObjects::Ptr lastLocalPts;
+  static std::optional<mp2p_icp::render_params_t> prevRpGlobal;
+  static mrpt::opengl::CSetOfObjects::Ptr          lastGlobalPts;
 
-    if (!lastLocalPts || regenerateMaps)
+  if (indexChanged || !prevRpGlobal.has_value() || *prevRpGlobal != rpGlobal)
+  {
+    prevRpGlobal  = rpGlobal;
+    lastGlobalPts = lr.pcGlobal->get_visualization(rpGlobal);
+  }
+  app.glVizICP->insert(lastGlobalPts);
+
+  // LOCAL PC:
+  mp2p_icp::render_params_t rpLocal;
+  rpLocal.points.visible = false;
+  for (const auto& lyName : app.layerNamesLocal)
+  {
+    if (!app.layerVisibleLocal[lyName])
     {
-        // Show all or selected layers:
-        for (auto& rpL : rpLocal.points.perLayer)
-        {
-            rpL.second.color = mrpt::img::TColor(0x00, 0x00, 0xff, 0xff);
-        }
-
-        auto glPts   = lr.pcLocal->get_visualization(rpLocal);
-        lastLocalPts = glPts;
-
-        glVizICP->insert(glPts);
+      continue;
     }
-    else
+    rpLocal.points.visible = true;
+
+    auto& rpL                       = rpLocal.points.perLayer[lyName];
+    rpL.pointSize                   = app.localPointSize;
+    rpL.render_voxelmaps_as_points  = app.viewVoxelsAsPoints;
+    rpL.render_voxelmaps_free_space = app.viewVoxelsFreeSpace;
+
+    if (app.colorizeLocalMap)
     {
-        // avoid the costly method of re-rendering maps, if possible:
-        glVizICP->insert(lastLocalPts);
+      auto& cm             = rpL.colorMode.emplace();
+      cm.colorMap          = mrpt::img::TColormap::cmHOT;
+      cm.recolorizeByField = "z";
     }
-    lastLocalPts->setPose(relativePose.mean);
+  }
+  for (auto& rpL : rpLocal.points.perLayer)
+  {
+    rpL.second.color = mrpt::img::TColor(0x00, 0x00, 0xff, 0xff);
+  }
 
-    // Global view options:
-    {
-        std::lock_guard<std::mutex> lck(win->background_scene_mtx);
-        win->camera().setCameraProjective(!cbViewOrtho->checked());
+  static std::optional<mp2p_icp::render_params_t> prevRpLocal;
+  static mrpt::opengl::CSetOfObjects::Ptr          lastLocalPts;
 
-        if (cbCameraFollowsLocal->checked())
-        {
-            const auto camLoc = relativePose.mean.translation().cast<float>();
-            win->camera().setCameraPointing(camLoc.x, camLoc.y, camLoc.z);
-        }
+  if (indexChanged || !prevRpLocal.has_value() || *prevRpLocal != rpLocal)
+  {
+    prevRpLocal  = rpLocal;
+    lastLocalPts = lr.pcLocal->get_visualization(rpLocal);
+  }
+  app.glVizICP->insert(lastLocalPts);
+  lastLocalPts->setPose(relativePose.mean);
 
-        // clip planes:
-        const auto depthFieldMid       = std::pow(10.0, slMidDepthField->value());
-        const auto depthFieldThickness = std::pow(10.0, slThicknessDepthField->value());
+  // Global view options:
+  auto& cam = app.sceneView.camera();
+  cam.setProjectiveModel(!app.viewOrtho);
 
-        const auto clipNear = std::max(1e-2, depthFieldMid - 0.5 * depthFieldThickness);
-        const auto clipFar  = depthFieldMid + 0.5 * depthFieldThickness;
+  if (app.cameraFollowsLocal)
+  {
+    const auto camLoc = relativePose.mean.translation().cast<float>();
+    cam.setPointingAt(camLoc.x, camLoc.y, camLoc.z);
+  }
 
-        lbDepthFieldMid->setCaption(mrpt::format("Frustrum depth center: %.03f", depthFieldMid));
-        lbDepthFieldThickness->setCaption(
-            mrpt::format("Frustum depth thickness: %.03f", depthFieldThickness));
-        lbDepthFieldValues->setCaption(
-            mrpt::format("Frustum: near=%.02f far=%.02f", clipNear, clipFar));
+  const auto depthFieldMid       = std::pow(10.0, app.midDepthField);
+  const auto depthFieldThickness = std::pow(10.0, app.thicknessDepthField);
+  const auto clipNear            = std::max(1e-2, depthFieldMid - 0.5 * depthFieldThickness);
+  const auto clipFar             = depthFieldMid + 0.5 * depthFieldThickness;
 
-        win->background_scene->getViewport()->setViewportClipDistances(
-            static_cast<float>(clipNear), static_cast<float>(clipFar));
-        win->camera().setMaximumZoom(std::max<float>(1000, static_cast<float>(3.0 * clipFar)));
-    }
+  app.scene->getViewport("main")->setViewportClipDistances(
+      static_cast<float>(clipNear), static_cast<float>(clipFar));
 
-    // Pairings ------------------
+  // Pairings ------------------
+  if (pairsToViz)
+  {
+    const double planeCovScale = std::pow(10.0, app.pairingsPl2PlSize);
 
-    // viz pairings:
-    if (pairsToViz)
-    {
-        const double planeCovScale = std::pow(10.0, slPairingsPl2PlSize->value());
+    mp2p_icp::pairings_render_params_t rp;
+    rp.pt2pt.visible        = app.viewPairingsPt2Pt;
+    rp.pt2pl.visible        = app.viewPairingsPt2Pl;
+    rp.pt2pl.planePatchSize = planeCovScale;
 
-        mp2p_icp::pairings_render_params_t rp;
+    rp.cov2cov.visible    = app.viewPairingsCov2Cov;
+    rp.cov2cov.decimation = static_cast<std::size_t>(std::pow(10.0, app.pairingsCov2CovDecim));
+    rp.cov2cov.covScale   = planeCovScale;
 
-        rp.pt2pt.visible        = cbViewPairings_pt2pt->checked();
-        rp.pt2pl.visible        = cbViewPairings_pt2pl->checked();
-        rp.pt2pl.planePatchSize = planeCovScale;
+    rp.pt2ln.visible    = app.viewPairingsPt2Ln;
+    rp.pt2ln.lineLength = std::pow(10.0, app.pairingsPl2LnSize);
 
-        rp.cov2cov.visible = cbViewPairings_cov2cov->checked();
-        rp.cov2cov.decimation =
-            static_cast<std::size_t>(std::pow(10.0, slPairingsCov2CovDecimation->value()));
-        rp.cov2cov.covScale = planeCovScale;
+    app.glVizICP->insert(pairsToViz->get_visualization(relativePose.mean, rp));
+    app.pairingsSummary = pairsToViz->contents_summary();
+  }
+  else
+  {
+    app.pairingsSummary = "None selected (mark one of the checkboxes below)";
+  }
 
-        rp.pt2ln.visible    = cbViewPairings_pt2ln->checked();
-        rp.pt2ln.lineLength = std::pow(10.0, slPairingsPl2LnSize->value());
-
-        glVizICP->insert(pairsToViz->get_visualization(relativePose.mean, rp));
-
-        tbPairings->setValue(pairsToViz->contents_summary());
-    }
-    else
-    {
-        tbPairings->setValue("None selected (mark one of the checkboxes below)");
-    }
-
-    // XYZ corner overlay viewport:
-    {
-        auto gl_view = win->background_scene->createViewport("small-view");
-
-        gl_view->setViewportPosition(0, 0, 0.1, 0.1 * 16.0 / 9.0);
-        gl_view->setTransparent(true);
-        {
-            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("X");
-            obj->setLocation(1.1, 0, 0);
-            gl_view->insert(obj);
-        }
-        {
-            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Y");
-            obj->setLocation(0, 1.1, 0);
-            gl_view->insert(obj);
-        }
-        {
-            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Z");
-            obj->setLocation(0, 0, 1.1);
-            gl_view->insert(obj);
-        }
-        gl_view->insert(mrpt::opengl::stock_objects::CornerXYZ());
-    }
+  ensureMiniCornerViewport();
 }
 catch (const std::exception& e)
 {
-    std::cerr << "[rebuild_3d_view] Exception: " << mrpt::exception_to_str(e) << std::endl;
-    if (lbICPStats[0])
-        lbICPStats[0]->setValue(std::string("ERROR: ") + mrpt::exception_to_str(e).substr(0, 80));
+  std::cerr << "[rebuild_3d_view] Exception: " << mrpt::exception_to_str(e) << std::endl;
+  app.statFileName = std::string("ERROR: ") + mrpt::exception_to_str(e).substr(0, 80);
 }
 
-#else  // MRPT_HAS_NANOGUI
-namespace
+void onExport(const std::string& outFile)
 {
-void main_show_gui()
-{
-    THROW_EXCEPTION(
-        "This application requires a version of MRPT built with nanogui "
-        "support.");
+  const size_t idx = static_cast<size_t>(app.selectorIdx);
+  auto&        lr  = app.logRecords.at(idx).get();
+
+  const mp2p_icp::metric_map_t& m = (app.exportWhich == 0) ? *lr.pcLocal : *lr.pcGlobal;
+  if (bool ok = m.save_to_file(outFile); !ok)
+  {
+    std::cerr << "Error saving file: " << outFile << "\n";
+  }
 }
+
+/** "Control" window: file selector, navigation, iteration slider, summary stat lines. */
+void renderControlPanel()
+{
+  ImGui::Begin("Control");
+
+  ImGui::Checkbox("Show at INITIAL GUESS pose", &app.showInitialPose);
+
+  ImGui::BeginDisabled(!app.iterationEnabled);
+  ImGui::TextUnformatted(app.iterationCaption.c_str());
+  ImGui::SetNextItemWidth(-1);
+  ImGui::SliderFloat("##iterationSlider", &app.iterationValue, 0.0f, static_cast<float>(std::max(0, app.iterationMax)));
+  ImGui::EndDisabled();
+
+  ImGui::Separator();
+  ImGui::Text("Select ICP record file (N=%u)", static_cast<unsigned int>(app.logRecords.size()));
+  ImGui::SetNextItemWidth(-1);
+  ImGui::SliderInt("##selectorIdx", &app.selectorIdx, 0, static_cast<int>(app.logRecords.size()) - 1);
+
+  ImGui::TextUnformatted(app.statFileName.c_str());
+  ImGui::TextUnformatted(app.statLogSummary.c_str());
+  ImGui::TextUnformatted(app.statQuality.c_str());
+  ImGui::TextWrapped("%s", app.statGlobalSummary.c_str());
+  ImGui::TextWrapped("%s", app.statLocalSummary.c_str());
+
+  ImGui::BeginDisabled(app.selectorIdx <= 0);
+  if (ImGui::Button("<<"))
+  {
+    app.selectorIdx--;
+  }
+  ImGui::EndDisabled();
+  ImGui::SameLine();
+  ImGui::BeginDisabled(app.selectorIdx >= static_cast<int>(app.logRecords.size()) - 1);
+  if (ImGui::Button(">>"))
+  {
+    app.selectorIdx++;
+  }
+  ImGui::EndDisabled();
+  ImGui::SameLine();
+  ImGui::Checkbox("Autoplay", &app.isAutoPlayActive);
+
+  ImGui::End();
+}
+
+/** "Summary" window: ICP result pose, deltas, covariance, prior. */
+void renderSummaryPanel()
+{
+  ImGui::Begin("Summary");
+
+  ImGui::TextUnformatted("ICP result pose [x y z yaw(deg) pitch(deg) roll(deg)]:");
+  ImGui::TextWrapped("%s", app.statLogPose.c_str());
+
+  ImGui::TextUnformatted("Initial -> final pose change:");
+  ImGui::TextWrapped("%s", app.statInit2Final.c_str());
+
+  ImGui::TextUnformatted("Uncertainty: diagonal sigmas (x y z [m] yaw pitch roll [deg])");
+  ImGui::TextWrapped("%s", app.statCovariance.c_str());
+
+  ImGui::TextUnformatted("Uncertainty: Covariance condition numbers");
+  ImGui::TextWrapped("%s", app.statConditionNumber.c_str());
+
+  ImGui::Separator();
+  ImGui::TextUnformatted("Initial guess pose:");
+  ImGui::TextWrapped("%s", app.statInitialGuess.c_str());
+
+  ImGui::TextUnformatted("Prior mean pose (if any):");
+  ImGui::TextWrapped("%s", app.statPriorMean.c_str());
+
+  ImGui::TextUnformatted("Prior: diagonal sigmas (x y z [m] yaw pitch roll [deg])");
+  ImGui::TextWrapped("%s", app.statPriorInfo.c_str());
+
+  ImGui::End();
+}
+
+/** "Variables" window: dynamic (YAML-expression) variables active in this ICP record. */
+void renderVariablesPanel()
+{
+  ImGui::Begin("Variables");
+  ImGui::TextUnformatted("Dynamic variables:");
+  if (ImGui::BeginChild("##dynVars", ImVec2(0, 0), true))
+  {
+    for (const auto& line : app.dynVariableLines)
+    {
+      ImGui::TextUnformatted(line.c_str());
+    }
+  }
+  ImGui::EndChild();
+  ImGui::End();
+}
+
+/** "Maps" window: global/local layer visibility + export buttons. */
+void renderMapsPanel()
+{
+  ImGui::Begin("Maps");
+
+  if (ImGui::Button("Export 'local' map..."))
+  {
+    app.exportWhich = 0;
+    app.exportDialog.open(mp2p_icp_viz::SimpleFileDialog::Mode::Save, {{"mm", "(*.mm)"}}, "Export local map");
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Export 'global' map..."))
+  {
+    app.exportWhich = 1;
+    app.exportDialog.open(mp2p_icp_viz::SimpleFileDialog::Mode::Save, {{"mm", "(*.mm)"}}, "Export global map");
+  }
+  if (auto path = app.exportDialog.render(); path.has_value())
+  {
+    onExport(*path);
+  }
+
+  ImGui::Separator();
+  ImGui::TextUnformatted("[GLOBAL map] Visible layers:");
+  ImGui::PushID("globalLayers");
+  for (const auto& lyName : app.layerNamesGlobal)
+  {
+    ImGui::Checkbox(lyName.c_str(), &app.layerVisibleGlobal[lyName]);
+  }
+  ImGui::PopID();
+
+  ImGui::Separator();
+  ImGui::TextUnformatted("[LOCAL map] Visible layers:");
+  ImGui::PushID("localLayers");
+  for (const auto& lyName : app.layerNamesLocal)
+  {
+    ImGui::Checkbox(lyName.c_str(), &app.layerVisibleLocal[lyName]);
+  }
+  ImGui::PopID();
+
+  ImGui::End();
+}
+
+/** "Pairings" window: pairing type toggles, sizes/decimation, summary. */
+void renderPairingsPanel()
+{
+  ImGui::Begin("Pairings");
+
+  ImGui::TextWrapped("%s", app.pairingsSummary.c_str());
+
+  ImGui::Checkbox("View pairings", &app.viewPairings);
+
+  ImGui::Checkbox("View: point-to-point", &app.viewPairingsPt2Pt);
+
+  ImGui::Checkbox("View: cov-to-cov", &app.viewPairingsCov2Cov);
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(140);
+  ImGui::SliderFloat("Decimation", &app.pairingsCov2CovDecim, 0.0f, 3.0f);
+
+  ImGui::Checkbox("View: point-to-plane", &app.viewPairingsPt2Pl);
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(140);
+  ImGui::SliderFloat("Plane size", &app.pairingsPl2PlSize, -4.0f, 2.0f);
+
+  ImGui::Checkbox("View: point-to-line", &app.viewPairingsPt2Ln);
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(140);
+  ImGui::SliderFloat("Line length", &app.pairingsPl2LnSize, -2.0f, 2.0f);
+
+  ImGui::End();
+}
+
+/** "View" window: point sizes, depth clip, ortho, camera-follow, voxel/colorize options. */
+void renderViewPanel()
+{
+  ImGui::Begin("View");
+
+  ImGui::SliderFloat("Global map point size", &app.globalPointSize, 1.0f, 10.0f);
+  ImGui::SliderFloat("Local map point size", &app.localPointSize, 1.0f, 10.0f);
+
+  ImGui::SliderFloat("Center depth clip plane", &app.midDepthField, -2.0f, 3.0f);
+  ImGui::SliderFloat("Max-Min depth thickness", &app.thicknessDepthField, -2.0f, 6.0f);
+
+  const auto depthFieldMid       = std::pow(10.0, app.midDepthField);
+  const auto depthFieldThickness = std::pow(10.0, app.thicknessDepthField);
+  const auto clipNear            = std::max(1e-2, depthFieldMid - 0.5 * depthFieldThickness);
+  const auto clipFar             = depthFieldMid + 0.5 * depthFieldThickness;
+  ImGui::Text("Frustum: near=%.02f far=%.02f", clipNear, clipFar);
+
+  ImGui::Checkbox("Orthogonal view", &app.viewOrtho);
+  ImGui::Checkbox("Camera follows 'local'", &app.cameraFollowsLocal);
+  ImGui::Checkbox("Render voxel maps as point clouds", &app.viewVoxelsAsPoints);
+  ImGui::Checkbox("Render free space of voxel maps", &app.viewVoxelsFreeSpace);
+  ImGui::Checkbox("Recolorize local map", &app.colorizeLocalMap);
+  ImGui::Checkbox("Recolorize global map", &app.colorizeGlobalMap);
+  ImGui::Checkbox("View prior ellipsoid", &app.viewPriorEllipsoid);
+
+  ImGui::End();
+}
+
+/** "Manual" window: 6-DoF manual nudge of the current record's optimal_tf pose. */
+void renderManualPanel()
+{
+  ImGui::Begin("Manual");
+  ImGui::TextUnformatted("Manual solution modification:");
+
+  constexpr float           handTunedRange[6] = {4.0f, 4.0f, 10.0f, 0.5f * static_cast<float>(M_PI),
+                                        0.25f * static_cast<float>(M_PI), 0.5f};
+  constexpr const char*     labels[6]         = {"X", "Y", "Z", "Yaw", "Pitch", "Roll"};
+
+  const size_t idx = static_cast<size_t>(app.selectorIdx);
+  for (int i = 0; i < 6; i++)
+  {
+    if (ImGui::SliderFloat(labels[i], &app.gtPose[i], -handTunedRange[i], handTunedRange[i]) &&
+        idx < app.logRecords.size())
+    {
+      auto& lr = app.logRecords.at(idx).get();
+      auto  p  = lr.icpResult.optimal_tf.mean.asTPose();
+      p[i]     = app.gtPose[i];
+      lr.icpResult.optimal_tf.mean = mrpt::poses::CPose3D(p);
+    }
+  }
+
+  ImGui::End();
+}
+
+void renderSceneWindow()
+{
+  ImGui::Begin("3D View");
+  app.sceneView.render();
+  ImGui::End();
+}
+
+void renderFrame()
+{
+  handleKeyboard();
+  processAutoPlay();
+  rebuild_3d_view();
+  updateMiniCornerView();
+
+  renderControlPanel();
+  renderSummaryPanel();
+  renderVariablesPanel();
+  renderMapsPanel();
+  renderPairingsPanel();
+  renderViewPanel();
+  renderManualPanel();
+  renderSceneWindow();
+}
+
+int mainShowGui()
+{
+  mrpt::system::CDirectoryExplorer::TFileInfoList files;
+
+  if (argSingleFile.empty())
+  {
+    const std::string searchDir = argSearchDir;
+    ASSERT_DIRECTORY_EXISTS_(searchDir);
+
+    std::cout << "Searching in: '" << searchDir << "' for files with extension '" << argExtension
+               << "'" << std::endl;
+
+    mrpt::system::CDirectoryExplorer::explore(searchDir, FILE_ATTRIB_ARCHIVE, files);
+    mrpt::system::CDirectoryExplorer::filterByExtension(files, argExtension);
+    mrpt::system::CDirectoryExplorer::sortByName(files);
+
+    std::cout << "Found " << files.size() << " ICP records." << std::endl;
+  }
+  else
+  {
+    std::cout << "Loading one single log file: " << argSingleFile << std::endl;
+    files.resize(1);
+    files[0].wholePath = argSingleFile;
+  }
+
+  if (argMinQualityOpt && argMinQualityOpt->count() > 0)
+  {
+    const double minQ = argMinQuality;
+    if (minQ < 0.0 || minQ > 1.0)
+    {
+      THROW_EXCEPTION_FMT("--min-quality must be in [0,1]. Got: %.03f", minQ);
+    }
+    std::cout << "Applying minimum quality filter: q >= " << minQ << std::endl;
+
+    mrpt::system::CDirectoryExplorer::TFileInfoList filteredFiles;
+    for (const auto& file : files)
+    {
+      mp2p_icp::LogRecord lr;
+      if (!lr.load_from_file(file.wholePath))
+      {
+        std::cerr << "  Warning: could not load '" << file.wholePath << "'" << std::endl;
+        continue;
+      }
+      if (lr.icpResult.quality >= minQ)
+      {
+        filteredFiles.push_back(file);
+      }
+      else
+      {
+        std::cout << "  Skipping (quality=" << lr.icpResult.quality << " < " << minQ
+                   << "): " << file.name << std::endl;
+      }
+    }
+    std::cout << "Quality filter: kept " << filteredFiles.size() << " / " << files.size()
+               << " files." << std::endl;
+
+    if (files.empty())
+    {
+      THROW_EXCEPTION_FMT(
+          "No log files passed --min-quality=%.03f. Lower the threshold or check input logs.",
+          minQ);
+    }
+    files = std::move(filteredFiles);
+  }
+
+  for (const auto& file : files)
+  {
+    app.logRecords.emplace_back(file.wholePath, file.name);
+  }
+  ASSERT_(!app.logRecords.empty());
+
+  {
+    const auto& lr = app.logRecords.front().get();
+    if (app.layerNamesGlobal.empty() && lr.pcGlobal)
+    {
+      for (const auto& layer : lr.pcGlobal->layers)
+      {
+        app.layerNamesGlobal.push_back(layer.first);
+        app.layerVisibleGlobal[layer.first] = true;
+        std::cout << "Global point cloud: Found point layer='" << layer.first << "'\n";
+      }
+    }
+    if (app.layerNamesLocal.empty() && lr.pcLocal)
+    {
+      for (const auto& layer : lr.pcLocal->layers)
+      {
+        app.layerNamesLocal.push_back(layer.first);
+        app.layerVisibleLocal[layer.first] = true;
+        std::cout << "Local point cloud: Found point layer='" << layer.first << "'\n";
+      }
+    }
+  }
+
+  if (!app.shell.init(APP_NAME, 1280, 800))
+  {
+    return 1;
+  }
+
+  // Default docking layout (only applied once, when no imgui.ini layout exists yet):
+  // "Control" as a thin left strip, the option panels tabbed below it, "3D View" filling the
+  // remaining (background) area.
+  app.shell.setupDefaultLayout = [](unsigned int dockspaceId)
+  {
+    ImGuiID rightId = 0;
+    ImGuiID leftId  = ImGui::DockBuilderSplitNode(dockspaceId, ImGuiDir_Left, 0.30f, nullptr, &rightId);
+
+    ImGuiID leftBottomId = 0;
+    ImGuiID leftTopId =
+        ImGui::DockBuilderSplitNode(leftId, ImGuiDir_Up, 0.4f, nullptr, &leftBottomId);
+
+    ImGui::DockBuilderDockWindow("Control", leftTopId);
+    ImGui::DockBuilderDockWindow("Summary", leftBottomId);
+    ImGui::DockBuilderDockWindow("Variables", leftBottomId);
+    ImGui::DockBuilderDockWindow("Maps", leftBottomId);
+    ImGui::DockBuilderDockWindow("Pairings", leftBottomId);
+    ImGui::DockBuilderDockWindow("View", leftBottomId);
+    ImGui::DockBuilderDockWindow("Manual", leftBottomId);
+    ImGui::DockBuilderDockWindow("3D View", rightId);
+  };
+
+  // Background scene:
+  {
+    auto glGrid = mrpt::opengl::CGridPlaneXY::Create();
+    glGrid->setColor_u8(0xff, 0xff, 0xff, 0x10);
+    app.scene->insert(glGrid);
+  }
+
+  auto glBase = mrpt::opengl::stock_objects::CornerXYZ(1.0f);
+  glBase->setName("Global");
+  glBase->enableShowName();
+  app.scene->insert(glBase);
+
+  app.scene->insert(app.glVizICP);
+
+  app.sceneView.setScene(app.scene);
+
+  app.sceneView.camera().setPointingAt(8.0f, 0.0f, 0.0f);
+  app.sceneView.camera().setAzimuthDegrees(110.0f);
+  app.sceneView.camera().setElevationDegrees(15.0f);
+  app.sceneView.camera().setZoomDistance(30.0f);
+
+  // Load/save persistent UI+camera state across sessions:
+  char appCfgFile[1024];
+  ::get_user_config_file(appCfgFile, sizeof(appCfgFile), APP_NAME);
+  mrpt::config::CConfigFile appCfg(appCfgFile);
+
+  auto& cam                = app.sceneView.camera();
+  app.colorizeLocalMap     = appCfg.read_bool("", "cbColorizeLocalMap", app.colorizeLocalMap);
+  app.colorizeGlobalMap    = appCfg.read_bool("", "cbColorizeGlobalMap", app.colorizeGlobalMap);
+  app.showInitialPose      = appCfg.read_bool("", "cbShowInitialPose", app.showInitialPose);
+  app.viewOrtho            = appCfg.read_bool("", "cbViewOrtho", app.viewOrtho);
+  app.cameraFollowsLocal   = appCfg.read_bool("", "cbCameraFollowsLocal", app.cameraFollowsLocal);
+  app.viewVoxelsAsPoints   = appCfg.read_bool("", "cbViewVoxelsAsPoints", app.viewVoxelsAsPoints);
+  app.viewPairings         = appCfg.read_bool("", "cbViewPairings", app.viewPairings);
+  app.viewPairingsPt2Pt    = appCfg.read_bool("", "cbViewPairings_pt2pt", app.viewPairingsPt2Pt);
+  app.viewPairingsPt2Pl    = appCfg.read_bool("", "cbViewPairings_pt2pl", app.viewPairingsPt2Pl);
+  app.viewPairingsPt2Ln    = appCfg.read_bool("", "cbViewPairings_pt2ln", app.viewPairingsPt2Ln);
+  app.viewPairingsCov2Cov  = appCfg.read_bool("", "cbViewPairings_cov2cov", app.viewPairingsCov2Cov);
+  app.viewPriorEllipsoid   = appCfg.read_bool("", "cbViewPriorEllipsoid", app.viewPriorEllipsoid);
+
+  app.pairingsPl2PlSize    = appCfg.read_float("", "slPairingsPl2PlSize", app.pairingsPl2PlSize);
+  app.pairingsPl2LnSize    = appCfg.read_float("", "slPairingsPl2LnSize", app.pairingsPl2LnSize);
+  app.pairingsCov2CovDecim = appCfg.read_float("", "slPairingsCov2CovDecimation", app.pairingsCov2CovDecim);
+  app.globalPointSize      = appCfg.read_float("", "slGlobalPointSize", app.globalPointSize);
+  app.localPointSize       = appCfg.read_float("", "slLocalPointSize", app.localPointSize);
+  app.midDepthField        = appCfg.read_float("", "slMidDepthField", app.midDepthField);
+  app.thicknessDepthField  = appCfg.read_float("", "slThicknessDepthField", app.thicknessDepthField);
+
+  cam.setPointingAt(
+      appCfg.read_float("", "cam_x", cam.getPointingAtX()),
+      appCfg.read_float("", "cam_y", cam.getPointingAtY()),
+      appCfg.read_float("", "cam_z", cam.getPointingAtZ()));
+  cam.setAzimuthDegrees(appCfg.read_float("", "cam_az", cam.getAzimuthDegrees()));
+  cam.setElevationDegrees(appCfg.read_float("", "cam_el", cam.getElevationDegrees()));
+  cam.setZoomDistance(appCfg.read_float("", "cam_d", cam.getZoomDistance()));
+
+  app.shell.run(&renderFrame);
+
+  appCfg.write("", "cbColorizeLocalMap", app.colorizeLocalMap);
+  appCfg.write("", "cbColorizeGlobalMap", app.colorizeGlobalMap);
+  appCfg.write("", "cbShowInitialPose", app.showInitialPose);
+  appCfg.write("", "cbViewOrtho", app.viewOrtho);
+  appCfg.write("", "cbCameraFollowsLocal", app.cameraFollowsLocal);
+  appCfg.write("", "cbViewVoxelsAsPoints", app.viewVoxelsAsPoints);
+  appCfg.write("", "cbViewPairings", app.viewPairings);
+  appCfg.write("", "cbViewPairings_pt2pt", app.viewPairingsPt2Pt);
+  appCfg.write("", "cbViewPairings_pt2pl", app.viewPairingsPt2Pl);
+  appCfg.write("", "cbViewPairings_pt2ln", app.viewPairingsPt2Ln);
+  appCfg.write("", "cbViewPairings_cov2cov", app.viewPairingsCov2Cov);
+  appCfg.write("", "cbViewPriorEllipsoid", app.viewPriorEllipsoid);
+
+  appCfg.write("", "slPairingsPl2PlSize", app.pairingsPl2PlSize);
+  appCfg.write("", "slPairingsPl2LnSize", app.pairingsPl2LnSize);
+  appCfg.write("", "slPairingsCov2CovDecimation", app.pairingsCov2CovDecim);
+  appCfg.write("", "slGlobalPointSize", app.globalPointSize);
+  appCfg.write("", "slLocalPointSize", app.localPointSize);
+  appCfg.write("", "slMidDepthField", app.midDepthField);
+  appCfg.write("", "slThicknessDepthField", app.thicknessDepthField);
+
+  appCfg.write("", "cam_x", cam.getPointingAtX());
+  appCfg.write("", "cam_y", cam.getPointingAtY());
+  appCfg.write("", "cam_z", cam.getPointingAtZ());
+  appCfg.write("", "cam_az", cam.getAzimuthDegrees());
+  appCfg.write("", "cam_el", cam.getElevationDegrees());
+  appCfg.write("", "cam_d", cam.getZoomDistance());
+
+  app.shell.shutdown();
+  return 0;
+}
+
 }  // namespace
-
-#endif  // MRPT_HAS_NANOGUI
 
 int main(int argc, char** argv)
 {
-    cmd.add_option(
-        "-e,--file-extension", argExtension, "Filename extension to look for. Default is `icplog`");
-    cmd.add_option(
-        "-d,--directory", argSearchDir, "Directory in which to search for *.icplog files.");
-    cmd.add_option("-f,--file", argSingleFile, "Load just this one single log *.icplog file.");
-    cmd.add_option(
-        "-l,--load-plugins", arg_plugins,
-        "One or more (comma separated) *.so files to load as plugins");
-    cmd.add_option(
-        "--autoplay-period", argAutoPlayPeriod,
-        "The period (in seconds) between timestamps to load and show in autoplay "
-        "mode.");
-    argMinQualityOpt = cmd.add_option(
-        "-q,--min-quality", argMinQuality,
-        "Minimum ICP quality (range [0,1], i.e. 0%-100%) to load a log file. "
-        "Files whose ICP result quality is below this threshold are skipped.");
+  cmd.add_option(
+      "-e,--file-extension", argExtension, "Filename extension to look for. Default is `icplog`");
+  cmd.add_option(
+      "-d,--directory", argSearchDir, "Directory in which to search for *.icplog files.");
+  cmd.add_option("-f,--file", argSingleFile, "Load just this one single log *.icplog file.");
+  cmd.add_option(
+      "-l,--load-plugins", arg_plugins, "One or more (comma separated) *.so files to load as plugins");
+  cmd.add_option(
+      "--autoplay-period", argAutoPlayPeriod,
+      "The period (in seconds) between timestamps to load and show in autoplay mode.");
+  argMinQualityOpt = cmd.add_option(
+      "-q,--min-quality", argMinQuality,
+      "Minimum ICP quality (range [0,1], i.e. 0%-100%) to load a log file. "
+      "Files whose ICP result quality is below this threshold are skipped.");
 
-    CLI11_PARSE(cmd, argc, argv);
+  CLI11_PARSE(cmd, argc, argv);
 
-    try
+  try
+  {
+    if (!arg_plugins.empty())
     {
-        // Load plugins:
-        if (!arg_plugins.empty())
-        {
-            std::string errMsg;
-            const auto& plugins = arg_plugins;
-            std::cout << "Loading plugin(s): " << plugins << std::endl;
-            if (!mrpt::system::loadPluginModules(plugins, errMsg))
-            {
-                std::cerr << errMsg << std::endl;
-                return 1;
-            }
-        }
-
-        main_show_gui();
-        return 0;
-    }
-    catch (std::exception& e)
-    {
-        std::cerr << "Exit due to exception:\n" << mrpt::exception_to_str(e) << std::endl;
+      std::string errMsg;
+      std::cout << "Loading plugin(s): " << arg_plugins << std::endl;
+      if (!mrpt::system::loadPluginModules(arg_plugins, errMsg))
+      {
+        std::cerr << errMsg << std::endl;
         return 1;
+      }
     }
+
+    return mainShowGui();
+  }
+  catch (std::exception& e)
+  {
+    std::cerr << "Exit due to exception:\n" << mrpt::exception_to_str(e) << std::endl;
+    return 1;
+  }
 }

--- a/mp2p_icp_viz/apps/imgui_app_common/CMakeLists.txt
+++ b/mp2p_icp_viz/apps/imgui_app_common/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Shared GLFW + Dear ImGui (docking) application shell used by both
+# mm-viewer and icp-log-viewer. Internal build detail only: not installed
+# or exported.
+project(imgui_app_common LANGUAGES CXX)
+
+add_library(${PROJECT_NAME} STATIC
+  src/ImGuiAppShell.cpp
+  include/imgui_app_common/ImGuiAppShell.h
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC include)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC imgui::imgui)
+
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)

--- a/mp2p_icp_viz/apps/imgui_app_common/CMakeLists.txt
+++ b/mp2p_icp_viz/apps/imgui_app_common/CMakeLists.txt
@@ -6,12 +6,15 @@ project(imgui_app_common LANGUAGES CXX)
 add_library(${PROJECT_NAME} STATIC
   src/ImGuiAppShell.cpp
   src/SimpleFileDialog.cpp
+  include/imgui_app_common/AsyncTask.h
   include/imgui_app_common/ImGuiAppShell.h
   include/imgui_app_common/SimpleFileDialog.h
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 
-target_link_libraries(${PROJECT_NAME} PUBLIC imgui::imgui)
+find_package(Threads REQUIRED)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC imgui::imgui Threads::Threads)
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)

--- a/mp2p_icp_viz/apps/imgui_app_common/CMakeLists.txt
+++ b/mp2p_icp_viz/apps/imgui_app_common/CMakeLists.txt
@@ -5,7 +5,9 @@ project(imgui_app_common LANGUAGES CXX)
 
 add_library(${PROJECT_NAME} STATIC
   src/ImGuiAppShell.cpp
+  src/SimpleFileDialog.cpp
   include/imgui_app_common/ImGuiAppShell.h
+  include/imgui_app_common/SimpleFileDialog.h
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC include)

--- a/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/AsyncTask.h
+++ b/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/AsyncTask.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <future>
+#include <optional>
+
+namespace mp2p_icp_viz
+{
+/** Runs a computation on a background thread and lets the caller poll for the result once per
+ *  frame without blocking.
+ *
+ *  Motivation: a GLFW/ImGui main loop must keep calling `glfwPollEvents()` (and swapping
+ *  buffers) at a steady cadence, or the window manager's own responsiveness watchdog concludes
+ *  the process is hung and offers to kill it -- even though the app would happily keep
+ *  processing input if given the chance. Long synchronous operations on the main thread (e.g.
+ *  loading a large map file, or building its OpenGL visualization) starve that loop. Running
+ *  them here instead keeps the main loop free to keep pumping events while the result is
+ *  awaited via poll().
+ */
+template <typename T>
+class AsyncTask
+{
+   public:
+    void start(std::function<T()> fn)
+    {
+        future_  = std::async(std::launch::async, std::move(fn));
+        running_ = true;
+    }
+
+    bool isRunning() const { return running_; }
+
+    /** Call once per frame. Returns the result exactly once, on the first poll() after the task
+     *  finished; nullopt every other time (including while still running). */
+    std::optional<T> poll()
+    {
+        if (!running_)
+        {
+            return std::nullopt;
+        }
+        if (future_.wait_for(std::chrono::seconds(0)) != std::future_status::ready)
+        {
+            return std::nullopt;
+        }
+        running_ = false;
+        return future_.get();
+    }
+
+   private:
+    std::future<T> future_;
+    bool           running_ = false;
+};
+
+}  // namespace mp2p_icp_viz

--- a/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/ImGuiAppShell.h
+++ b/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/ImGuiAppShell.h
@@ -42,6 +42,13 @@ class ImGuiAppShell
 
   GLFWwindow* windowHandle() const { return window_; }
 
+  /** Optional hook, called once with the dockspace's ImGuiID, only the very first time the
+   *  app runs with no saved docking layout (no `imgui.ini` entry yet) -- lets each app define
+   *  its own default panel arrangement (which is app-specific, so it does not belong in this
+   *  shared shell) via `ImGui::DockBuilderSplitNode()`/`DockBuilderDockWindow()`. Once the
+   *  user rearranges panels, their layout is persisted and this hook is not called again. */
+  std::function<void(unsigned int dockspaceId)> setupDefaultLayout;
+
  private:
   GLFWwindow* window_           = nullptr;
   std::string iniPath_;

--- a/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/ImGuiAppShell.h
+++ b/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/ImGuiAppShell.h
@@ -17,42 +17,42 @@ namespace mp2p_icp_viz
  */
 class ImGuiAppShell
 {
- public:
-  ImGuiAppShell() = default;
-  ~ImGuiAppShell();
+   public:
+    ImGuiAppShell() = default;
+    ~ImGuiAppShell();
 
-  ImGuiAppShell(const ImGuiAppShell&)            = delete;
-  ImGuiAppShell& operator=(const ImGuiAppShell&) = delete;
+    ImGuiAppShell(const ImGuiAppShell&)            = delete;
+    ImGuiAppShell& operator=(const ImGuiAppShell&) = delete;
 
-  /** Creates the GLFW window, GL context, and ImGui/backends state.
-   *  Returns false on failure (details logged to stderr). */
-  bool init(const std::string& windowTitle, int width = 1280, int height = 800);
+    /** Creates the GLFW window, GL context, and ImGui/backends state.
+     *  Returns false on failure (details logged to stderr). */
+    bool init(const std::string& windowTitle, int width = 1280, int height = 800);
 
-  /** Runs the main loop until the window is closed or requestClose() is
-   *  called. `renderFrame` is invoked once per frame between
-   *  `ImGui::NewFrame()` and `ImGui::Render()`. */
-  void run(const std::function<void()>& renderFrame);
+    /** Runs the main loop until the window is closed or requestClose() is
+     *  called. `renderFrame` is invoked once per frame between
+     *  `ImGui::NewFrame()` and `ImGui::Render()`. */
+    void run(const std::function<void()>& renderFrame);
 
-  /** Releases ImGui/backends state and destroys the GLFW window.
-   *  Safe to call more than once. */
-  void shutdown();
+    /** Releases ImGui/backends state and destroys the GLFW window.
+     *  Safe to call more than once. */
+    void shutdown();
 
-  /** Requests that run() stop its loop after the current frame. */
-  void requestClose();
+    /** Requests that run() stop its loop after the current frame. */
+    void requestClose();
 
-  GLFWwindow* windowHandle() const { return window_; }
+    GLFWwindow* windowHandle() const { return window_; }
 
-  /** Optional hook, called once with the dockspace's ImGuiID, only the very first time the
-   *  app runs with no saved docking layout (no `imgui.ini` entry yet) -- lets each app define
-   *  its own default panel arrangement (which is app-specific, so it does not belong in this
-   *  shared shell) via `ImGui::DockBuilderSplitNode()`/`DockBuilderDockWindow()`. Once the
-   *  user rearranges panels, their layout is persisted and this hook is not called again. */
-  std::function<void(unsigned int dockspaceId)> setupDefaultLayout;
+    /** Optional hook, called once with the dockspace's ImGuiID, only the very first time the
+     *  app runs with no saved docking layout (no `imgui.ini` entry yet) -- lets each app define
+     *  its own default panel arrangement (which is app-specific, so it does not belong in this
+     *  shared shell) via `ImGui::DockBuilderSplitNode()`/`DockBuilderDockWindow()`. Once the
+     *  user rearranges panels, their layout is persisted and this hook is not called again. */
+    std::function<void(unsigned int dockspaceId)> setupDefaultLayout;
 
- private:
-  GLFWwindow* window_           = nullptr;
-  std::string iniPath_;
-  bool        imguiInitialized_ = false;
+   private:
+    GLFWwindow* window_ = nullptr;
+    std::string iniPath_;
+    bool        imguiInitialized_ = false;
 };
 
 }  // namespace mp2p_icp_viz

--- a/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/ImGuiAppShell.h
+++ b/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/ImGuiAppShell.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <functional>
+#include <string>
+
+struct GLFWwindow;
+
+namespace mp2p_icp_viz
+{
+/** Minimal GLFW + Dear ImGui (docking) application shell shared by
+ *  mm-viewer and icp-log-viewer.
+ *
+ *  Owns the window, the GL context, and the ImGui/backends lifecycle.
+ *  Callers only provide a per-frame render callback; a full-window
+ *  passthrough dockspace is already set up before it is invoked, so callers
+ *  just open ImGui windows and let the user dock them freely.
+ */
+class ImGuiAppShell
+{
+ public:
+  ImGuiAppShell() = default;
+  ~ImGuiAppShell();
+
+  ImGuiAppShell(const ImGuiAppShell&)            = delete;
+  ImGuiAppShell& operator=(const ImGuiAppShell&) = delete;
+
+  /** Creates the GLFW window, GL context, and ImGui/backends state.
+   *  Returns false on failure (details logged to stderr). */
+  bool init(const std::string& windowTitle, int width = 1280, int height = 800);
+
+  /** Runs the main loop until the window is closed or requestClose() is
+   *  called. `renderFrame` is invoked once per frame between
+   *  `ImGui::NewFrame()` and `ImGui::Render()`. */
+  void run(const std::function<void()>& renderFrame);
+
+  /** Releases ImGui/backends state and destroys the GLFW window.
+   *  Safe to call more than once. */
+  void shutdown();
+
+  /** Requests that run() stop its loop after the current frame. */
+  void requestClose();
+
+  GLFWwindow* windowHandle() const { return window_; }
+
+ private:
+  GLFWwindow* window_           = nullptr;
+  std::string iniPath_;
+  bool        imguiInitialized_ = false;
+};
+
+}  // namespace mp2p_icp_viz

--- a/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/SimpleFileDialog.h
+++ b/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/SimpleFileDialog.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace mp2p_icp_viz
+{
+/** One selectable file-type filter, e.g. {"mm", "Metric maps (*.mm)"}.
+ *  An empty `extension` means "any file". */
+struct FileDialogFilter
+{
+  std::string extension;
+  std::string description;
+};
+
+/** Minimal, self-contained ImGui file browser (no native/system dialog, no
+ *  extra third-party dependency beyond Dear ImGui itself), used for both
+ *  "open" and "save" prompts by mm-viewer and icp-log-viewer.
+ *
+ *  Usage:
+ *  \code
+ *    dialog.open(SimpleFileDialog::Mode::Open, {{"mm", "Metric maps (*.mm)"}});
+ *    // every frame:
+ *    if (auto path = dialog.render(); path.has_value()) { ... use *path ... }
+ *  \endcode
+ */
+class SimpleFileDialog
+{
+ public:
+  enum class Mode
+  {
+    Open,
+    Save
+  };
+
+  /** Opens the dialog, starting at `initialDir` (or the current directory,
+   *  or the last directory this dialog was used in, if empty). */
+  void open(
+      Mode mode, const std::vector<FileDialogFilter>& filters, const std::string& title = "",
+      const std::string& initialDir = "");
+
+  /** Must be called every frame while isOpen(). Returns the selected path
+   *  once the user confirms (Open/Save), or nullopt otherwise (still open,
+   *  or cancelled -- check isOpen() to tell those apart). */
+  std::optional<std::string> render();
+
+  bool isOpen() const { return open_; }
+
+ private:
+  bool                          open_ = false;
+  Mode                          mode_ = Mode::Open;
+  std::string                   title_;
+  std::vector<FileDialogFilter> filters_;
+  int                           selectedFilterIdx_ = 0;
+
+  std::string currentDir_;
+  std::string typedName_;
+  std::string errorMsg_;
+};
+
+}  // namespace mp2p_icp_viz

--- a/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/SimpleFileDialog.h
+++ b/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/SimpleFileDialog.h
@@ -10,8 +10,8 @@ namespace mp2p_icp_viz
  *  An empty `extension` means "any file". */
 struct FileDialogFilter
 {
-  std::string extension;
-  std::string description;
+    std::string extension;
+    std::string description;
 };
 
 /** Minimal, self-contained ImGui file browser (no native/system dialog, no
@@ -27,36 +27,36 @@ struct FileDialogFilter
  */
 class SimpleFileDialog
 {
- public:
-  enum class Mode
-  {
-    Open,
-    Save
-  };
+   public:
+    enum class Mode
+    {
+        Open,
+        Save
+    };
 
-  /** Opens the dialog, starting at `initialDir` (or the current directory,
-   *  or the last directory this dialog was used in, if empty). */
-  void open(
-      Mode mode, const std::vector<FileDialogFilter>& filters, const std::string& title = "",
-      const std::string& initialDir = "");
+    /** Opens the dialog, starting at `initialDir` (or the current directory,
+     *  or the last directory this dialog was used in, if empty). */
+    void open(
+        Mode mode, const std::vector<FileDialogFilter>& filters, const std::string& title = "",
+        const std::string& initialDir = "");
 
-  /** Must be called every frame while isOpen(). Returns the selected path
-   *  once the user confirms (Open/Save), or nullopt otherwise (still open,
-   *  or cancelled -- check isOpen() to tell those apart). */
-  std::optional<std::string> render();
+    /** Must be called every frame while isOpen(). Returns the selected path
+     *  once the user confirms (Open/Save), or nullopt otherwise (still open,
+     *  or cancelled -- check isOpen() to tell those apart). */
+    std::optional<std::string> render();
 
-  bool isOpen() const { return open_; }
+    bool isOpen() const { return open_; }
 
- private:
-  bool                          open_ = false;
-  Mode                          mode_ = Mode::Open;
-  std::string                   title_;
-  std::vector<FileDialogFilter> filters_;
-  int                           selectedFilterIdx_ = 0;
+   private:
+    bool                          open_ = false;
+    Mode                          mode_ = Mode::Open;
+    std::string                   title_;
+    std::vector<FileDialogFilter> filters_;
+    int                           selectedFilterIdx_ = 0;
 
-  std::string currentDir_;
-  std::string typedName_;
-  std::string errorMsg_;
+    std::string currentDir_;
+    std::string typedName_;
+    std::string errorMsg_;
 };
 
 }  // namespace mp2p_icp_viz

--- a/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/SimpleFileDialog.h
+++ b/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/SimpleFileDialog.h
@@ -61,6 +61,8 @@ class SimpleFileDialog
     // Unique per instance (derived from `this`), so two SimpleFileDialog objects never share the
     // same ImGui popup ID -- otherwise ImGui would treat them as the very same modal popup.
     std::string popupId_;
+    std::string overwritePopupId_;
+    std::string pendingOverwritePath_;
 };
 
 }  // namespace mp2p_icp_viz

--- a/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/SimpleFileDialog.h
+++ b/mp2p_icp_viz/apps/imgui_app_common/include/imgui_app_common/SimpleFileDialog.h
@@ -57,6 +57,10 @@ class SimpleFileDialog
     std::string currentDir_;
     std::string typedName_;
     std::string errorMsg_;
+
+    // Unique per instance (derived from `this`), so two SimpleFileDialog objects never share the
+    // same ImGui popup ID -- otherwise ImGui would treat them as the very same modal popup.
+    std::string popupId_;
 };
 
 }  // namespace mp2p_icp_viz

--- a/mp2p_icp_viz/apps/imgui_app_common/src/ImGuiAppShell.cpp
+++ b/mp2p_icp_viz/apps/imgui_app_common/src/ImGuiAppShell.cpp
@@ -1,11 +1,9 @@
-#include <imgui_app_common/ImGuiAppShell.h>
-
+#include <GLFW/glfw3.h>
 #include <backends/imgui_impl_glfw.h>
 #include <backends/imgui_impl_opengl3.h>
 #include <imgui.h>
+#include <imgui_app_common/ImGuiAppShell.h>
 #include <imgui_internal.h>  // DockBuilder* API (default layout on first run)
-
-#include <GLFW/glfw3.h>
 
 #include <cstdio>
 
@@ -17,7 +15,7 @@ namespace
 {
 void glfwErrorCallback(int error, const char* description)
 {
-  std::fprintf(stderr, "[ImGuiAppShell] GLFW error %d: %s\n", error, description);
+    std::fprintf(stderr, "[ImGuiAppShell] GLFW error %d: %s\n", error, description);
 }
 }  // namespace
 
@@ -25,134 +23,135 @@ ImGuiAppShell::~ImGuiAppShell() { shutdown(); }
 
 bool ImGuiAppShell::init(const std::string& windowTitle, int width, int height)
 {
-  glfwSetErrorCallback(glfwErrorCallback);
-  if (!glfwInit())
-  {
-    std::fprintf(stderr, "[ImGuiAppShell] glfwInit() failed\n");
-    return false;
-  }
+    glfwSetErrorCallback(glfwErrorCallback);
+    if (!glfwInit())
+    {
+        std::fprintf(stderr, "[ImGuiAppShell] glfwInit() failed\n");
+        return false;
+    }
 
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
-  window_ = glfwCreateWindow(width, height, windowTitle.c_str(), nullptr, nullptr);
-  if (!window_)
-  {
-    std::fprintf(stderr, "[ImGuiAppShell] glfwCreateWindow() failed\n");
-    glfwTerminate();
-    return false;
-  }
-  glfwMakeContextCurrent(window_);
-  glfwSwapInterval(1);  // vsync
+    window_ = glfwCreateWindow(width, height, windowTitle.c_str(), nullptr, nullptr);
+    if (!window_)
+    {
+        std::fprintf(stderr, "[ImGuiAppShell] glfwCreateWindow() failed\n");
+        glfwTerminate();
+        return false;
+    }
+    glfwMakeContextCurrent(window_);
+    glfwSwapInterval(1);  // vsync
 
-  IMGUI_CHECKVERSION();
-  ImGui::CreateContext();
-  ImGuiIO& io = ImGui::GetIO();
-  io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
-  io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO();
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+    io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
 
-  // Persist the docking layout in a per-app imgui.ini file, under the user's config
-  // directory (e.g. ~/.config/<windowTitle>/), not the current working directory.
-  char configDir[MAX_PATH];
-  get_user_config_folder(configDir, sizeof(configDir), windowTitle.c_str());
-  iniPath_       = configDir[0] != '\0' ? std::string(configDir) + windowTitle + ".imgui.ini"
-                                        : windowTitle + ".imgui.ini";
-  io.IniFilename = iniPath_.c_str();
+    // Persist the docking layout in a per-app imgui.ini file, under the user's config
+    // directory (e.g. ~/.config/<windowTitle>/), not the current working directory.
+    char configDir[MAX_PATH];
+    get_user_config_folder(configDir, sizeof(configDir), windowTitle.c_str());
+    iniPath_       = configDir[0] != '\0' ? std::string(configDir) + windowTitle + ".imgui.ini"
+                                          : windowTitle + ".imgui.ini";
+    io.IniFilename = iniPath_.c_str();
 
-  ImGui::StyleColorsDark();
+    ImGui::StyleColorsDark();
 
-  ImGui_ImplGlfw_InitForOpenGL(window_, true);
-  ImGui_ImplOpenGL3_Init("#version 330");
-  imguiInitialized_ = true;
+    ImGui_ImplGlfw_InitForOpenGL(window_, true);
+    ImGui_ImplOpenGL3_Init("#version 330");
+    imguiInitialized_ = true;
 
-  return true;
+    return true;
 }
 
 void ImGuiAppShell::run(const std::function<void()>& renderFrame)
 {
-  while (window_ && !glfwWindowShouldClose(window_))
-  {
-    glfwPollEvents();
-
-    ImGui_ImplOpenGL3_NewFrame();
-    ImGui_ImplGlfw_NewFrame();
-    ImGui::NewFrame();
-
-    const ImGuiViewport* viewport = ImGui::GetMainViewport();
-    ImGui::SetNextWindowPos(viewport->WorkPos);
-    ImGui::SetNextWindowSize(viewport->WorkSize);
-    ImGui::SetNextWindowViewport(viewport->ID);
-
-    const ImGuiWindowFlags hostFlags =
-        ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
-        ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus |
-        ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoBackground;
-
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
-    ImGui::Begin("##DockSpaceRoot", nullptr, hostFlags);
-    ImGui::PopStyleVar(3);
-
-    const ImGuiID dockspaceId = ImGui::GetID("MainDockSpace");
-
-    if (setupDefaultLayout && !ImGui::DockBuilderGetNode(dockspaceId))
+    while (window_ && !glfwWindowShouldClose(window_))
     {
-      ImGui::DockBuilderRemoveNode(dockspaceId);
-      ImGui::DockBuilderAddNode(dockspaceId, ImGuiDockNodeFlags_PassthruCentralNode | ImGuiDockNodeFlags_DockSpace);
-      ImGui::DockBuilderSetNodeSize(dockspaceId, viewport->Size);
+        glfwPollEvents();
 
-      setupDefaultLayout(dockspaceId);
+        ImGui_ImplOpenGL3_NewFrame();
+        ImGui_ImplGlfw_NewFrame();
+        ImGui::NewFrame();
 
-      ImGui::DockBuilderFinish(dockspaceId);
+        const ImGuiViewport* viewport = ImGui::GetMainViewport();
+        ImGui::SetNextWindowPos(viewport->WorkPos);
+        ImGui::SetNextWindowSize(viewport->WorkSize);
+        ImGui::SetNextWindowViewport(viewport->ID);
+
+        const ImGuiWindowFlags hostFlags =
+            ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
+            ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus |
+            ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoBackground;
+
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+        ImGui::Begin("##DockSpaceRoot", nullptr, hostFlags);
+        ImGui::PopStyleVar(3);
+
+        const ImGuiID dockspaceId = ImGui::GetID("MainDockSpace");
+
+        if (setupDefaultLayout && !ImGui::DockBuilderGetNode(dockspaceId))
+        {
+            ImGui::DockBuilderRemoveNode(dockspaceId);
+            ImGui::DockBuilderAddNode(
+                dockspaceId, ImGuiDockNodeFlags_PassthruCentralNode | ImGuiDockNodeFlags_DockSpace);
+            ImGui::DockBuilderSetNodeSize(dockspaceId, viewport->Size);
+
+            setupDefaultLayout(dockspaceId);
+
+            ImGui::DockBuilderFinish(dockspaceId);
+        }
+
+        ImGui::DockSpace(dockspaceId, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_PassthruCentralNode);
+        ImGui::End();
+
+        if (renderFrame)
+        {
+            renderFrame();
+        }
+
+        ImGui::Render();
+
+        int displayW = 0;
+        int displayH = 0;
+        glfwGetFramebufferSize(window_, &displayW, &displayH);
+        glViewport(0, 0, displayW, displayH);
+        glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+
+        glfwSwapBuffers(window_);
     }
-
-    ImGui::DockSpace(dockspaceId, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_PassthruCentralNode);
-    ImGui::End();
-
-    if (renderFrame)
-    {
-      renderFrame();
-    }
-
-    ImGui::Render();
-
-    int displayW = 0;
-    int displayH = 0;
-    glfwGetFramebufferSize(window_, &displayW, &displayH);
-    glViewport(0, 0, displayW, displayH);
-    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT);
-    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
-
-    glfwSwapBuffers(window_);
-  }
 }
 
 void ImGuiAppShell::requestClose()
 {
-  if (window_)
-  {
-    glfwSetWindowShouldClose(window_, GLFW_TRUE);
-  }
+    if (window_)
+    {
+        glfwSetWindowShouldClose(window_, GLFW_TRUE);
+    }
 }
 
 void ImGuiAppShell::shutdown()
 {
-  if (imguiInitialized_)
-  {
-    ImGui_ImplOpenGL3_Shutdown();
-    ImGui_ImplGlfw_Shutdown();
-    ImGui::DestroyContext();
-    imguiInitialized_ = false;
-  }
-  if (window_)
-  {
-    glfwDestroyWindow(window_);
-    window_ = nullptr;
-    glfwTerminate();
-  }
+    if (imguiInitialized_)
+    {
+        ImGui_ImplOpenGL3_Shutdown();
+        ImGui_ImplGlfw_Shutdown();
+        ImGui::DestroyContext();
+        imguiInitialized_ = false;
+    }
+    if (window_)
+    {
+        glfwDestroyWindow(window_);
+        window_ = nullptr;
+        glfwTerminate();
+    }
 }
 
 }  // namespace mp2p_icp_viz

--- a/mp2p_icp_viz/apps/imgui_app_common/src/ImGuiAppShell.cpp
+++ b/mp2p_icp_viz/apps/imgui_app_common/src/ImGuiAppShell.cpp
@@ -9,6 +9,8 @@
 
 #include <cstdio>
 
+#include "../../libcfgpath/cfgpath.h"
+
 namespace mp2p_icp_viz
 {
 namespace
@@ -50,8 +52,12 @@ bool ImGuiAppShell::init(const std::string& windowTitle, int width, int height)
   io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
   io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
 
-  // Persist the docking layout in a per-app imgui.ini file.
-  iniPath_       = windowTitle + ".imgui.ini";
+  // Persist the docking layout in a per-app imgui.ini file, under the user's config
+  // directory (e.g. ~/.config/<windowTitle>/), not the current working directory.
+  char configDir[MAX_PATH];
+  get_user_config_folder(configDir, sizeof(configDir), windowTitle.c_str());
+  iniPath_       = configDir[0] != '\0' ? std::string(configDir) + windowTitle + ".imgui.ini"
+                                        : windowTitle + ".imgui.ini";
   io.IniFilename = iniPath_.c_str();
 
   ImGui::StyleColorsDark();

--- a/mp2p_icp_viz/apps/imgui_app_common/src/ImGuiAppShell.cpp
+++ b/mp2p_icp_viz/apps/imgui_app_common/src/ImGuiAppShell.cpp
@@ -1,0 +1,139 @@
+#include <imgui_app_common/ImGuiAppShell.h>
+
+#include <backends/imgui_impl_glfw.h>
+#include <backends/imgui_impl_opengl3.h>
+#include <imgui.h>
+
+#include <GLFW/glfw3.h>
+
+#include <cstdio>
+
+namespace mp2p_icp_viz
+{
+namespace
+{
+void glfwErrorCallback(int error, const char* description)
+{
+  std::fprintf(stderr, "[ImGuiAppShell] GLFW error %d: %s\n", error, description);
+}
+}  // namespace
+
+ImGuiAppShell::~ImGuiAppShell() { shutdown(); }
+
+bool ImGuiAppShell::init(const std::string& windowTitle, int width, int height)
+{
+  glfwSetErrorCallback(glfwErrorCallback);
+  if (!glfwInit())
+  {
+    std::fprintf(stderr, "[ImGuiAppShell] glfwInit() failed\n");
+    return false;
+  }
+
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+  glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+  glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
+  window_ = glfwCreateWindow(width, height, windowTitle.c_str(), nullptr, nullptr);
+  if (!window_)
+  {
+    std::fprintf(stderr, "[ImGuiAppShell] glfwCreateWindow() failed\n");
+    glfwTerminate();
+    return false;
+  }
+  glfwMakeContextCurrent(window_);
+  glfwSwapInterval(1);  // vsync
+
+  IMGUI_CHECKVERSION();
+  ImGui::CreateContext();
+  ImGuiIO& io = ImGui::GetIO();
+  io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+  io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+
+  // Persist the docking layout in a per-app imgui.ini file.
+  iniPath_       = windowTitle + ".imgui.ini";
+  io.IniFilename = iniPath_.c_str();
+
+  ImGui::StyleColorsDark();
+
+  ImGui_ImplGlfw_InitForOpenGL(window_, true);
+  ImGui_ImplOpenGL3_Init("#version 330");
+  imguiInitialized_ = true;
+
+  return true;
+}
+
+void ImGuiAppShell::run(const std::function<void()>& renderFrame)
+{
+  while (window_ && !glfwWindowShouldClose(window_))
+  {
+    glfwPollEvents();
+
+    ImGui_ImplOpenGL3_NewFrame();
+    ImGui_ImplGlfw_NewFrame();
+    ImGui::NewFrame();
+
+    const ImGuiViewport* viewport = ImGui::GetMainViewport();
+    ImGui::SetNextWindowPos(viewport->WorkPos);
+    ImGui::SetNextWindowSize(viewport->WorkSize);
+    ImGui::SetNextWindowViewport(viewport->ID);
+
+    const ImGuiWindowFlags hostFlags =
+        ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
+        ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus |
+        ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoBackground;
+
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+    ImGui::Begin("##DockSpaceRoot", nullptr, hostFlags);
+    ImGui::PopStyleVar(3);
+
+    const ImGuiID dockspaceId = ImGui::GetID("MainDockSpace");
+    ImGui::DockSpace(dockspaceId, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_PassthruCentralNode);
+    ImGui::End();
+
+    if (renderFrame)
+    {
+      renderFrame();
+    }
+
+    ImGui::Render();
+
+    int displayW = 0;
+    int displayH = 0;
+    glfwGetFramebufferSize(window_, &displayW, &displayH);
+    glViewport(0, 0, displayW, displayH);
+    glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+
+    glfwSwapBuffers(window_);
+  }
+}
+
+void ImGuiAppShell::requestClose()
+{
+  if (window_)
+  {
+    glfwSetWindowShouldClose(window_, GLFW_TRUE);
+  }
+}
+
+void ImGuiAppShell::shutdown()
+{
+  if (imguiInitialized_)
+  {
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplGlfw_Shutdown();
+    ImGui::DestroyContext();
+    imguiInitialized_ = false;
+  }
+  if (window_)
+  {
+    glfwDestroyWindow(window_);
+    window_ = nullptr;
+    glfwTerminate();
+  }
+}
+
+}  // namespace mp2p_icp_viz

--- a/mp2p_icp_viz/apps/imgui_app_common/src/ImGuiAppShell.cpp
+++ b/mp2p_icp_viz/apps/imgui_app_common/src/ImGuiAppShell.cpp
@@ -3,6 +3,7 @@
 #include <backends/imgui_impl_glfw.h>
 #include <backends/imgui_impl_opengl3.h>
 #include <imgui.h>
+#include <imgui_internal.h>  // DockBuilder* API (default layout on first run)
 
 #include <GLFW/glfw3.h>
 
@@ -89,6 +90,18 @@ void ImGuiAppShell::run(const std::function<void()>& renderFrame)
     ImGui::PopStyleVar(3);
 
     const ImGuiID dockspaceId = ImGui::GetID("MainDockSpace");
+
+    if (setupDefaultLayout && !ImGui::DockBuilderGetNode(dockspaceId))
+    {
+      ImGui::DockBuilderRemoveNode(dockspaceId);
+      ImGui::DockBuilderAddNode(dockspaceId, ImGuiDockNodeFlags_PassthruCentralNode | ImGuiDockNodeFlags_DockSpace);
+      ImGui::DockBuilderSetNodeSize(dockspaceId, viewport->Size);
+
+      setupDefaultLayout(dockspaceId);
+
+      ImGui::DockBuilderFinish(dockspaceId);
+    }
+
     ImGui::DockSpace(dockspaceId, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_PassthruCentralNode);
     ImGui::End();
 

--- a/mp2p_icp_viz/apps/imgui_app_common/src/SimpleFileDialog.cpp
+++ b/mp2p_icp_viz/apps/imgui_app_common/src/SimpleFileDialog.cpp
@@ -51,7 +51,9 @@ void SimpleFileDialog::open(
     {
         // Unique per instance so two SimpleFileDialog objects never collide on the same
         // ImGui popup ID (ImGui would otherwise treat them as the very same modal popup).
-        popupId_ = "SimpleFileDialog##popup" + std::to_string(reinterpret_cast<uintptr_t>(this));
+        const auto instanceTag = std::to_string(reinterpret_cast<uintptr_t>(this));
+        popupId_               = "SimpleFileDialog##popup" + instanceTag;
+        overwritePopupId_      = "Overwrite file?##overwrite" + instanceTag;
     }
 
     open_ = true;
@@ -191,10 +193,26 @@ std::optional<std::string> SimpleFileDialog::render()
             }
             else
             {
-                const auto candidate = std::filesystem::path(currentDir_) / typedName_;
-                if (mode_ == Mode::Open && !std::filesystem::exists(candidate))
+                const auto      candidate = std::filesystem::path(currentDir_) / typedName_;
+                std::error_code candidateEc;
+                if (mode_ == Mode::Open)
                 {
-                    errorMsg_ = "File does not exist.";
+                    if (!std::filesystem::is_regular_file(candidate, candidateEc))
+                    {
+                        errorMsg_ = candidateEc ? "Unable to inspect file."
+                                                : "File does not exist or is not a regular file.";
+                    }
+                    else
+                    {
+                        result = candidate.string();
+                    }
+                }
+                else if (std::filesystem::exists(candidate, candidateEc))
+                {
+                    // Ask for explicit confirmation before overwriting -- unlike a native OS
+                    // save dialog, this in-app one has no built-in overwrite protection.
+                    pendingOverwritePath_ = candidate.string();
+                    ImGui::OpenPopup(overwritePopupId_.c_str());
                 }
                 else
                 {
@@ -207,6 +225,24 @@ std::optional<std::string> SimpleFileDialog::render()
         {
             open_ = false;
             ImGui::CloseCurrentPopup();
+        }
+
+        if (ImGui::BeginPopupModal(
+                overwritePopupId_.c_str(), nullptr,
+                ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings))
+        {
+            ImGui::Text("File already exists:\n%s\n\nOverwrite it?", pendingOverwritePath_.c_str());
+            if (ImGui::Button("Overwrite"))
+            {
+                result = pendingOverwritePath_;
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Cancel"))
+            {
+                ImGui::CloseCurrentPopup();
+            }
+            ImGui::EndPopup();
         }
 
         if (result.has_value())

--- a/mp2p_icp_viz/apps/imgui_app_common/src/SimpleFileDialog.cpp
+++ b/mp2p_icp_viz/apps/imgui_app_common/src/SimpleFileDialog.cpp
@@ -2,6 +2,7 @@
 #include <imgui_app_common/SimpleFileDialog.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <cstdio>
 #include <filesystem>
 #include <system_error>
@@ -10,8 +11,6 @@ namespace mp2p_icp_viz
 {
 namespace
 {
-constexpr const char* kPopupId = "SimpleFileDialog##popup";
-
 bool matchesFilter(const std::filesystem::directory_entry& entry, const FileDialogFilter& filter)
 {
     if (filter.extension.empty())
@@ -48,8 +47,15 @@ void SimpleFileDialog::open(
     }
     currentDir_ = startDir.string();
 
+    if (popupId_.empty())
+    {
+        // Unique per instance so two SimpleFileDialog objects never collide on the same
+        // ImGui popup ID (ImGui would otherwise treat them as the very same modal popup).
+        popupId_ = "SimpleFileDialog##popup" + std::to_string(reinterpret_cast<uintptr_t>(this));
+    }
+
     open_ = true;
-    ImGui::OpenPopup(kPopupId);
+    ImGui::OpenPopup(popupId_.c_str());
 }
 
 std::optional<std::string> SimpleFileDialog::render()
@@ -62,7 +68,7 @@ std::optional<std::string> SimpleFileDialog::render()
     std::optional<std::string> result;
 
     ImGui::SetNextWindowSize(ImVec2(560, 420), ImGuiCond_FirstUseEver);
-    if (ImGui::BeginPopupModal(kPopupId, nullptr, ImGuiWindowFlags_NoSavedSettings))
+    if (ImGui::BeginPopupModal(popupId_.c_str(), nullptr, ImGuiWindowFlags_NoSavedSettings))
     {
         ImGui::TextUnformatted(title_.c_str());
         ImGui::Separator();
@@ -88,7 +94,13 @@ std::optional<std::string> SimpleFileDialog::render()
             std::vector<std::filesystem::directory_entry> files;
             for (const auto& entry : std::filesystem::directory_iterator(currentDir_, ec))
             {
-                if (entry.is_directory())
+                std::error_code statusEc;
+                const bool      isDir = entry.is_directory(statusEc);
+                if (statusEc)
+                {
+                    continue;  // entry status could not be resolved (e.g. broken symlink)
+                }
+                if (isDir)
                 {
                     dirs.push_back(entry);
                 }
@@ -128,7 +140,9 @@ std::optional<std::string> SimpleFileDialog::render()
                         name.c_str(), isSelected, ImGuiSelectableFlags_AllowDoubleClick))
                 {
                     typedName_ = name;
-                    if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
+                    // Only Open mode confirms on double-click; Save mode always goes through
+                    // the Save button (and its overwrite/empty-name checks below).
+                    if (mode_ == Mode::Open && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
                     {
                         result = (std::filesystem::path(currentDir_) / name).string();
                     }

--- a/mp2p_icp_viz/apps/imgui_app_common/src/SimpleFileDialog.cpp
+++ b/mp2p_icp_viz/apps/imgui_app_common/src/SimpleFileDialog.cpp
@@ -1,6 +1,5 @@
-#include <imgui_app_common/SimpleFileDialog.h>
-
 #include <imgui.h>
+#include <imgui_app_common/SimpleFileDialog.h>
 
 #include <algorithm>
 #include <cstdio>
@@ -15,16 +14,16 @@ constexpr const char* kPopupId = "SimpleFileDialog##popup";
 
 bool matchesFilter(const std::filesystem::directory_entry& entry, const FileDialogFilter& filter)
 {
-  if (filter.extension.empty())
-  {
-    return true;
-  }
-  auto ext = entry.path().extension().string();
-  if (!ext.empty() && ext.front() == '.')
-  {
-    ext.erase(0, 1);
-  }
-  return ext == filter.extension;
+    if (filter.extension.empty())
+    {
+        return true;
+    }
+    auto ext = entry.path().extension().string();
+    if (!ext.empty() && ext.front() == '.')
+    {
+        ext.erase(0, 1);
+    }
+    return ext == filter.extension;
 }
 }  // namespace
 
@@ -32,181 +31,185 @@ void SimpleFileDialog::open(
     Mode mode, const std::vector<FileDialogFilter>& filters, const std::string& title,
     const std::string& initialDir)
 {
-  mode_              = mode;
-  filters_           = filters;
-  selectedFilterIdx_ = 0;
-  title_             = title.empty() ? (mode == Mode::Open ? "Open file" : "Save file") : title;
-  typedName_.clear();
-  errorMsg_.clear();
+    mode_              = mode;
+    filters_           = filters;
+    selectedFilterIdx_ = 0;
+    title_             = title.empty() ? (mode == Mode::Open ? "Open file" : "Save file") : title;
+    typedName_.clear();
+    errorMsg_.clear();
 
-  std::error_code   ec;
-  std::filesystem::path startDir = !initialDir.empty()  ? std::filesystem::path(initialDir)
-                                    : !currentDir_.empty() ? std::filesystem::path(currentDir_)
+    std::error_code       ec;
+    std::filesystem::path startDir = !initialDir.empty()    ? std::filesystem::path(initialDir)
+                                     : !currentDir_.empty() ? std::filesystem::path(currentDir_)
                                                             : std::filesystem::current_path(ec);
-  if (!std::filesystem::is_directory(startDir, ec))
-  {
-    startDir = std::filesystem::current_path(ec);
-  }
-  currentDir_ = startDir.string();
+    if (!std::filesystem::is_directory(startDir, ec))
+    {
+        startDir = std::filesystem::current_path(ec);
+    }
+    currentDir_ = startDir.string();
 
-  open_ = true;
-  ImGui::OpenPopup(kPopupId);
+    open_ = true;
+    ImGui::OpenPopup(kPopupId);
 }
 
 std::optional<std::string> SimpleFileDialog::render()
 {
-  if (!open_)
-  {
-    return std::nullopt;
-  }
-
-  std::optional<std::string> result;
-
-  ImGui::SetNextWindowSize(ImVec2(560, 420), ImGuiCond_FirstUseEver);
-  if (ImGui::BeginPopupModal(kPopupId, nullptr, ImGuiWindowFlags_NoSavedSettings))
-  {
-    ImGui::TextUnformatted(title_.c_str());
-    ImGui::Separator();
-
-    if (ImGui::Button("Up"))
+    if (!open_)
     {
-      const std::filesystem::path p(currentDir_);
-      if (p.has_parent_path() && p.parent_path() != p)
-      {
-        currentDir_ = p.parent_path().string();
-      }
+        return std::nullopt;
     }
-    ImGui::SameLine();
-    ImGui::TextUnformatted(currentDir_.c_str());
 
-    ImGui::Separator();
+    std::optional<std::string> result;
 
-    if (ImGui::BeginChild(
-            "##fileList", ImVec2(0, -80), true, ImGuiWindowFlags_HorizontalScrollbar))
+    ImGui::SetNextWindowSize(ImVec2(560, 420), ImGuiCond_FirstUseEver);
+    if (ImGui::BeginPopupModal(kPopupId, nullptr, ImGuiWindowFlags_NoSavedSettings))
     {
-      std::error_code                               ec;
-      std::vector<std::filesystem::directory_entry> dirs;
-      std::vector<std::filesystem::directory_entry> files;
-      for (const auto& entry : std::filesystem::directory_iterator(currentDir_, ec))
-      {
-        if (entry.is_directory())
+        ImGui::TextUnformatted(title_.c_str());
+        ImGui::Separator();
+
+        if (ImGui::Button("Up"))
         {
-          dirs.push_back(entry);
+            const std::filesystem::path p(currentDir_);
+            if (p.has_parent_path() && p.parent_path() != p)
+            {
+                currentDir_ = p.parent_path().string();
+            }
         }
-        else if (
-            filters_.empty() || static_cast<size_t>(selectedFilterIdx_) >= filters_.size() ||
-            matchesFilter(entry, filters_[static_cast<size_t>(selectedFilterIdx_)]))
+        ImGui::SameLine();
+        ImGui::TextUnformatted(currentDir_.c_str());
+
+        ImGui::Separator();
+
+        if (ImGui::BeginChild(
+                "##fileList", ImVec2(0, -80), true, ImGuiWindowFlags_HorizontalScrollbar))
         {
-          files.push_back(entry);
-        }
-      }
-      std::sort(
-          dirs.begin(), dirs.end(),
-          [](const auto& a, const auto& b) { return a.path().filename() < b.path().filename(); });
-      std::sort(
-          files.begin(), files.end(),
-          [](const auto& a, const auto& b) { return a.path().filename() < b.path().filename(); });
+            std::error_code                               ec;
+            std::vector<std::filesystem::directory_entry> dirs;
+            std::vector<std::filesystem::directory_entry> files;
+            for (const auto& entry : std::filesystem::directory_iterator(currentDir_, ec))
+            {
+                if (entry.is_directory())
+                {
+                    dirs.push_back(entry);
+                }
+                else if (
+                    filters_.empty() ||
+                    static_cast<size_t>(selectedFilterIdx_) >= filters_.size() ||
+                    matchesFilter(entry, filters_[static_cast<size_t>(selectedFilterIdx_)]))
+                {
+                    files.push_back(entry);
+                }
+            }
+            std::sort(
+                dirs.begin(), dirs.end(),
+                [](const auto& a, const auto& b)
+                { return a.path().filename() < b.path().filename(); });
+            std::sort(
+                files.begin(), files.end(),
+                [](const auto& a, const auto& b)
+                { return a.path().filename() < b.path().filename(); });
 
-      for (const auto& d : dirs)
-      {
-        const std::string label = std::string("[") + d.path().filename().string() + "]";
-        if (ImGui::Selectable(label.c_str(), false, ImGuiSelectableFlags_AllowDoubleClick))
+            for (const auto& d : dirs)
+            {
+                const std::string label = std::string("[") + d.path().filename().string() + "]";
+                if (ImGui::Selectable(label.c_str(), false, ImGuiSelectableFlags_AllowDoubleClick))
+                {
+                    if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
+                    {
+                        currentDir_ = d.path().string();
+                    }
+                }
+            }
+            for (const auto& f : files)
+            {
+                const std::string name       = f.path().filename().string();
+                const bool        isSelected = (name == typedName_);
+                if (ImGui::Selectable(
+                        name.c_str(), isSelected, ImGuiSelectableFlags_AllowDoubleClick))
+                {
+                    typedName_ = name;
+                    if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
+                    {
+                        result = (std::filesystem::path(currentDir_) / name).string();
+                    }
+                }
+            }
+        }
+        ImGui::EndChild();
+
+        if (!filters_.empty())
         {
-          if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
-          {
-            currentDir_ = d.path().string();
-          }
+            const std::string& previewLabel =
+                filters_[static_cast<size_t>(selectedFilterIdx_)].description;
+            if (ImGui::BeginCombo("Filter", previewLabel.c_str()))
+            {
+                for (size_t i = 0; i < filters_.size(); i++)
+                {
+                    const bool isSelected = (static_cast<int>(i) == selectedFilterIdx_);
+                    if (ImGui::Selectable(filters_[i].description.c_str(), isSelected))
+                    {
+                        selectedFilterIdx_ = static_cast<int>(i);
+                    }
+                }
+                ImGui::EndCombo();
+            }
         }
-      }
-      for (const auto& f : files)
-      {
-        const std::string name       = f.path().filename().string();
-        const bool        isSelected = (name == typedName_);
-        if (ImGui::Selectable(name.c_str(), isSelected, ImGuiSelectableFlags_AllowDoubleClick))
+
+        char buf[512];
+        std::snprintf(buf, sizeof(buf), "%s", typedName_.c_str());
+        ImGui::SetNextItemWidth(-1);
+        if (ImGui::InputText("##fileName", buf, sizeof(buf)))
         {
-          typedName_ = name;
-          if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
-          {
-            result = (std::filesystem::path(currentDir_) / name).string();
-          }
+            typedName_ = buf;
         }
-      }
-    }
-    ImGui::EndChild();
 
-    if (!filters_.empty())
-    {
-      const std::string& previewLabel =
-          filters_[static_cast<size_t>(selectedFilterIdx_)].description;
-      if (ImGui::BeginCombo("Filter", previewLabel.c_str()))
-      {
-        for (size_t i = 0; i < filters_.size(); i++)
+        if (!errorMsg_.empty())
         {
-          const bool isSelected = (static_cast<int>(i) == selectedFilterIdx_);
-          if (ImGui::Selectable(filters_[i].description.c_str(), isSelected))
-          {
-            selectedFilterIdx_ = static_cast<int>(i);
-          }
+            ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "%s", errorMsg_.c_str());
         }
-        ImGui::EndCombo();
-      }
-    }
 
-    char buf[512];
-    std::snprintf(buf, sizeof(buf), "%s", typedName_.c_str());
-    ImGui::SetNextItemWidth(-1);
-    if (ImGui::InputText("##fileName", buf, sizeof(buf)))
-    {
-      typedName_ = buf;
-    }
-
-    if (!errorMsg_.empty())
-    {
-      ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "%s", errorMsg_.c_str());
-    }
-
-    const char* confirmLabel = (mode_ == Mode::Open) ? "Open" : "Save";
-    if (ImGui::Button(confirmLabel))
-    {
-      if (typedName_.empty())
-      {
-        errorMsg_ = "Please select or type a file name.";
-      }
-      else
-      {
-        const auto candidate = std::filesystem::path(currentDir_) / typedName_;
-        if (mode_ == Mode::Open && !std::filesystem::exists(candidate))
+        const char* confirmLabel = (mode_ == Mode::Open) ? "Open" : "Save";
+        if (ImGui::Button(confirmLabel))
         {
-          errorMsg_ = "File does not exist.";
+            if (typedName_.empty())
+            {
+                errorMsg_ = "Please select or type a file name.";
+            }
+            else
+            {
+                const auto candidate = std::filesystem::path(currentDir_) / typedName_;
+                if (mode_ == Mode::Open && !std::filesystem::exists(candidate))
+                {
+                    errorMsg_ = "File does not exist.";
+                }
+                else
+                {
+                    result = candidate.string();
+                }
+            }
         }
-        else
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel"))
         {
-          result = candidate.string();
+            open_ = false;
+            ImGui::CloseCurrentPopup();
         }
-      }
+
+        if (result.has_value())
+        {
+            open_ = false;
+            ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::EndPopup();
     }
-    ImGui::SameLine();
-    if (ImGui::Button("Cancel"))
+    else
     {
-      open_ = false;
-      ImGui::CloseCurrentPopup();
+        // Popup was dismissed by other means (e.g. Esc key).
+        open_ = false;
     }
 
-    if (result.has_value())
-    {
-      open_ = false;
-      ImGui::CloseCurrentPopup();
-    }
-
-    ImGui::EndPopup();
-  }
-  else
-  {
-    // Popup was dismissed by other means (e.g. Esc key).
-    open_ = false;
-  }
-
-  return result;
+    return result;
 }
 
 }  // namespace mp2p_icp_viz

--- a/mp2p_icp_viz/apps/imgui_app_common/src/SimpleFileDialog.cpp
+++ b/mp2p_icp_viz/apps/imgui_app_common/src/SimpleFileDialog.cpp
@@ -1,0 +1,212 @@
+#include <imgui_app_common/SimpleFileDialog.h>
+
+#include <imgui.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <system_error>
+
+namespace mp2p_icp_viz
+{
+namespace
+{
+constexpr const char* kPopupId = "SimpleFileDialog##popup";
+
+bool matchesFilter(const std::filesystem::directory_entry& entry, const FileDialogFilter& filter)
+{
+  if (filter.extension.empty())
+  {
+    return true;
+  }
+  auto ext = entry.path().extension().string();
+  if (!ext.empty() && ext.front() == '.')
+  {
+    ext.erase(0, 1);
+  }
+  return ext == filter.extension;
+}
+}  // namespace
+
+void SimpleFileDialog::open(
+    Mode mode, const std::vector<FileDialogFilter>& filters, const std::string& title,
+    const std::string& initialDir)
+{
+  mode_              = mode;
+  filters_           = filters;
+  selectedFilterIdx_ = 0;
+  title_             = title.empty() ? (mode == Mode::Open ? "Open file" : "Save file") : title;
+  typedName_.clear();
+  errorMsg_.clear();
+
+  std::error_code   ec;
+  std::filesystem::path startDir = !initialDir.empty()  ? std::filesystem::path(initialDir)
+                                    : !currentDir_.empty() ? std::filesystem::path(currentDir_)
+                                                            : std::filesystem::current_path(ec);
+  if (!std::filesystem::is_directory(startDir, ec))
+  {
+    startDir = std::filesystem::current_path(ec);
+  }
+  currentDir_ = startDir.string();
+
+  open_ = true;
+  ImGui::OpenPopup(kPopupId);
+}
+
+std::optional<std::string> SimpleFileDialog::render()
+{
+  if (!open_)
+  {
+    return std::nullopt;
+  }
+
+  std::optional<std::string> result;
+
+  ImGui::SetNextWindowSize(ImVec2(560, 420), ImGuiCond_FirstUseEver);
+  if (ImGui::BeginPopupModal(kPopupId, nullptr, ImGuiWindowFlags_NoSavedSettings))
+  {
+    ImGui::TextUnformatted(title_.c_str());
+    ImGui::Separator();
+
+    if (ImGui::Button("Up"))
+    {
+      const std::filesystem::path p(currentDir_);
+      if (p.has_parent_path() && p.parent_path() != p)
+      {
+        currentDir_ = p.parent_path().string();
+      }
+    }
+    ImGui::SameLine();
+    ImGui::TextUnformatted(currentDir_.c_str());
+
+    ImGui::Separator();
+
+    if (ImGui::BeginChild(
+            "##fileList", ImVec2(0, -80), true, ImGuiWindowFlags_HorizontalScrollbar))
+    {
+      std::error_code                               ec;
+      std::vector<std::filesystem::directory_entry> dirs;
+      std::vector<std::filesystem::directory_entry> files;
+      for (const auto& entry : std::filesystem::directory_iterator(currentDir_, ec))
+      {
+        if (entry.is_directory())
+        {
+          dirs.push_back(entry);
+        }
+        else if (
+            filters_.empty() || static_cast<size_t>(selectedFilterIdx_) >= filters_.size() ||
+            matchesFilter(entry, filters_[static_cast<size_t>(selectedFilterIdx_)]))
+        {
+          files.push_back(entry);
+        }
+      }
+      std::sort(
+          dirs.begin(), dirs.end(),
+          [](const auto& a, const auto& b) { return a.path().filename() < b.path().filename(); });
+      std::sort(
+          files.begin(), files.end(),
+          [](const auto& a, const auto& b) { return a.path().filename() < b.path().filename(); });
+
+      for (const auto& d : dirs)
+      {
+        const std::string label = std::string("[") + d.path().filename().string() + "]";
+        if (ImGui::Selectable(label.c_str(), false, ImGuiSelectableFlags_AllowDoubleClick))
+        {
+          if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
+          {
+            currentDir_ = d.path().string();
+          }
+        }
+      }
+      for (const auto& f : files)
+      {
+        const std::string name       = f.path().filename().string();
+        const bool        isSelected = (name == typedName_);
+        if (ImGui::Selectable(name.c_str(), isSelected, ImGuiSelectableFlags_AllowDoubleClick))
+        {
+          typedName_ = name;
+          if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
+          {
+            result = (std::filesystem::path(currentDir_) / name).string();
+          }
+        }
+      }
+    }
+    ImGui::EndChild();
+
+    if (!filters_.empty())
+    {
+      const std::string& previewLabel =
+          filters_[static_cast<size_t>(selectedFilterIdx_)].description;
+      if (ImGui::BeginCombo("Filter", previewLabel.c_str()))
+      {
+        for (size_t i = 0; i < filters_.size(); i++)
+        {
+          const bool isSelected = (static_cast<int>(i) == selectedFilterIdx_);
+          if (ImGui::Selectable(filters_[i].description.c_str(), isSelected))
+          {
+            selectedFilterIdx_ = static_cast<int>(i);
+          }
+        }
+        ImGui::EndCombo();
+      }
+    }
+
+    char buf[512];
+    std::snprintf(buf, sizeof(buf), "%s", typedName_.c_str());
+    ImGui::SetNextItemWidth(-1);
+    if (ImGui::InputText("##fileName", buf, sizeof(buf)))
+    {
+      typedName_ = buf;
+    }
+
+    if (!errorMsg_.empty())
+    {
+      ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "%s", errorMsg_.c_str());
+    }
+
+    const char* confirmLabel = (mode_ == Mode::Open) ? "Open" : "Save";
+    if (ImGui::Button(confirmLabel))
+    {
+      if (typedName_.empty())
+      {
+        errorMsg_ = "Please select or type a file name.";
+      }
+      else
+      {
+        const auto candidate = std::filesystem::path(currentDir_) / typedName_;
+        if (mode_ == Mode::Open && !std::filesystem::exists(candidate))
+        {
+          errorMsg_ = "File does not exist.";
+        }
+        else
+        {
+          result = candidate.string();
+        }
+      }
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Cancel"))
+    {
+      open_ = false;
+      ImGui::CloseCurrentPopup();
+    }
+
+    if (result.has_value())
+    {
+      open_ = false;
+      ImGui::CloseCurrentPopup();
+    }
+
+    ImGui::EndPopup();
+  }
+  else
+  {
+    // Popup was dismissed by other means (e.g. Esc key).
+    open_ = false;
+  }
+
+  return result;
+}
+
+}  // namespace mp2p_icp_viz

--- a/mp2p_icp_viz/apps/mm-viewer/CMakeLists.txt
+++ b/mp2p_icp_viz/apps/mm-viewer/CMakeLists.txt
@@ -12,4 +12,5 @@ mola_add_executable(
     CLI11::CLI11
     mrpt::gui
     Threads::Threads
+    imgui_app_common
   )

--- a/mp2p_icp_viz/apps/mm-viewer/main.cpp
+++ b/mp2p_icp_viz/apps/mm-viewer/main.cpp
@@ -46,7 +46,9 @@
 #include <mrpt/version.h>
 
 #include <CLI/CLI.hpp>
+#include <algorithm>
 #include <cmath>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -148,6 +150,12 @@ struct AppState
     int mouseUnitsIdx        = 0;  // map / enu / lat-lon
 
     bool doFitView = false;
+
+    // Forces regeneration of the cached point-cloud OpenGL representation on the next
+    // rebuild_3d_view() call, even if render_params_t happens to compare equal to the last
+    // build (e.g. after loading a different map whose layers coincidentally share names,
+    // visibility, and render options with the previous one).
+    bool forceRebuildViz = true;
 
     std::string mouseCoordText = "Mouse pointing to: -";
     std::string cameraLookText = "Camera looking at: -";
@@ -275,6 +283,12 @@ bool loadMapFile(const std::string& mapFile)
     std::cout << "Loading map file: " << mapFile << std::endl;
 
     app.theMap = mp2p_icp::metric_map_t();  // reset
+    // Clear bookkeeping alongside theMap so any early-return-on-failure below leaves the UI
+    // consistently reflecting "no map", rather than describing the previous (different) map:
+    app.theMapFileName = "unnamed.mm";
+    app.layerNames.clear();
+    app.knownPointFields.clear();
+    app.layerVisible.clear();
 
     if (mrpt::system::extractFileExtension(mapFile) == "bin")
     {
@@ -422,6 +436,13 @@ std::string transformAndFormatSelectedPoint(const mrpt::math::TPoint3D& pt)
     const bool ptIsENU   = hasGeoref && app.applyGeoRef;
     const int  idx       = hasGeoref ? app.mouseUnitsIdx : 0;
 
+    // `pt` is in the ENU frame when ptIsENU, otherwise it is in the "map" frame -- convert to
+    // ENU once so cases 1/2 (which are only offered when hasGeoref) are correct regardless of
+    // whether "Apply georeferenced pose" is currently checked.
+    const mrpt::math::TPoint3D ptEnu =
+        (!ptIsENU && hasGeoref) ? app.theMap.georeferencing->T_enu_to_map.mean.composePoint(pt)
+                                : pt;
+
     switch (idx)
     {
         case 0:  // show in map
@@ -438,14 +459,14 @@ std::string transformAndFormatSelectedPoint(const mrpt::math::TPoint3D& pt)
             return mrpt::format("X=%6.03f Y=%6.03f Z=%6.03f", ptViz.x, ptViz.y, ptViz.z);
         }
         case 1:  // show in enu
-            return mrpt::format("X=%6.03f Y=%6.03f Z=%6.03f", pt.x, pt.y, pt.z);
+            return mrpt::format("X=%6.03f Y=%6.03f Z=%6.03f", ptEnu.x, ptEnu.y, ptEnu.z);
         case 2:  // show as lat/lon
         {
             try
             {
                 mrpt::topography::TGeocentricCoords geocentricPt;
                 mrpt::topography::ENUToGeocentric(
-                    pt, app.theMap.georeferencing->geo_coord, geocentricPt,
+                    ptEnu, app.theMap.georeferencing->geo_coord, geocentricPt,
                     mrpt::topography::TEllipsoid::Ellipsoid_WGS84());
 
                 mrpt::topography::TGeodeticCoords outCoords;
@@ -632,6 +653,8 @@ void updateMiniCornerView()
 
 void updateGuiAfterLoadingNewMap()
 {
+    app.forceRebuildViz = true;
+
     app.layerVisible.clear();
     for (const auto& name : app.layerNames)
     {
@@ -870,11 +893,21 @@ void handleKeyboard()
 
 void onSaveLayers(const std::string& outFile)
 {
+    const std::filesystem::path base(outFile);
+
     for (const auto& lyName : app.layerNames)
     {
+        if (auto itV = app.layerVisible.find(lyName); itV == app.layerVisible.end() || !itV->second)
+        {
+            continue;  // not a marked (visible) layer
+        }
         if (auto itL = app.theMap.layers.find(lyName); itL != app.theMap.layers.end())
         {
-            itL->second->saveMetricMapRepresentationToFile(outFile);
+            // One file per layer: writing every layer to the same outFile would clobber all
+            // but the last one.
+            const auto perLayerFile = base.parent_path() / (base.stem().string() + "_" + lyName +
+                                                            base.extension().string());
+            itL->second->saveMetricMapRepresentationToFile(perLayerFile.string());
         }
     }
 }
@@ -897,7 +930,9 @@ void rebuild_3d_view()
             }
         }
 
-        if (!app.layerVisible[lyName])
+        const auto itV       = app.layerVisible.find(lyName);
+        const bool isVisible = (itV == app.layerVisible.end()) ? true : itV->second;
+        if (!isVisible)
         {
             continue;  // hidden
         }
@@ -938,12 +973,14 @@ void rebuild_3d_view()
         rp.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0x80);
     }
 
-    // Regenerate points opengl representation only if some parameter changed:
+    // Regenerate points opengl representation only if some parameter changed (or a new map
+    // was just loaded, regardless of whether rpMap happens to compare equal to the last one):
     static std::optional<mp2p_icp::render_params_t> prevRenderParams;
 
-    if (!prevRenderParams.has_value() || prevRenderParams.value() != rpMap)
+    if (!prevRenderParams.has_value() || prevRenderParams.value() != rpMap || app.forceRebuildViz)
     {
-        prevRenderParams = rpMap;
+        app.forceRebuildViz = false;
+        prevRenderParams    = rpMap;
         app.glVizMap->clear();
 
         auto glPts = app.theMap.get_visualization(rpMap);
@@ -1051,18 +1088,6 @@ void renderMapViewerPanel()
     {
         app.exportDialog.open(
             mp2p_icp_viz::SimpleFileDialog::Mode::Save, {{"txt", "(*.txt)"}}, "Export layers");
-    }
-
-    if (auto path = app.openDialog.render(); path.has_value())
-    {
-        if (loadMapFile(*path))
-        {
-            updateGuiAfterLoadingNewMap();
-        }
-    }
-    if (auto path = app.exportDialog.render(); path.has_value())
-    {
-        onSaveLayers(*path);
     }
 
     ImGui::Separator();
@@ -1281,20 +1306,17 @@ void renderTravellingPanel()
 
     ImGui::TextUnformatted("Define camera travelling paths");
 
-    ImGui::SetNextItemWidth(-1);
-    if (!app.camTravellingLabels.empty())
+    // Plain read-only list (not a combo): keyframes cannot currently be selected, jumped to,
+    // or deleted individually, so an interactive-looking widget would be misleading.
+    ImGui::TextUnformatted("Keyframes:");
+    if (ImGui::BeginChild("##travellingKeys", ImVec2(0, 100), true))
     {
-        const int   selected = static_cast<int>(app.camTravellingLabels.size()) - 1;
-        const char* preview  = app.camTravellingLabels[static_cast<size_t>(selected)].c_str();
-        if (ImGui::BeginCombo("##travellingKeys", preview))
+        for (const auto& label : app.camTravellingLabels)
         {
-            for (size_t i = 0; i < app.camTravellingLabels.size(); i++)
-            {
-                ImGui::Selectable(app.camTravellingLabels[i].c_str(), false);
-            }
-            ImGui::EndCombo();
+            ImGui::TextUnformatted(label.c_str());
         }
     }
+    ImGui::EndChild();
 
     ImGui::InputFloat("New keyframe time [s]", &app.newKeyframeTime);
     ImGui::SameLine();
@@ -1327,7 +1349,10 @@ void renderTravellingPanel()
     }
     ImGui::EndDisabled();
 
-    ImGui::InputFloat("Animation FPS", &app.animFPS);
+    if (ImGui::InputFloat("Animation FPS", &app.animFPS))
+    {
+        app.animFPS = std::clamp(app.animFPS, 1.0f, 240.0f);
+    }
 
     const char* interpItems[] = {"Linear", "Spline"};
     ImGui::Combo("Interpolation", &app.travellingInterpIdx, interpItems, 2);
@@ -1337,6 +1362,25 @@ void renderTravellingPanel()
     ImGui::EndDisabled();
 
     ImGui::End();
+}
+
+/** Renders both file dialogs at top level, outside any other window's Begin/End -- nesting them
+ * inside e.g. "Map viewer" would silently cancel an open dialog whenever that window is
+ * collapsed (BeginPopupModal() fails to start, which SimpleFileDialog::render() treats as a
+ * dismiss). */
+void renderFileDialogs()
+{
+    if (auto path = app.openDialog.render(); path.has_value())
+    {
+        if (loadMapFile(*path))
+        {
+            updateGuiAfterLoadingNewMap();
+        }
+    }
+    if (auto path = app.exportDialog.render(); path.has_value())
+    {
+        onSaveLayers(*path);
+    }
 }
 
 /** "3D View" window: fills the remaining (background) dockspace area. */
@@ -1359,6 +1403,7 @@ void renderFrame()
     renderViewPanel();
     renderMapsPanel();
     renderTravellingPanel();
+    renderFileDialogs();
     renderSceneWindow();
 }
 
@@ -1462,6 +1507,11 @@ int mainShowGui()
     // only remembers panel docking):
     char appCfgFile[1024];
     ::get_user_config_file(appCfgFile, sizeof(appCfgFile), APP_NAME);
+    if (appCfgFile[0] == '\0')
+    {
+        std::cerr << "Warning: could not determine a user config file path; "
+                     "UI/camera settings will not be persisted.\n";
+    }
     mrpt::config::CConfigFile appCfg(appCfgFile);
 
     auto& cam               = app.sceneView.camera();

--- a/mp2p_icp_viz/apps/mm-viewer/main.cpp
+++ b/mp2p_icp_viz/apps/mm-viewer/main.cpp
@@ -19,6 +19,7 @@
 // other deps:
 #include <GLFW/glfw3.h>
 #include <imgui.h>
+#include <imgui_app_common/AsyncTask.h>
 #include <imgui_app_common/ImGuiAppShell.h>
 #include <imgui_app_common/SimpleFileDialog.h>
 #include <imgui_internal.h>  // DockBuilder* API (default docking layout)
@@ -89,6 +90,19 @@ struct ExtraVizLayer
     std::string                      fileName;
     mrpt::opengl::CSetOfObjects::Ptr glObjects;
     bool                             visible = true;
+};
+
+/** Result of loadMapFileWorker(), running on a background thread: a self-contained value (no
+ *  reference to AppState) so it is safe to build off the main/GL thread. Committed to AppState
+ *  on the main thread once ready -- see pollMapLoad(). */
+struct MapLoadResult
+{
+    bool                     success = false;
+    std::string              errorMessage;
+    std::string              mapFileName;
+    mp2p_icp::metric_map_t   map;
+    std::vector<std::string> layerNames;
+    std::vector<std::string> knownPointFields;
 };
 
 /** All mutable application state, replacing the individual nanogui widget
@@ -162,6 +176,23 @@ struct AppState
 
     mp2p_icp_viz::SimpleFileDialog openDialog;
     mp2p_icp_viz::SimpleFileDialog exportDialog;
+
+    // Async map loading (see loadMapFileWorker()/pollMapLoad()): keeps the file I/O off the
+    // main/GL thread so the window manager doesn't consider the app "not responding" while a
+    // large map file is being read.
+    mp2p_icp_viz::AsyncTask<MapLoadResult> mapLoadTask;
+    bool                                   isLoadingMap = false;
+    std::string                            loadingFileName;
+
+    // Bumped every time app.theMap is replaced (successfully or not). Lets an in-flight
+    // vizBuildTask (started for a previous map) recognize its result is now stale once polled.
+    int mapGeneration = 0;
+
+    // Async point-cloud visualization building (see rebuild_3d_view()): same rationale, for
+    // theMap.get_visualization(), which can also take a long time on large maps.
+    mp2p_icp_viz::AsyncTask<mrpt::opengl::CSetOfObjects::Ptr> vizBuildTask;
+    bool                                                      isBuildingViz          = false;
+    int                                                       vizBuildTaskGeneration = -1;
 };
 
 AppState app;
@@ -264,6 +295,8 @@ mrpt::opengl::CSetOfObjects::Ptr buildGeorefPolygonLayer(
     return glLayer;
 }
 
+void updateGuiAfterLoadingNewMap();
+
 void rebuildCamTravellingLabels()
 {
     app.camTravellingLabels.clear();
@@ -278,17 +311,17 @@ void rebuildCamTravellingLabels()
     }
 }
 
-bool loadMapFile(const std::string& mapFile)
+/** Does the actual (potentially slow: disk I/O, decompression, sanity checks) map loading work.
+ *  Deliberately self-contained -- reads/writes only its local `res`, never `app.*` -- so it is
+ *  safe to run on a background thread (see startMapLoad()/pollMapLoad()) instead of blocking the
+ *  main/GL thread, which would otherwise starve glfwPollEvents() for large files and make the
+ *  window manager conclude the app is "not responding". */
+MapLoadResult loadMapFileWorker(const std::string& mapFile)
+try
 {
-    std::cout << "Loading map file: " << mapFile << std::endl;
+    MapLoadResult res;
 
-    app.theMap = mp2p_icp::metric_map_t();  // reset
-    // Clear bookkeeping alongside theMap so any early-return-on-failure below leaves the UI
-    // consistently reflecting "no map", rather than describing the previous (different) map:
-    app.theMapFileName = "unnamed.mm";
-    app.layerNames.clear();
-    app.knownPointFields.clear();
-    app.layerVisible.clear();
+    std::cout << "Loading map file: " << mapFile << std::endl;
 
     if (mrpt::system::extractFileExtension(mapFile) == "bin")
     {
@@ -300,26 +333,28 @@ bool loadMapFile(const std::string& mapFile)
             auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(obj);
             if (!pts)
             {
-                std::cerr << "Error: .bin file did not deserialize to a CPointsMap-derived object"
-                          << (obj ? std::string(" (got: ") + obj->GetRuntimeClass()->className + ")"
-                                  : std::string(" (null object)"))
-                          << std::endl;
-                return false;
+                res.errorMessage =
+                    "Error: .bin file did not deserialize to a CPointsMap-derived object" +
+                    (obj ? std::string(" (got: ") + obj->GetRuntimeClass()->className + ")"
+                         : std::string(" (null object)"));
+                std::cerr << res.errorMessage << std::endl;
+                return res;
             }
-            const std::string layerName  = mrpt::system::extractFileName(mapFile);
-            app.theMap.layers[layerName] = pts;
+            const std::string layerName = mrpt::system::extractFileName(mapFile);
+            res.map.layers[layerName]   = pts;
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Error loading .bin file: " << e.what() << std::endl;
-            return false;
+            res.errorMessage = std::string("Error loading .bin file: ") + e.what();
+            std::cerr << res.errorMessage << std::endl;
+            return res;
         }
     }
     else
     {
         std::string loadErrorMsg;
 
-        if (!app.theMap.load_from_file(mapFile, loadErrorMsg))
+        if (!res.map.load_from_file(mapFile, loadErrorMsg))
         {
             bool retry_was_successful = false;
 
@@ -334,27 +369,28 @@ bool loadMapFile(const std::string& mapFile)
 
                 if (!load_plugins("libmola_metric_maps.so"))
                 {
-                    return false;
+                    res.errorMessage = "Failed to load plugin 'libmola_metric_maps.so'";
+                    return res;
                 }
-                retry_was_successful = app.theMap.load_from_file(mapFile, loadErrorMsg);
+                retry_was_successful = res.map.load_from_file(mapFile, loadErrorMsg);
             }
 
             if (!retry_was_successful)
             {
-                std::cerr << "Error loading metric map from file!:\n" << loadErrorMsg << std::endl;
-                return false;
+                res.errorMessage = "Error loading metric map from file!:\n" + loadErrorMsg;
+                std::cerr << res.errorMessage << std::endl;
+                return res;
             }
         }
     }
 
-    app.theMapFileName = mapFile;
+    res.mapFileName = mapFile;
 
-    std::cout << "Loaded map: " << app.theMap.contents_summary() << std::endl;
+    std::cout << "Loaded map: " << res.map.contents_summary() << std::endl;
 
-    app.layerNames.clear();
-    for (const auto& [name, map] : app.theMap.layers)
+    for (const auto& [name, map] : res.map.layers)
     {
-        app.layerNames.push_back(name);
+        res.layerNames.push_back(name);
     }
 
     // Find point cloud field names:
@@ -364,7 +400,7 @@ bool loadMapFile(const std::string& mapFile)
         fields.insert("y");
         fields.insert("z");
 
-        for (const auto& [name, map] : app.theMap.layers)
+        for (const auto& [name, map] : res.map.layers)
         {
             auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(map);
             if (!pts)
@@ -406,15 +442,14 @@ bool loadMapFile(const std::string& mapFile)
             fields.insert("rgbf");
         }
 
-        app.knownPointFields.clear();
         for (const auto& f : fields)
         {
-            app.knownPointFields.push_back(f);
+            res.knownPointFields.push_back(f);
         }
     }
 
     // sanity checks:
-    for (const auto& [name, map] : app.theMap.layers)
+    for (const auto& [name, map] : res.map.layers)
     {
         const auto* pc = mp2p_icp::MapToPointsMap(*map);
         if (!pc)
@@ -426,7 +461,61 @@ bool loadMapFile(const std::string& mapFile)
             sanityPassed, mrpt::format("sanity check did not pass for layer: '%s'", name.c_str()));
     }
 
-    return true;
+    res.success = true;
+    return res;
+}
+catch (const std::exception& e)
+{
+    MapLoadResult res;
+    res.errorMessage = std::string("Error loading map: ") + e.what();
+    std::cerr << res.errorMessage << std::endl;
+    return res;
+}
+
+/** Starts loading `mapFile` on a background thread; see pollMapLoad() for the main-thread
+ * commit. */
+void startMapLoad(const std::string& mapFile)
+{
+    app.isLoadingMap    = true;
+    app.loadingFileName = mapFile;
+    app.mapLoadTask.start([mapFile]() { return loadMapFileWorker(mapFile); });
+}
+
+/** Installs a (successful or failed) load result into AppState. Must run on the main thread.
+ * Does NOT call updateGuiAfterLoadingNewMap() -- callers do that explicitly, since the initial
+ * CLI-arg load (before the GUI even exists) already gets it invoked once, unconditionally,
+ * right after the window is set up. */
+void commitMapLoadResult(MapLoadResult&& res)
+{
+    app.mapGeneration++;  // invalidate any in-flight vizBuildTask started for the old map
+
+    if (!res.success)
+    {
+        // Leave bookkeeping consistent with "no map loaded", rather than describing whatever
+        // (different) map was loaded before this attempt.
+        app.theMap         = mp2p_icp::metric_map_t();
+        app.theMapFileName = "unnamed.mm";
+        app.layerNames.clear();
+        app.knownPointFields.clear();
+        app.layerVisible.clear();
+        return;
+    }
+
+    app.theMap           = std::move(res.map);
+    app.theMapFileName   = res.mapFileName;
+    app.layerNames       = std::move(res.layerNames);
+    app.knownPointFields = std::move(res.knownPointFields);
+}
+
+/** Call once per frame: if a background map load finished, commits it on the main thread. */
+void pollMapLoad()
+{
+    if (auto res = app.mapLoadTask.poll())
+    {
+        app.isLoadingMap = false;
+        commitMapLoadResult(std::move(*res));
+        updateGuiAfterLoadingNewMap();
+    }
 }
 
 /** Transform to show in the selected frame of reference and units: "map", "enu", or "lat/lon" */
@@ -974,21 +1063,47 @@ void rebuild_3d_view()
     }
 
     // Regenerate points opengl representation only if some parameter changed (or a new map
-    // was just loaded, regardless of whether rpMap happens to compare equal to the last one):
+    // was just loaded, regardless of whether rpMap happens to compare equal to the last one).
+    // Built on a background thread (theMap.get_visualization() can take a long time on large
+    // maps) so the main/GL thread keeps pumping events instead of appearing "not responding".
     static std::optional<mp2p_icp::render_params_t> prevRenderParams;
 
-    if (!prevRenderParams.has_value() || prevRenderParams.value() != rpMap || app.forceRebuildViz)
+    const bool needsRebuild =
+        !prevRenderParams.has_value() || prevRenderParams.value() != rpMap || app.forceRebuildViz;
+
+    if (needsRebuild && !app.isBuildingViz)
     {
         app.forceRebuildViz = false;
         prevRenderParams    = rpMap;
-        app.glVizMap->clear();
 
-        auto glPts = app.theMap.get_visualization(rpMap);
+        app.isBuildingViz          = true;
+        app.vizBuildTaskGeneration = app.mapGeneration;
 
-        app.glVizMap->insert(glPts);
-        app.glVizMap->insert(app.glMapCorner);
-        app.glVizMap->insert(app.glTrajectory);
-        app.glVizMap->insert(app.glVizObjects);
+        // Shallow copy: shares the underlying (immutable, once loaded) layer CMetricMap::Ptr
+        // objects, so this is cheap regardless of map size, and safe to read from the
+        // background thread even if the main thread replaces app.theMap in the meantime.
+        const mp2p_icp::metric_map_t mapCopy = app.theMap;
+        app.vizBuildTask.start([mapCopy, rpMap]() { return mapCopy.get_visualization(rpMap); });
+    }
+
+    if (auto glPts = app.vizBuildTask.poll())
+    {
+        app.isBuildingViz = false;
+
+        if (app.vizBuildTaskGeneration == app.mapGeneration)
+        {
+            app.glVizMap->clear();
+            app.glVizMap->insert(*glPts);
+            app.glVizMap->insert(app.glMapCorner);
+            app.glVizMap->insert(app.glTrajectory);
+            app.glVizMap->insert(app.glVizObjects);
+        }
+        else
+        {
+            // Stale: app.theMap was replaced while this build was in flight. Force a fresh
+            // rebuild for the current map on the next frame.
+            app.forceRebuildViz = true;
+        }
     }
 
     if (app.applyGeoRef && app.theMap.georeferencing.has_value())
@@ -1076,6 +1191,8 @@ void renderMapViewerPanel()
 
     const std::string headerLine = app.theMapFileName + "  |  " + app.theMap.contents_summary();
     ImGui::TextWrapped("%s", headerLine.c_str());
+
+    ImGui::BeginDisabled(app.isLoadingMap);
     if (ImGui::Button("Open..."))
     {
         app.openDialog.open(
@@ -1088,6 +1205,17 @@ void renderMapViewerPanel()
     {
         app.exportDialog.open(
             mp2p_icp_viz::SimpleFileDialog::Mode::Save, {{"txt", "(*.txt)"}}, "Export layers");
+    }
+    ImGui::EndDisabled();
+
+    if (app.isLoadingMap)
+    {
+        ImGui::TextColored(
+            ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "Loading '%s'...", app.loadingFileName.c_str());
+    }
+    else if (app.isBuildingViz)
+    {
+        ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "Building 3D visualization...");
     }
 
     ImGui::Separator();
@@ -1372,10 +1500,7 @@ void renderFileDialogs()
 {
     if (auto path = app.openDialog.render(); path.has_value())
     {
-        if (loadMapFile(*path))
-        {
-            updateGuiAfterLoadingNewMap();
-        }
+        startMapLoad(*path);
     }
     if (auto path = app.exportDialog.render(); path.has_value())
     {
@@ -1394,6 +1519,7 @@ void renderSceneWindow()
 void renderFrame()
 {
     handleKeyboard();
+    pollMapLoad();
     processCameraTravelling();
     rebuild_3d_view();
     updateCameraClipDistances();
@@ -1413,10 +1539,15 @@ int mainShowGui()
 
     if (!argMapFile.empty())
     {
-        if (!loadMapFile(argMapFile))
+        // Synchronous here: no GUI window exists yet at this point (still before
+        // app.shell.init() below), so there is nothing for the window manager to consider
+        // "not responding" -- this only matters once a window is on screen and pumping events.
+        auto res = loadMapFileWorker(argMapFile);
+        if (!res.success)
         {
             return 1;
         }
+        commitMapLoadResult(std::move(res));
     }
 
     if (!arg_georefPolygon.empty())

--- a/mp2p_icp_viz/apps/mm-viewer/main.cpp
+++ b/mp2p_icp_viz/apps/mm-viewer/main.cpp
@@ -1,6 +1,6 @@
-﻿/* -------------------------------------------------------------------------
+/* -------------------------------------------------------------------------
  *  A repertory of multi primitive-to-primitive (MP2P) ICP algorithms in C++
- * Copyright (C) 2018-2021 Jose Luis Blanco, University of Almeria
+ * Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria
  * See LICENSE for license information.
  * ------------------------------------------------------------------------- */
 
@@ -14,7 +14,7 @@
 // The goal is to visualize these guys:
 #include <mp2p_icp/metricmap.h>
 // using this:
-#include <mrpt/gui/CDisplayWindowGUI.h>
+#include <mrpt/imgui/CImGuiSceneView.h>
 
 // other deps:
 #include <mp2p_icp/pointcloud_sanity_check.h>
@@ -29,6 +29,7 @@
 #include <mrpt/opengl/COpenGLScene.h>
 #include <mrpt/opengl/CPointCloudColoured.h>
 #include <mrpt/opengl/CSetOfLines.h>
+#include <mrpt/opengl/CText.h>
 #include <mrpt/opengl/stock_objects.h>
 #include <mrpt/poses/CPose3DInterpolator.h>
 #include <mrpt/serialization/CArchive.h>
@@ -38,120 +39,127 @@
 #include <mrpt/topography/conversions.h>
 #include <mrpt/version.h>
 
+#include <imgui.h>
+#include <imgui_app_common/ImGuiAppShell.h>
+#include <imgui_app_common/SimpleFileDialog.h>
+#include <imgui_internal.h>  // DockBuilder* API (default docking layout)
+#include <imgui_stdlib.h>  // ImGui::InputText(std::string*)
+
+#include <GLFW/glfw3.h>
+
 #include <CLI/CLI.hpp>
+#include <cmath>
 #include <fstream>
 #include <iostream>
 #include <sstream>
 
 #include "../libcfgpath/cfgpath.h"
 
-constexpr const char* APP_NAME        = "mm-viewer";
-constexpr int         MID_FONT_SIZE   = 14;
-constexpr int         SMALL_FONT_SIZE = 13;
-
-constexpr const char* FIRST_MINI_VIEW_NAME  = "small-view-1";
-constexpr const char* SECOND_MINI_VIEW_NAME = "small-view-2";
-
-// =========== Declare supported cli switches ===========
-static CLI::App cmd{APP_NAME};
-
-static std::string              argMapFile;
-static std::string              arg_plugins;
-static std::string              arg_tumTrajectory;
-static std::vector<std::string> arg_add3dScenes;
-static std::string              arg_georefPolygon;
-
-// =========== Declare global variables ===========
-#if MRPT_HAS_NANOGUI
-
-auto                             glVizMap = mrpt::opengl::CSetOfObjects::Create();
-auto                             glGrid   = mrpt::opengl::CGridPlaneXY::Create();
-mrpt::opengl::CSetOfObjects::Ptr glENUCorner;
-mrpt::opengl::CSetOfObjects::Ptr glMapCorner;
-mrpt::opengl::CSetOfObjects::Ptr glTrajectory;
-mrpt::opengl::CSetOfObjects::Ptr glVizObjects;
-
-mrpt::gui::CDisplayWindowGUI::Ptr win;
-
-std::array<nanogui::TextBox*, 2> lbMapStats                   = {nullptr, nullptr};
-nanogui::CheckBox*               cbApplyGeoRef                = nullptr;
-nanogui::CheckBox*               cbViewOrtho                  = nullptr;
-nanogui::CheckBox*               cbView2D                     = nullptr;
-nanogui::CheckBox*               cbViewVoxelsAsPoints         = nullptr;
-nanogui::CheckBox*               cbViewVoxelsFreeSpace        = nullptr;
-nanogui::CheckBox*               cbColorizeMap                = nullptr;
-nanogui::CheckBox*               cbKeepNativeCloudColors      = nullptr;
-nanogui::CheckBox*               cbAutoBBoxOutliers           = nullptr;
-nanogui::Slider*                 slAutoBBoxOutliersPercentile = nullptr;
-nanogui::Label*                  lbAutoBBoxOutliersPercentile = nullptr;
-nanogui::ComboBox*               cmbColorIntensity            = nullptr;
-nanogui::ComboBox*               cmbRecolorizeByField         = nullptr;
-nanogui::CheckBox*               cbShowGroundGrid             = nullptr;
-nanogui::Slider*                 slPointSize                  = nullptr;
-nanogui::Slider*                 slTrajectoryThickness        = nullptr;
-nanogui::Slider*                 slClipNear                   = nullptr;
-nanogui::Slider*                 slClipFar                    = nullptr;
-nanogui::TextBox*                edClipNear                   = nullptr;
-nanogui::TextBox*                edClipFar                    = nullptr;
-nanogui::Label*                  lbClipNear                   = nullptr;
-nanogui::Label*                  lbClipFar                    = nullptr;
-nanogui::CheckBox*               cbDepthLogScale              = nullptr;
-nanogui::Slider*                 slCameraFOV                  = nullptr;
-nanogui::Label*                  lbCameraFOV                  = nullptr;
-nanogui::Label*                  lbMousePos                   = nullptr;
-nanogui::ComboBox*               cbMouseUnits                 = nullptr;
-nanogui::Button*                 btnCopyCoords                = nullptr;
-nanogui::Label*                  lbCameraPointing             = nullptr;
-nanogui::Label*                  lbDepthFieldValues           = nullptr;
-nanogui::Label*                  lbPointSize                  = nullptr;
-nanogui::Label*                  lbTrajectoryThick            = nullptr;
-nanogui::Widget*                 panelLayers                  = nullptr;
-nanogui::ComboBox*               cbTravellingKeys             = nullptr;
-nanogui::TextBox*                edAnimFPS                    = nullptr;
-nanogui::Slider*                 slAnimProgress               = nullptr;
-nanogui::Button *                btnAnimate = nullptr, *btnAnimStop = nullptr;
-nanogui::ComboBox*               cbTravellingInterp = nullptr;
-
-std::vector<std::string>                  layerNames;
-std::vector<std::string>                  knownPointFields;
-std::map<std::string, nanogui::CheckBox*> cbLayersByName;
-bool                                      doFitView = false;
-
-mp2p_icp::metric_map_t theMap;
-std::string            theMapFileName = "unnamed.mm";
-
-// Robot path to display (optional):
-mrpt::poses::CPose3DInterpolator trajectory;
-
-// Extra viz layers from 3Dscene files (optional)
-struct ExtraVizLayer
-{
-    std::string                      fileName;
-    mrpt::opengl::CSetOfObjects::Ptr glObjects;
-    nanogui::CheckBox*               checkBox = nullptr;
-};
-static std::vector<ExtraVizLayer> extraVizLayers;
-
-// Camera travelling trajectory:
-mrpt::poses::CPose3DInterpolator camTravelling;
-std::optional<double>            camTravellingCurrentTime;
-
-constexpr float TRAVELING_ZOOM2ROLL = 1e-4;
-
-static void rebuild_3d_view(bool force_rebuild_view = false);
-static void onSaveLayers();
-
 namespace
 {
-static bool load_plugins(const std::string& plugins)
+constexpr const char* APP_NAME = "mm-viewer";
+
+constexpr float TRAVELING_ZOOM2ROLL = 1e-4f;
+
+const char* const kColorIntensityNames[]  = {"cmNONE", "cmHOT", "cmJET", "cmGRAYSCALE"};
+const char* const kColorIntensityLabels[] = {"None", "Hot", "Jet", "Grayscale"};
+constexpr int      kNumColorIntensity     = 4;
+
+// =========== Declare supported cli switches ===========
+CLI::App cmd{APP_NAME};
+
+std::string              argMapFile;
+std::string              arg_plugins;
+std::string              arg_tumTrajectory;
+std::vector<std::string> arg_add3dScenes;
+std::string              arg_georefPolygon;
+
+/** Extra viz layer loaded from a *.3dscene file, or from --georef-polygon. */
+struct ExtraVizLayer
 {
-    std::string errMsg;
-    if (!mrpt::system::loadPluginModules(plugins, errMsg))
-    {
-        std::cerr << errMsg << std::endl;
-        return false;
-    }
-    return true;
+  std::string                      fileName;
+  mrpt::opengl::CSetOfObjects::Ptr glObjects;
+  bool                             visible = true;
+};
+
+/** All mutable application state, replacing the individual nanogui widget
+ *  pointers of the previous implementation with plain value types (this is
+ *  an immediate-mode GUI: widgets read/write these each frame). */
+struct AppState
+{
+  mp2p_icp_viz::ImGuiAppShell  shell;
+  mrpt::imgui::CImGuiSceneView sceneView;
+  mrpt::opengl::Scene::Ptr     scene = mrpt::opengl::COpenGLScene::Create();
+
+  mrpt::opengl::CSetOfObjects::Ptr glVizMap     = mrpt::opengl::CSetOfObjects::Create();
+  mrpt::opengl::CGridPlaneXY::Ptr  glGrid       = mrpt::opengl::CGridPlaneXY::Create();
+  mrpt::opengl::CSetOfObjects::Ptr glENUCorner;
+  mrpt::opengl::CSetOfObjects::Ptr glMapCorner;
+  mrpt::opengl::CSetOfObjects::Ptr glTrajectory = mrpt::opengl::CSetOfObjects::Create();
+  mrpt::opengl::CSetOfObjects::Ptr glVizObjects = mrpt::opengl::CSetOfObjects::Create();
+
+  mp2p_icp::metric_map_t theMap;
+  std::string            theMapFileName = "unnamed.mm";
+
+  std::vector<std::string>    layerNames;
+  std::vector<std::string>    knownPointFields;
+  std::map<std::string, bool> layerVisible;
+
+  std::vector<ExtraVizLayer> extraVizLayers;
+
+  mrpt::poses::CPose3DInterpolator trajectory;
+
+  // Camera travelling:
+  mrpt::poses::CPose3DInterpolator camTravelling;
+  std::optional<double>            camTravellingCurrentTime;
+  std::vector<std::string>         camTravellingLabels;
+  float                            animFPS             = 30.0f;
+  float                            animProgress        = 0.0f;
+  int                              travellingInterpIdx = 0;  // 0=Linear, 1=Spline
+  float                            newKeyframeTime      = 0.0f;
+
+  // View options (mirrors the old nanogui side panel):
+  bool  applyGeoRef                = false;
+  bool  viewOrtho                  = false;
+  bool  view2D                     = false;
+  bool  viewVoxelsAsPoints         = false;
+  bool  viewVoxelsFreeSpace        = false;
+  bool  colorizeMap                = true;
+  bool  keepNativeCloudColors      = false;
+  bool  autoBBoxOutliers           = true;
+  float autoBBoxOutliersPercentile = 0.025f;
+  bool  showGroundGrid             = true;
+  bool  depthLogScale              = true;
+  float pointSize                  = 2.0f;
+  float trajectoryThicknessLog     = std::log(0.05f);
+  float clipNear                   = 0.1f;
+  float clipFar                    = 4.0f;
+  float cameraFOV                  = 90.0f;
+
+  int recolorizeByFieldIdx = 0;
+  int colorIntensityIdx    = 2;  // cmJET
+  int mouseUnitsIdx        = 0;  // map / enu / lat-lon
+
+  bool doFitView = false;
+
+  std::string mouseCoordText = "Mouse pointing to: -";
+  std::string cameraLookText = "Camera looking at: -";
+
+  mp2p_icp_viz::SimpleFileDialog openDialog;
+  mp2p_icp_viz::SimpleFileDialog exportDialog;
+};
+
+AppState app;
+
+bool load_plugins(const std::string& plugins)
+{
+  std::string errMsg;
+  if (!mrpt::system::loadPluginModules(plugins, errMsg))
+  {
+    std::cerr << errMsg << std::endl;
+    return false;
+  }
+  return true;
 }
 
 /** Reads a text file with one "lat,lon" (WGS84 degrees) vertex per line
@@ -160,44 +168,44 @@ static bool load_plugins(const std::string& plugins)
  */
 std::vector<mrpt::math::TPoint2D> readLatLonPolygonFile(const std::string& filePath)
 {
-    std::vector<mrpt::math::TPoint2D> latLonPoints;
+  std::vector<mrpt::math::TPoint2D> latLonPoints;
 
-    std::ifstream f(filePath);
-    ASSERTMSG_(
-        f.is_open(), mrpt::format("Cannot open georef polygon file: '%s'", filePath.c_str()));
+  std::ifstream f(filePath);
+  ASSERTMSG_(
+      f.is_open(), mrpt::format("Cannot open georef polygon file: '%s'", filePath.c_str()));
 
-    std::string line;
-    while (std::getline(f, line))
+  std::string line;
+  while (std::getline(f, line))
+  {
+    for (char& c : line)
     {
-        // normalize comma separators into whitespace:
-        for (char& c : line)
-        {
-            if (c == ',')
-            {
-                c = ' ';
-            }
-        }
-
-        std::istringstream iss(line);
-        std::string        firstTok;
-        if (!(iss >> firstTok) || firstTok.empty() || firstTok[0] == '#')
-        {
-            continue;  // blank or comment line
-        }
-
-        double lat = 0, lon = 0;
-        std::istringstream(firstTok) >> lat;
-        if (!(iss >> lon))
-        {
-            std::cerr << "Warning: malformed line in georef polygon file, skipping: \"" << line
-                      << "\"\n";
-            continue;
-        }
-
-        latLonPoints.emplace_back(lat, lon);
+      if (c == ',')
+      {
+        c = ' ';
+      }
     }
 
-    return latLonPoints;
+    std::istringstream iss(line);
+    std::string        firstTok;
+    if (!(iss >> firstTok) || firstTok.empty() || firstTok[0] == '#')
+    {
+      continue;  // blank or comment line
+    }
+
+    double lat = 0;
+    double lon = 0;
+    std::istringstream(firstTok) >> lat;
+    if (!(iss >> lon))
+    {
+      std::cerr << "Warning: malformed line in georef polygon file, skipping: \"" << line
+                 << "\"\n";
+      continue;
+    }
+
+    latLonPoints.emplace_back(lat, lon);
+  }
+
+  return latLonPoints;
 }
 
 /** Builds a closed polygon outline, in the metric map's local ("map") frame,
@@ -208,1856 +216,1229 @@ mrpt::opengl::CSetOfObjects::Ptr buildGeorefPolygonLayer(
     const std::vector<mrpt::math::TPoint2D>&      latLonPoints,
     const mp2p_icp::metric_map_t::Georeferencing& georef)
 {
-    auto glLayer = mrpt::opengl::CSetOfObjects::Create();
+  auto glLayer = mrpt::opengl::CSetOfObjects::Create();
 
-    std::vector<mrpt::math::TPoint3D> mapPoints;
-    mapPoints.reserve(latLonPoints.size());
-    for (const auto& ll : latLonPoints)
+  std::vector<mrpt::math::TPoint3D> mapPoints;
+  mapPoints.reserve(latLonPoints.size());
+  for (const auto& ll : latLonPoints)
+  {
+    const mrpt::topography::TGeodeticCoords geodeticPt(
+        ll.x /*lat*/, ll.y /*lon*/, georef.geo_coord.height);
+
+    mrpt::math::TPoint3D enuPt;
+    mrpt::topography::geodeticToENU_WGS84(geodeticPt, enuPt, georef.geo_coord);
+
+    mapPoints.push_back(georef.T_enu_to_map.mean.inverseComposePoint(enuPt));
+  }
+
+  if (mapPoints.size() >= 2)
+  {
+    auto glLines = mrpt::opengl::CSetOfLines::Create();
+    glLines->setColor_u8(0xff, 0xd0, 0x00, 0xff);
+    glLines->setLineWidth(3.0f);
+
+    for (size_t i = 0; i < mapPoints.size(); i++)
     {
-        const mrpt::topography::TGeodeticCoords geodeticPt(
-            ll.x /*lat*/, ll.y /*lon*/, georef.geo_coord.height);
-
-        mrpt::math::TPoint3D enuPt;
-        mrpt::topography::geodeticToENU_WGS84(geodeticPt, enuPt, georef.geo_coord);
-
-        mapPoints.push_back(georef.T_enu_to_map.mean.inverseComposePoint(enuPt));
+      const auto& p0 = mapPoints[i];
+      const auto& p1 = mapPoints[(i + 1) % mapPoints.size()];
+      glLines->appendLine(p0, p1);
     }
+    glLayer->insert(glLines);
+  }
 
-    if (mapPoints.size() >= 2)
-    {
-        auto glLines = mrpt::opengl::CSetOfLines::Create();
-        glLines->setColor_u8(0xff, 0xd0, 0x00, 0xff);
-        glLines->setLineWidth(3.0f);
+  return glLayer;
+}
 
-        for (size_t i = 0; i < mapPoints.size(); i++)
-        {
-            const auto& p0 = mapPoints[i];
-            const auto& p1 = mapPoints[(i + 1) % mapPoints.size()];
-            glLines->appendLine(p0, p1);
-        }
-        glLayer->insert(glLines);
-    }
+void rebuildCamTravellingLabels()
+{
+  app.camTravellingLabels.clear();
+  for (size_t i = 0; i < app.camTravelling.size(); i++)
+  {
+    auto it = app.camTravelling.begin();
+    std::advance(it, static_cast<std::ptrdiff_t>(i));
 
-    return glLayer;
+    app.camTravellingLabels.push_back(mrpt::format(
+        "[%02u] t=%.02fs pose=%s", static_cast<unsigned int>(i),
+        mrpt::Clock::toDouble(it->first), it->second.asString().c_str()));
+  }
 }
 
 bool loadMapFile(const std::string& mapFile)
 {
-    // Load one single file:
-    std::cout << "Loading map file: " << mapFile << std::endl;
+  std::cout << "Loading map file: " << mapFile << std::endl;
 
-    theMap = mp2p_icp::metric_map_t();  // reset
+  app.theMap = mp2p_icp::metric_map_t();  // reset
 
-    if (mrpt::system::extractFileExtension(mapFile) == "bin")
+  if (mrpt::system::extractFileExtension(mapFile) == "bin")
+  {
+    try
     {
-        // Load as externally-stored CGenericPointsMap via CCompressedInputStream
-        try
-        {
-            mrpt::io::CCompressedInputStream        f(mapFile);
-            auto                                    arch = mrpt::serialization::archiveFrom(f);
-            mrpt::serialization::CSerializable::Ptr obj  = arch.ReadObject();
-            auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(obj);
-            if (!pts)
-            {
-                std::cerr << "Error: .bin file did not deserialize to a CPointsMap-derived object"
-                          << (obj ? std::string(" (got: ") + obj->GetRuntimeClass()->className + ")"
-                                  : std::string(" (null object)"))
-                          << std::endl;
-                return false;
-            }
-            const std::string layerName = mrpt::system::extractFileName(mapFile);
-            theMap.layers[layerName]    = pts;
-        }
-        catch (const std::exception& e)
-        {
-            std::cerr << "Error loading .bin file: " << e.what() << std::endl;
-            return false;
-        }
+      mrpt::io::CCompressedInputStream        f(mapFile);
+      auto                                    arch = mrpt::serialization::archiveFrom(f);
+      mrpt::serialization::CSerializable::Ptr obj  = arch.ReadObject();
+      auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(obj);
+      if (!pts)
+      {
+        std::cerr << "Error: .bin file did not deserialize to a CPointsMap-derived object"
+                   << (obj ? std::string(" (got: ") + obj->GetRuntimeClass()->className + ")"
+                           : std::string(" (null object)"))
+                   << std::endl;
+        return false;
+      }
+      const std::string layerName  = mrpt::system::extractFileName(mapFile);
+      app.theMap.layers[layerName] = pts;
     }
-    else
+    catch (const std::exception& e)
     {
-        std::string loadErrorMsg;
+      std::cerr << "Error loading .bin file: " << e.what() << std::endl;
+      return false;
+    }
+  }
+  else
+  {
+    std::string loadErrorMsg;
 
-        if (!theMap.load_from_file(mapFile, loadErrorMsg))
+    if (!app.theMap.load_from_file(mapFile, loadErrorMsg))
+    {
+      bool retry_was_successful = false;
+
+      if (loadErrorMsg.find("which is not registered") != std::string::npos &&
+          arg_plugins.empty())
+      {
+        std::cout << "The map file requires plugins for missing C++ classes.\n"
+                     "Trying to load 'libmola_metric_maps.so' and retrying.\n"
+                     "Note that you can directly use '-l libmola_metric_maps.so' or any other "
+                     "custom plugin next time.\n";
+
+        if (!load_plugins("libmola_metric_maps.so"))
         {
-            bool retry_was_successful = false;
-
-            // If it fails and it's because of a missing plugin, try to load plugins to make life of
-            // users easier:
-            if (loadErrorMsg.find("which is not registered") != std::string::npos &&
-                arg_plugins.empty())
-            {
-                std::cout
-                    << "The map file requires plugins for missing C++ classes.\n"
-                       "Trying to load 'libmola_metric_maps.so' and retrying.\n"
-                       "Note that you can directly use '-l libmola_metric_maps.so' or any other "
-                       "custom plugin next time.\n";
-
-                if (!load_plugins("libmola_metric_maps.so"))
-                {
-                    return false;
-                }
-                // Retry:
-                retry_was_successful = theMap.load_from_file(mapFile, loadErrorMsg);
-            }
-
-            if (!retry_was_successful)
-            {
-                std::cerr << "Error loading metric map from file!:\n" << loadErrorMsg << std::endl;
-                return false;
-            }
+          return false;
         }
+        retry_was_successful = app.theMap.load_from_file(mapFile, loadErrorMsg);
+      }
+
+      if (!retry_was_successful)
+      {
+        std::cerr << "Error loading metric map from file!:\n" << loadErrorMsg << std::endl;
+        return false;
+      }
     }
+  }
 
-    theMapFileName = mapFile;
+  app.theMapFileName = mapFile;
 
-    // Obtain layer info:
-    std::cout << "Loaded map: " << theMap.contents_summary() << std::endl;
+  std::cout << "Loaded map: " << app.theMap.contents_summary() << std::endl;
 
-    layerNames.clear();
-    for (const auto& [name, map] : theMap.layers)
+  app.layerNames.clear();
+  for (const auto& [name, map] : app.theMap.layers)
+  {
+    app.layerNames.push_back(name);
+  }
+
+  // Find point cloud field names:
+  {
+    std::set<std::string> fields;
+    fields.insert("x");
+    fields.insert("y");
+    fields.insert("z");
+
+    for (const auto& [name, map] : app.theMap.layers)
     {
-        layerNames.push_back(name);
-    }
-
-    // Find point cloud field names:
-    {
-        std::set<std::string> fields;
-        fields.insert("x");
-        fields.insert("y");
-        fields.insert("z");
-
-        for (const auto& [name, map] : theMap.layers)
-        {
-            auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(map);
-            if (!pts)
-            {
-                continue;
-            }
-            for (const auto& f : pts->getPointFieldNames_float())
-            {
-                fields.insert(std::string(f));
-            }
-            for (const auto& f : pts->getPointFieldNames_uint16())
-            {
-                fields.insert(std::string(f));
-            }
+      auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(map);
+      if (!pts)
+      {
+        continue;
+      }
+      for (const auto& f : pts->getPointFieldNames_float())
+      {
+        fields.insert(std::string(f));
+      }
+      for (const auto& f : pts->getPointFieldNames_uint16())
+      {
+        fields.insert(std::string(f));
+      }
 #if MRPT_VERSION >= 0x020f03  // 2.15.3
-            for (const auto& f : pts->getPointFieldNames_double())
-            {
-                fields.insert(std::string(f));
-            }
-            for (const auto& f : pts->getPointFieldNames_uint8())
-            {
-                fields.insert(std::string(f));
-            }
+      for (const auto& f : pts->getPointFieldNames_double())
+      {
+        fields.insert(std::string(f));
+      }
+      for (const auto& f : pts->getPointFieldNames_uint8())
+      {
+        fields.insert(std::string(f));
+      }
 #endif
-        }
-
-        // Handle special color channels:
-        // See reference: mrpt::obs::PointCloudRecoloringParameters
-        // - `rgb` for `{color_r,color_g,color_b}` (uint8_t, in range 0-255)
-        // - `rgbf` for `{color_rf,color_gf,color_bf}` (float, in range 0-1)
-        if (fields.count("color_r") && fields.count("color_g") && fields.count("color_b"))
-        {
-            fields.erase("color_r");
-            fields.erase("color_g");
-            fields.erase("color_b");
-            fields.insert("rgb");
-        }
-        if (fields.count("color_rf") && fields.count("color_gf") && fields.count("color_bf"))
-        {
-            fields.erase("color_rf");
-            fields.erase("color_gf");
-            fields.erase("color_bf");
-            fields.insert("rgbf");
-        }
-
-        // Now convert the set into a vector:
-        knownPointFields.clear();
-        for (const auto& f : fields)
-        {
-            knownPointFields.push_back(f);
-        }
     }
 
-    // sanity checks:
-    for (const auto& [name, map] : theMap.layers)
+    if (fields.count("color_r") && fields.count("color_g") && fields.count("color_b"))
     {
-        const auto* pc = mp2p_icp::MapToPointsMap(*map);
-        if (!pc)
-        {
-            continue;  // not a point map
-        }
-        const bool sanityPassed = mp2p_icp::pointcloud_sanity_check(*pc);
-        ASSERTMSG_(
-            sanityPassed, mrpt::format("sanity check did not pass for layer: '%s'", name.c_str()));
+      fields.erase("color_r");
+      fields.erase("color_g");
+      fields.erase("color_b");
+      fields.insert("rgb");
+    }
+    if (fields.count("color_rf") && fields.count("color_gf") && fields.count("color_bf"))
+    {
+      fields.erase("color_rf");
+      fields.erase("color_gf");
+      fields.erase("color_bf");
+      fields.insert("rgbf");
     }
 
-    return true;
+    app.knownPointFields.clear();
+    for (const auto& f : fields)
+    {
+      app.knownPointFields.push_back(f);
+    }
+  }
+
+  // sanity checks:
+  for (const auto& [name, map] : app.theMap.layers)
+  {
+    const auto* pc = mp2p_icp::MapToPointsMap(*map);
+    if (!pc)
+    {
+      continue;  // not a point map
+    }
+    const bool sanityPassed = mp2p_icp::pointcloud_sanity_check(*pc);
+    ASSERTMSG_(
+        sanityPassed, mrpt::format("sanity check did not pass for layer: '%s'", name.c_str()));
+  }
+
+  return true;
 }
 
-/** Transform to show in the selected frame of reference and units: "enu", "map", or "lat/lon" */
+/** Transform to show in the selected frame of reference and units: "map", "enu", or "lat/lon" */
 std::string transformAndFormatSelectedPoint(const mrpt::math::TPoint3D& pt)
 {
-    using namespace std::string_literals;
-    const bool ptIsENU = cbApplyGeoRef->checked() && theMap.georeferencing.has_value();
+  const bool hasGeoref = app.theMap.georeferencing.has_value();
+  const bool ptIsENU   = hasGeoref && app.applyGeoRef;
+  const int  idx       = hasGeoref ? app.mouseUnitsIdx : 0;
 
-    ASSERT_(cbMouseUnits);
-
-    if (theMap.georeferencing.has_value())
+  switch (idx)
+  {
+    case 0:  // show in map
     {
-        if (cbMouseUnits->items().size() != 3)
-        {
-            cbMouseUnits->setItems(std::vector<std::string>({"map", "enu", "lat/lon "}));
-            cbMouseUnits->setEnabled(true);
-        }
+      mrpt::math::TPoint3D ptViz;
+      if (ptIsENU)
+      {
+        ptViz = app.theMap.georeferencing->T_enu_to_map.mean.inverseComposePoint(pt);
+      }
+      else
+      {
+        ptViz = pt;
+      }
+      return mrpt::format("X=%6.03f Y=%6.03f Z=%6.03f", ptViz.x, ptViz.y, ptViz.z);
     }
-    else
+    case 1:  // show in enu
+      return mrpt::format("X=%6.03f Y=%6.03f Z=%6.03f", pt.x, pt.y, pt.z);
+    case 2:  // show as lat/lon
     {
-        if (cbMouseUnits->items().size() != 1)
-        {
-            cbMouseUnits->setItems(std::vector<std::string>({"map"}));
-            cbMouseUnits->setSelectedIndex(0);
-            cbMouseUnits->setEnabled(false);
-        }
+      try
+      {
+        mrpt::topography::TGeocentricCoords geocentricPt;
+        mrpt::topography::ENUToGeocentric(
+            pt, app.theMap.georeferencing->geo_coord, geocentricPt,
+            mrpt::topography::TEllipsoid::Ellipsoid_WGS84());
+
+        mrpt::topography::TGeodeticCoords outCoords;
+        mrpt::topography::geocentricToGeodetic(geocentricPt, outCoords);
+
+        return mrpt::format(
+            "%.06f, %.06f, h=%.03f", outCoords.lat.getDecimalValue(),
+            outCoords.lon.getDecimalValue(), outCoords.height);
+      }
+      catch (const std::exception& e)
+      {
+        std::cerr << "[transformAndFormatSelectedPoint] " << e.what() << "\n";
+        return {};
+      }
     }
-
-    switch (cbMouseUnits->selectedIndex())
-    {
-        case 0:  // show in map
-        {
-            mrpt::math::TPoint3D ptViz;
-            if (ptIsENU)
-            {
-                ptViz = theMap.georeferencing->T_enu_to_map.mean.inverseComposePoint(pt);
-            }
-            else  // pt is already map
-            {
-                ptViz = pt;
-            }
-            return mrpt::format("X=%6.03f Y=%6.03f Z=%6.03f", ptViz.x, ptViz.y, ptViz.z);
-        }
-        break;
-
-        case 1:  // show in enu
-        {
-            // ptIsENU must be true here.
-            return mrpt::format("X=%6.03f Y=%6.03f Z=%6.03f", pt.x, pt.y, pt.z);
-        }
-        break;
-
-        case 2:  // show as lat/lon
-        {
-            // pt is ENU.
-            try
-            {
-                mrpt::topography::TGeocentricCoords geocentricPt;
-                mrpt::topography::ENUToGeocentric(
-                    pt, theMap.georeferencing->geo_coord, geocentricPt,
-                    mrpt::topography::TEllipsoid::Ellipsoid_WGS84());
-
-                mrpt::topography::TGeodeticCoords outCoords;
-                mrpt::topography::geocentricToGeodetic(geocentricPt, outCoords);
-
-                return mrpt::format(
-                    "%.06f, %.06f, h=%.03f", outCoords.lat.getDecimalValue(),
-                    outCoords.lon.getDecimalValue(), outCoords.height);
-            }
-            catch (const std::exception& e)
-            {
-                std::cerr << "[transformAndFormatSelectedPoint] " << e.what() << "\n";
-                return {};
-            }
-        }
-        break;
-        default:
-            THROW_EXCEPTION(
-                "Unexpected selection in combo-box for mouse coordinate transformation");
-            break;
-    };
-}
-
-void updateMouseCoordinates()
-{
-    const auto mouse_xy = win->mousePos();
-
-    mrpt::math::TLine3D mouse_ray;
-    win->background_scene->getViewport("main")->get3DRayForPixelCoord(
-        mouse_xy.x(), mouse_xy.y(), mouse_ray);
-
-    // Create a 3D plane, e.g. Z=0
-    using mrpt::math::TPoint3D;
-
-    const mrpt::math::TPlane ground_plane(TPoint3D(0, 0, 0), TPoint3D(1, 0, 0), TPoint3D(0, 1, 0));
-    // Intersection of the line with the plane:
-    mrpt::math::TObject3D inters;
-    mrpt::math::intersect(mouse_ray, ground_plane, inters);
-    // Interpret the intersection as a point, if there is an intersection:
-    mrpt::math::TPoint3D inters_pt;
-    if (inters.getPoint(inters_pt))
-    {
-        lbMousePos->setCaption(
-            mrpt::format("Mouse at: %s", transformAndFormatSelectedPoint(inters_pt).c_str()));
-    }
+    default:
+      return {};
+  }
 }
 
 void updateCameraLookCoordinates()
 {
-    const auto pt = mrpt::math::TPoint3D(
-        win->camera().getCameraPointingX(), win->camera().getCameraPointingY(),
-        win->camera().getCameraPointingZ());
-
-    lbCameraPointing->setCaption(
-        mrpt::format("Looking at: %s", transformAndFormatSelectedPoint(pt).c_str()));
+  const auto& cam = app.sceneView.camera();
+  const mrpt::math::TPoint3D pt(cam.getPointingAtX(), cam.getPointingAtY(), cam.getPointingAtZ());
+  app.cameraLookText = "Camera looking at: " + transformAndFormatSelectedPoint(pt);
 }
 
-void observeViewOptions()
+/** Wired as `sceneView.onOverlayGui`: runs right after the 3-D canvas is drawn, while it is
+ * still the last ImGui item, so `ImGui::IsItemHovered()`/`GetItemRect*()` refer to it. */
+void renderSceneOverlay()
 {
-    if (cbView2D->checked())
-    {
-        win->camera().setAzimuthDegrees(-90.0f);
-        win->camera().setElevationDegrees(90.0f);
-    }
-}
+  updateCameraLookCoordinates();
 
-void updateMiniCornerView()
-{
-    auto gl_view1 = win->background_scene->getViewport(FIRST_MINI_VIEW_NAME);
-    if (!gl_view1)
-    {
-        return;
-    }
+  const bool   hovered  = ImGui::IsItemHovered();
+  const ImVec2 rectMin  = ImGui::GetItemRectMin();
+  const ImVec2 rectSize = ImGui::GetItemRectSize();
 
-    mrpt::opengl::TFontParams fp;
-    fp.draw_shadow = true;
-    fp.vfont_scale = 9.0f;
+  if (!hovered)
+  {
+    app.mouseCoordText = "Mouse pointing to: -";
+    return;
+  }
 
-    {
-        mrpt::opengl::CCamera& view_cam = gl_view1->getCamera();
+  const ImVec2 mouse  = ImGui::GetMousePos();
+  const double localX = static_cast<double>(mouse.x - rectMin.x);
+  const double localY = static_cast<double>(mouse.y - rectMin.y);
+  if (localX < 0 || localY < 0 || localX >= rectSize.x || localY >= rectSize.y)
+  {
+    app.mouseCoordText = "Mouse pointing to: -";
+    return;
+  }
 
-        view_cam.setAzimuthDegrees(win->camera().getAzimuthDegrees());
-        view_cam.setElevationDegrees(win->camera().getElevationDegrees());
-        view_cam.setZoomDistance(5);
-    }
+  mrpt::math::TLine3D mouseRay;
+  app.scene->getViewport("main")->get3DRayForPixelCoord(localX, localY, mouseRay);
 
-    const bool show_two_corners = cbApplyGeoRef->checked() && theMap.georeferencing.has_value();
-
-    gl_view1->addTextMessage(
-        static_cast<double>(win->width()) * 0.05 - 35, 5,
-        show_two_corners ? "ENU frame" : "Map frame", 0, fp);
-
-    auto gl_view2 = win->background_scene->getViewport(SECOND_MINI_VIEW_NAME);
-    if (!gl_view2 || gl_view2->empty())
-    {
-        return;
-    }
-
-    auto glRoot = *gl_view2->begin();
-    if (!glRoot)
-    {
-        return;
-    }
-    glRoot->setVisibility(show_two_corners);
-
-    if (!show_two_corners)
-    {
-        gl_view2->clearTextMessages();
-        return;
-    }
-
-    glRoot->setPose(mrpt::poses::CPose3D::FromRotationAndTranslation(
-        theMap.georeferencing.value().T_enu_to_map.mean.getRotationMatrix(),
-        mrpt::math::TVector3D(0, 0, 0)));
-
-    {
-        mrpt::opengl::CCamera& view_cam = gl_view2->getCamera();
-
-        view_cam.setAzimuthDegrees(win->camera().getAzimuthDegrees());
-        view_cam.setElevationDegrees(win->camera().getElevationDegrees());
-        view_cam.setZoomDistance(5);
-    }
-
-    gl_view2->addTextMessage(static_cast<double>(win->width()) * 0.05 - 35, 5, "Map frame", 0, fp);
+  using mrpt::math::TPoint3D;
+  const mrpt::math::TPlane groundPlane(TPoint3D(0, 0, 0), TPoint3D(1, 0, 0), TPoint3D(0, 1, 0));
+  mrpt::math::TObject3D    inters;
+  mrpt::math::intersect(mouseRay, groundPlane, inters);
+  mrpt::math::TPoint3D intersPt;
+  if (inters.getPoint(intersPt))
+  {
+    app.mouseCoordText = "Mouse pointing to: " + transformAndFormatSelectedPoint(intersPt);
+  }
 }
 
 void updateGuiAfterLoadingNewMap()
 {
-    // Build layer checkboxes:
-    ASSERT_(panelLayers);
-    while (panelLayers->childCount())
-    {  //
-        panelLayers->removeChild(0);
-    }
+  app.layerVisible.clear();
+  for (const auto& name : app.layerNames)
+  {
+    app.layerVisible[name] = true;
+  }
 
-    for (size_t i = 0; i < layerNames.size(); i++)
+  for (auto& evl : app.extraVizLayers)
+  {
+    evl.visible = true;
+  }
+
+  app.recolorizeByFieldIdx = 0;
+
+  // Auto-range clip sliders from map Z bounds (linear mode only):
+  if (!app.depthLogScale)
+  {
+    float zMin = std::numeric_limits<float>::max();
+    float zMax = -std::numeric_limits<float>::max();
+    for (const auto& [name, map] : app.theMap.layers)
     {
-        auto cb = panelLayers->add<nanogui::CheckBox>(layerNames.at(i));
-        cb->setChecked(true);
-        cb->setCallback([](bool) { rebuild_3d_view(); });
-        cb->setFontSize(SMALL_FONT_SIZE);
-
-        cbLayersByName[layerNames.at(i)] = cb;
+      const auto* pc = mp2p_icp::MapToPointsMap(*map);
+      if (!pc || pc->empty())
+      {
+        continue;
+      }
+      const auto bb = pc->boundingBox();
+      zMin          = std::min(zMin, bb.min.z);
+      zMax          = std::max(zMax, bb.max.z);
     }
-
-    for (auto& evl : extraVizLayers)
+    if (zMin < zMax)
     {
-        evl.checkBox = panelLayers->add<nanogui::CheckBox>(
-            "(viz) " + evl.fileName,
-            [&evl](bool checked)
-            {
-                evl.glObjects->setVisibility(checked);
-                rebuild_3d_view(false);
-            });
-        evl.checkBox->setFontSize(SMALL_FONT_SIZE);
-        evl.checkBox->setChecked(true);
+      app.clipNear = zMin;
+      app.clipFar  = zMax;
     }
-
-    // and point cloud fields:
-    ASSERT_(cmbRecolorizeByField);
-    cmbRecolorizeByField->setItems(knownPointFields);
-
-    // Auto-range clip sliders from map Z bounds (linear mode only):
-    if (!cbDepthLogScale->checked())
-    {
-        float zMin = std::numeric_limits<float>::max();
-        float zMax = -std::numeric_limits<float>::max();
-        for (const auto& [name, map] : theMap.layers)
-        {
-            const auto* pc = mp2p_icp::MapToPointsMap(*map);
-            if (!pc || pc->empty())
-            {
-                continue;
-            }
-            const auto bb = pc->boundingBox();
-            zMin          = std::min(zMin, bb.min.z);
-            zMax          = std::max(zMax, bb.max.z);
-        }
-        if (zMin < zMax)
-        {
-            const float margin = std::max(1.0f, 0.1f * (zMax - zMin));
-            const float rMin   = zMin - margin;
-            const float rMax   = zMax + margin;
-            slClipNear->setRange({rMin, rMax});
-            slClipFar->setRange({rMin, rMax});
-            slClipNear->setValue(zMin);
-            slClipFar->setValue(zMax);
-            edClipNear->setValue(mrpt::format("%.2f", zMin));
-            edClipFar->setValue(mrpt::format("%.2f", zMax));
-        }
-    }  // end linear auto-range
+  }
 }
 
-void rebuildCamTravellingCombo()
-{
-    std::vector<std::string> lst, lstShort;
-    for (size_t i = 0; i < camTravelling.size(); i++)
-    {
-        auto it = camTravelling.begin();
-        std::advance(it, i);
+void camTravellingStop() { app.camTravellingCurrentTime.reset(); }
 
-        lstShort.push_back(std::to_string(i));
-        lst.push_back(mrpt::format(
-            "[%02u] t=%.02fs pose=%s", static_cast<unsigned int>(i),
-            mrpt::Clock::toDouble(it->first), it->second.asString().c_str()));
-    }
-    cbTravellingKeys->setItems(lst, lstShort);
-
-    if (!lst.empty())
-    {
-        cbTravellingKeys->setSelectedIndex(static_cast<int>(lst.size()) - 1);
-    }
-    win->performLayout();
-}
-
-void onKeyboardAction(int key, int modifiers)
-{
-    using mrpt::DEG2RAD;
-
-    constexpr float SLIDE_VELOCITY     = 0.01;
-    constexpr float SENSIBILITY_ROTATE = 1.0;
-
-    auto cam = win->camera().cameraParams();
-
-    auto doStrideSides = [&](bool toTheRight)
-    {
-        const float dx = std::cos(DEG2RAD(cam.cameraAzimuthDeg + 90.f));
-        const float dy = std::sin(DEG2RAD(cam.cameraAzimuthDeg + 90.f));
-        const float d  = toTheRight ? 1.0f : -1.0f;
-        cam.cameraPointingX += d * dx * cam.cameraZoomDistance * SLIDE_VELOCITY;
-        cam.cameraPointingY += d * dy * cam.cameraZoomDistance * SLIDE_VELOCITY;
-        win->camera().setCameraParams(cam);
-    };
-
-    auto doRotateEyeYaw = [&](bool toTheRight)
-    {
-        int cmd_rot  = toTheRight ? 1 : -1;
-        int cmd_elev = 0;
-
-        const float dis   = std::max(0.01f, (cam.cameraZoomDistance));
-        const auto  eye_x = cam.cameraPointingX + dis * cos(DEG2RAD(cam.cameraAzimuthDeg)) *
-                                                     cos(DEG2RAD(cam.cameraElevationDeg));
-        const auto eye_y = cam.cameraPointingY + dis * sin(DEG2RAD(cam.cameraAzimuthDeg)) *
-                                                     cos(DEG2RAD(cam.cameraElevationDeg));
-        const auto eye_z = cam.cameraPointingZ + dis * sin(DEG2RAD(cam.cameraElevationDeg));
-
-        // Orbit camera:
-        float A_AzimuthDeg = -SENSIBILITY_ROTATE * static_cast<float>(cmd_rot);
-        cam.cameraAzimuthDeg += A_AzimuthDeg;
-
-        float A_ElevationDeg = SENSIBILITY_ROTATE * static_cast<float>(cmd_elev);
-        cam.setElevationDeg(cam.cameraElevationDeg + A_ElevationDeg);
-
-        // Move cameraPointing pos:
-        cam.cameraPointingX = static_cast<float>(
-            eye_x -
-            dis * cos(DEG2RAD(cam.cameraAzimuthDeg)) * cos(DEG2RAD(cam.cameraElevationDeg)));
-        cam.cameraPointingY = static_cast<float>(
-            eye_y -
-            dis * sin(DEG2RAD(cam.cameraAzimuthDeg)) * cos(DEG2RAD(cam.cameraElevationDeg)));
-        cam.cameraPointingZ =
-            static_cast<float>(eye_z - dis * sin(DEG2RAD(cam.cameraElevationDeg)));
-
-        win->camera().setCameraParams(cam);
-    };
-
-    auto doRotateEyeUpDown = [&](bool toUp)
-    {
-        const float dx = std::cos(DEG2RAD(cam.cameraAzimuthDeg));
-        const float dy = std::sin(DEG2RAD(cam.cameraAzimuthDeg));
-        const float d  = toUp ? -1.0f : 1.0f;
-        cam.cameraPointingX += d * dx * cam.cameraZoomDistance * SLIDE_VELOCITY;
-        cam.cameraPointingY += d * dy * cam.cameraZoomDistance * SLIDE_VELOCITY;
-        win->camera().setCameraParams(cam);
-    };
-
-    auto doMoveVertically = [&](bool toUp)
-    {
-        const float d = toUp ? 1.0f : -1.0f;
-        cam.cameraPointingZ += d * cam.cameraZoomDistance * SLIDE_VELOCITY;
-        win->camera().setCameraParams(cam);
-    };
-
-    switch (key)
-    {
-        case GLFW_KEY_UP:
-        case GLFW_KEY_DOWN:
-        case GLFW_KEY_S:
-        case GLFW_KEY_W:
-        {
-            if (modifiers & GLFW_MOD_SHIFT)
-            {
-                // Move vertically:
-                doMoveVertically(key == GLFW_KEY_UP || key == GLFW_KEY_W);
-            }
-            else
-            {
-                // Rotate:
-                doRotateEyeUpDown(key == GLFW_KEY_UP || key == GLFW_KEY_W);
-            }
-        }
-        break;
-
-        case GLFW_KEY_A:
-        case GLFW_KEY_D:
-        {
-            doStrideSides(key == GLFW_KEY_D);
-        }
-        break;
-
-        case GLFW_KEY_RIGHT:
-        case GLFW_KEY_LEFT:
-        {
-            if (modifiers & GLFW_MOD_SHIFT)
-            {
-                // Strafe:
-                doStrideSides(key == GLFW_KEY_RIGHT);
-            }
-            else
-            {
-                // Rotate:
-                doRotateEyeYaw(key == GLFW_KEY_RIGHT);
-            }
-        }
-        break;
-
-        // CTRL+C copies the coordinates
-        case GLFW_KEY_C:
-        {
-            if (btnCopyCoords && (modifiers & GLFW_MOD_CONTROL))
-            {
-                // this seems to need to be done from the nanogui thread.
-                btnCopyCoords->callback()();
-            }
-        }
-        break;
-
-        default:  // Do nothing
-            break;
-    };
-}
-
-void camTravellingStop()
-{
-    camTravellingCurrentTime.reset();
-    btnAnimate->setEnabled(true);
-    btnAnimStop->setEnabled(false);
-}
-
-// Clip plane calculation is delegated to be done in the idle loop so it's refreshed as the
-// user zooms/pans, etc. since the camera data is needed for the "linear" mode.
+/** Recomputed every frame so it stays in sync as the user zooms/pans (the "linear" mode needs
+ * the current camera pose). */
 void updateCameraClipDistances()
 {
-    std::lock_guard<std::mutex> lck(win->background_scene_mtx);
-    // clip planes:
-    float clipNear, clipFar;
-    if (cbDepthLogScale->checked())
+  auto& cam = app.sceneView.camera();
+
+  float clipNear = 0;
+  float clipFar  = 0;
+  if (app.depthLogScale)
+  {
+    const auto depthFieldMid       = std::pow(10.0, app.clipNear);
+    const auto depthFieldThickness = std::pow(10.0, app.clipFar);
+    clipNear = static_cast<float>(std::max(1e-2, depthFieldMid - 0.5 * depthFieldThickness));
+    clipFar  = static_cast<float>(depthFieldMid + 0.5 * depthFieldThickness);
+  }
+  else
+  {
+    // Linear mode: slider values are world Z coordinates.
+    // Convert to frustum distances using the camera elevation and zoom.
+    const float elDeg   = cam.getElevationDegrees();
+    const float sinEl   = std::sin(mrpt::DEG2RAD(elDeg));
+    const float cameraZ = cam.getPointingAtZ() + cam.getZoomDistance() * sinEl;
+
+    const float orthoFactor = cam.isProjective() ? 1.0f : 2.0f;
+    const float zFloor      = orthoFactor * app.clipNear;
+    const float zCeiling    = orthoFactor * app.clipFar;
+
+    if (std::abs(sinEl) > 0.05f)
     {
-        const auto depthFieldMid       = std::pow(10.0, slClipNear->value());
-        const auto depthFieldThickness = std::pow(10.0, slClipFar->value());
-        clipNear = static_cast<float>(std::max(1e-2, depthFieldMid - 0.5 * depthFieldThickness));
-        clipFar  = static_cast<float>(depthFieldMid + 0.5 * depthFieldThickness);
+      clipFar  = std::max(0.01f, (cameraZ - zFloor) / sinEl);
+      clipNear = std::max(0.01f, std::min(clipFar - 0.01f, (cameraZ - zCeiling) / sinEl));
     }
     else
     {
-        // Linear mode: slider values are world Z coordinates.
-        // Convert to frustum distances using the camera elevation and zoom.
-
-        const float elDeg   = win->camera().getElevationDegrees();
-        const float sinEl   = std::sin(mrpt::DEG2RAD(elDeg));
-        const float cameraZ = static_cast<float>(win->camera().getCameraPointingZ()) +
-                              win->camera().getZoomDistance() * sinEl;
-
-        const float orthoFactor = win->camera().isCameraProjective() ? 1.0f : 2.0f;
-        const float zFloor      = orthoFactor * slClipNear->value();  // near in world Z = floor
-        const float zCeiling    = orthoFactor * slClipFar->value();  // far in world Z = ceiling
-
-        if (std::abs(sinEl) > 0.05f)
-        {
-            clipFar  = std::max(0.01f, (cameraZ - zFloor) / sinEl);
-            clipNear = std::max(0.01f, std::min(clipFar - 0.01f, (cameraZ - zCeiling) / sinEl));
-        }
-        else
-        {
-            // Near-horizontal view: fall back to direct distance values
-            clipNear = std::max(0.01f, std::abs(zFloor));
-            clipFar  = std::max(clipNear + 0.01f, std::abs(zCeiling));
-        }
+      clipNear = std::max(0.01f, std::abs(zFloor));
+      clipFar  = std::max(clipNear + 0.01f, std::abs(zCeiling));
     }
+  }
 
-    const float cameraFOV = slCameraFOV->value();
-    win->camera().setCameraFOV(cameraFOV);
-    win->camera().setMaximumZoom(std::max<float>(1000.0f, 3.0f * clipFar));
+  cam.setProjectiveFOVdeg(app.cameraFOV);
 
-    lbDepthFieldValues->setCaption(
-        mrpt::format("Frustum: near=%.02g far=%.02g", clipNear, clipFar));
-
-    lbCameraFOV->setCaption(mrpt::format("Camera FOV: %.02f deg", cameraFOV));
-
-    win->background_scene->getViewport()->setViewportClipDistances(clipNear, clipFar);
+  app.scene->getViewport("main")->setViewportClipDistances(clipNear, clipFar);
 }
 
 void processCameraTravelling()
 {
-    if (!camTravellingCurrentTime.has_value())
-    {
-        return;
-    }
-    double& t = camTravellingCurrentTime.value();
+  if (!app.camTravellingCurrentTime.has_value())
+  {
+    return;
+  }
+  double& t = app.camTravellingCurrentTime.value();
 
-    // Time range:
-    const double t0 = mrpt::Clock::toDouble(camTravelling.begin()->first);
-    const double t1 = mrpt::Clock::toDouble(camTravelling.rbegin()->first);
-    slAnimProgress->setRange(std::make_pair<float>(static_cast<float>(t0), static_cast<float>(t1)));
-    slAnimProgress->setValue(static_cast<float>(t));
+  const double t0 = mrpt::Clock::toDouble(app.camTravelling.begin()->first);
+  const double t1 = mrpt::Clock::toDouble(app.camTravelling.rbegin()->first);
+  app.animProgress = (t1 > t0) ? static_cast<float>((t - t0) / (t1 - t0)) : 0.0f;
 
-    if (t >= t1)
-    {
-        camTravellingStop();
-        return;
-    }
+  if (t >= t1)
+  {
+    camTravellingStop();
+    return;
+  }
 
-    // Interpolate camera params:
-    const auto interpMethod = cbTravellingInterp->selectedIndex() == 0
-                                  ? mrpt::poses::TInterpolatorMethod::imLinear2Neig
-                                  : mrpt::poses::TInterpolatorMethod::imSSLSLL;
-    camTravelling.setInterpolationMethod(interpMethod);
+  const auto interpMethod = app.travellingInterpIdx == 0 ? mrpt::poses::TInterpolatorMethod::imLinear2Neig
+                                                          : mrpt::poses::TInterpolatorMethod::imSSLSLL;
+  app.camTravelling.setInterpolationMethod(interpMethod);
 
-    mrpt::math::TPose3D p;
-    bool                valid = false;
-    camTravelling.interpolate(mrpt::Clock::fromDouble(t), p, valid);
-    if (valid)
-    {
-        const auto pt = p.translation().cast<float>();
-        win->camera().setCameraPointing(pt.x, pt.y, pt.z);
-        win->camera().setAzimuthDegrees(static_cast<float>(mrpt::RAD2DEG(p.yaw)));
-        win->camera().setElevationDegrees(static_cast<float>(mrpt::RAD2DEG(p.pitch)));
-        win->camera().setZoomDistance(static_cast<float>(p.roll / TRAVELING_ZOOM2ROLL));
-    }
+  mrpt::math::TPose3D p;
+  bool                valid = false;
+  app.camTravelling.interpolate(mrpt::Clock::fromDouble(t), p, valid);
+  if (valid)
+  {
+    auto& cam = app.sceneView.camera();
+    cam.setPointingAt(static_cast<float>(p.x), static_cast<float>(p.y), static_cast<float>(p.z));
+    cam.setAzimuthDegrees(static_cast<float>(mrpt::RAD2DEG(p.yaw)));
+    cam.setElevationDegrees(static_cast<float>(mrpt::RAD2DEG(p.pitch)));
+    cam.setZoomDistance(static_cast<float>(p.roll / TRAVELING_ZOOM2ROLL));
+  }
 
-    // Move to next time step:
-    const double FPS = std::stod(edAnimFPS->value());
-    ASSERT_(FPS > 0);
-    const double dt = 1.0 / FPS;
-    t += dt;
+  const double dt = app.animFPS > 0 ? 1.0 / app.animFPS : 1.0 / 30.0;
+  t += dt;
 }
 
-void main_show_gui()
+void handleKeyboard()
 {
-    using namespace std::string_literals;
+  ImGuiIO& io = ImGui::GetIO();
+  if (io.WantTextInput)
+  {
+    return;
+  }
 
-    if (!argMapFile.empty())
+  constexpr float SLIDE_VELOCITY     = 0.01f;
+  constexpr float SENSIBILITY_ROTATE = 1.0f;
+  auto&           cam                = app.sceneView.camera();
+
+  auto doStrideSides = [&](bool toTheRight)
+  {
+    const float az   = cam.getAzimuthDegrees();
+    const float dx   = std::cos(mrpt::DEG2RAD(az + 90.f));
+    const float dy   = std::sin(mrpt::DEG2RAD(az + 90.f));
+    const float d    = toTheRight ? 1.0f : -1.0f;
+    const float dist = cam.getZoomDistance();
+    cam.setPointingAt(
+        cam.getPointingAtX() + d * dx * dist * SLIDE_VELOCITY,
+        cam.getPointingAtY() + d * dy * dist * SLIDE_VELOCITY, cam.getPointingAtZ());
+  };
+
+  auto doRotateEyeYaw = [&](bool toTheRight)
+  {
+    const float dis = std::max(0.01f, cam.getZoomDistance());
+    const float az0 = cam.getAzimuthDegrees();
+    const float el0 = cam.getElevationDegrees();
+
+    const float eyeX = cam.getPointingAtX() +
+                        dis * std::cos(mrpt::DEG2RAD(az0)) * std::cos(mrpt::DEG2RAD(el0));
+    const float eyeY = cam.getPointingAtY() +
+                        dis * std::sin(mrpt::DEG2RAD(az0)) * std::cos(mrpt::DEG2RAD(el0));
+    const float eyeZ = cam.getPointingAtZ() + dis * std::sin(mrpt::DEG2RAD(el0));
+
+    const float newAz = az0 + (toTheRight ? -SENSIBILITY_ROTATE : SENSIBILITY_ROTATE);
+    cam.setAzimuthDegrees(newAz);
+
+    cam.setPointingAt(
+        eyeX - dis * std::cos(mrpt::DEG2RAD(newAz)) * std::cos(mrpt::DEG2RAD(el0)),
+        eyeY - dis * std::sin(mrpt::DEG2RAD(newAz)) * std::cos(mrpt::DEG2RAD(el0)),
+        eyeZ - dis * std::sin(mrpt::DEG2RAD(el0)));
+  };
+
+  auto doRotateEyeUpDown = [&](bool toUp)
+  {
+    const float az   = cam.getAzimuthDegrees();
+    const float dx   = std::cos(mrpt::DEG2RAD(az));
+    const float dy   = std::sin(mrpt::DEG2RAD(az));
+    const float d    = toUp ? -1.0f : 1.0f;
+    const float dist = cam.getZoomDistance();
+    cam.setPointingAt(
+        cam.getPointingAtX() + d * dx * dist * SLIDE_VELOCITY,
+        cam.getPointingAtY() + d * dy * dist * SLIDE_VELOCITY, cam.getPointingAtZ());
+  };
+
+  auto doMoveVertically = [&](bool toUp)
+  {
+    const float d    = toUp ? 1.0f : -1.0f;
+    const float dist = cam.getZoomDistance();
+    cam.setPointingAt(
+        cam.getPointingAtX(), cam.getPointingAtY(), cam.getPointingAtZ() + d * dist * SLIDE_VELOCITY);
+  };
+
+  const bool up   = ImGui::IsKeyPressed(ImGuiKey_UpArrow, true) || ImGui::IsKeyPressed(ImGuiKey_W, true);
+  const bool down = ImGui::IsKeyPressed(ImGuiKey_DownArrow, true) || ImGui::IsKeyPressed(ImGuiKey_S, true);
+  if (up || down)
+  {
+    if (io.KeyShift)
     {
-        if (!loadMapFile(argMapFile))
-        {
-            return;
-        }
+      doMoveVertically(up);
+    }
+    else
+    {
+      doRotateEyeUpDown(up);
+    }
+  }
+
+  if (ImGui::IsKeyPressed(ImGuiKey_A, true))
+  {
+    doStrideSides(false);
+  }
+  if (ImGui::IsKeyPressed(ImGuiKey_D, true))
+  {
+    doStrideSides(true);
+  }
+
+  const bool right = ImGui::IsKeyPressed(ImGuiKey_RightArrow, true);
+  const bool left   = ImGui::IsKeyPressed(ImGuiKey_LeftArrow, true);
+  if (right || left)
+  {
+    if (io.KeyShift)
+    {
+      doStrideSides(right);
+    }
+    else
+    {
+      doRotateEyeYaw(right);
+    }
+  }
+
+  // CTRL+C copies the coordinates
+  if (io.KeyCtrl && ImGui::IsKeyPressed(ImGuiKey_C, false))
+  {
+    const std::string text = app.mouseCoordText + "\n" + app.cameraLookText;
+    glfwSetClipboardString(app.shell.windowHandle(), text.c_str());
+  }
+}
+
+void onSaveLayers(const std::string& outFile)
+{
+  for (const auto& lyName : app.layerNames)
+  {
+    if (auto itL = app.theMap.layers.find(lyName); itL != app.theMap.layers.end())
+    {
+      itL->second->saveMetricMapRepresentationToFile(outFile);
+    }
+  }
+}
+
+void rebuild_3d_view()
+{
+  std::optional<mrpt::math::TBoundingBoxf> mapBbox;
+
+  mp2p_icp::render_params_t rpMap;
+  rpMap.points.visible = false;
+
+  for (const auto& lyName : app.layerNames)
+  {
+    if (auto itL = app.theMap.layers.find(lyName); itL != app.theMap.layers.end())
+    {
+      if (auto pc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itL->second); pc)
+      {
+        const auto bb = pc->boundingBox();
+        mapBbox        = mapBbox.has_value() ? mapBbox->unionWith(bb) : bb;
+      }
     }
 
-    // Optional georeferenced polygon overlay (needs the map's georeferencing info, so
-    // it must be handled once the map above has been loaded):
-    if (!arg_georefPolygon.empty())
+    if (!app.layerVisible[lyName])
     {
-        if (!theMap.georeferencing.has_value())
+      continue;  // hidden
+    }
+    rpMap.points.visible = true;
+
+    auto& rpL                       = rpMap.points.perLayer[lyName];
+    rpL.pointSize                   = app.pointSize;
+    rpL.render_voxelmaps_as_points  = app.viewVoxelsAsPoints;
+    rpL.render_voxelmaps_free_space = app.viewVoxelsFreeSpace;
+
+    if (app.colorizeMap)
+    {
+      auto& cm    = rpL.colorMode.emplace();
+      cm.colorMap = mrpt::typemeta::str2enum<mrpt::img::TColormap>(
+          kColorIntensityNames[app.colorIntensityIdx]);
+
+      if (!app.knownPointFields.empty())
+      {
+        cm.recolorizeByField =
+            app.knownPointFields.at(static_cast<size_t>(app.recolorizeByFieldIdx));
+      }
+
+      if (app.autoBBoxOutliers)
+      {
+        cm.autoBoundingBoxOutliersPercentile = app.autoBBoxOutliersPercentile;
+      }
+    }
+    if (app.keepNativeCloudColors)
+    {
+      auto& cm                     = rpL.colorMode.emplace();
+      cm.keep_original_cloud_color = true;
+      rpL.force_alpha_channel      = true;
+    }
+  }
+
+  for (auto& [layer, rp] : rpMap.points.perLayer)
+  {
+    rp.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0x80);
+  }
+
+  // Regenerate points opengl representation only if some parameter changed:
+  static std::optional<mp2p_icp::render_params_t> prevRenderParams;
+
+  if (!prevRenderParams.has_value() || prevRenderParams.value() != rpMap)
+  {
+    prevRenderParams = rpMap;
+    app.glVizMap->clear();
+
+    auto glPts = app.theMap.get_visualization(rpMap);
+
+    app.glVizMap->insert(glPts);
+    app.glVizMap->insert(app.glMapCorner);
+    app.glVizMap->insert(app.glTrajectory);
+    app.glVizMap->insert(app.glVizObjects);
+  }
+
+  if (app.applyGeoRef && app.theMap.georeferencing.has_value())
+  {
+    app.glVizMap->setPose(app.theMap.georeferencing->T_enu_to_map.mean);
+    app.glENUCorner->setVisibility(true);
+  }
+  else
+  {
+    app.glVizMap->setPose(mrpt::poses::CPose3D::Identity());
+    app.glENUCorner->setVisibility(false);
+  }
+
+  if (mapBbox)
+  {
+    app.glGrid->setPlaneLimits(mapBbox->min.x, mapBbox->max.x, mapBbox->min.y, mapBbox->max.y);
+
+    constexpr float MAX_GRID_LINES = 20.0f;
+    const auto      bboxDiagonal   = (mapBbox->max - mapBbox->min).cast<float>().norm();
+    app.glGrid->setGridFrequency(std::max<float>(1.0f, std::round(bboxDiagonal / MAX_GRID_LINES)));
+  }
+  app.glGrid->setVisibility(app.showGroundGrid);
+
+  if (mapBbox && app.doFitView)
+  {
+    const auto midPt  = (mapBbox->min + mapBbox->max) * 0.5;
+    const auto mapLen = (mapBbox->max - mapBbox->min).norm();
+
+    app.sceneView.camera().setPointingAt(midPt.x, midPt.y, midPt.z);
+    app.sceneView.camera().setZoomDistance(mapLen);
+  }
+  app.doFitView = false;
+
+  if (app.glTrajectory->empty() && app.trajectory.size() >= 2)
+  {
+    const float trajectoryCylRadius = std::exp(app.trajectoryThicknessLog);
+
+    std::optional<mrpt::math::TPose3D> prevPose;
+    for (const auto& [t, p] : app.trajectory)
+    {
+      if (prevPose)
+      {
+        const auto& p0 = prevPose.value();
+
+        auto glSegment = mrpt::opengl::CArrow::Create();
+        glSegment->setArrowEnds(p0.translation(), p.translation());
+        glSegment->setHeadRatio(.0);
+        glSegment->setLargeRadius(trajectoryCylRadius);
+        glSegment->setSmallRadius(trajectoryCylRadius);
+        glSegment->setColor_u8(0x30, 0x30, 0x30, 0xff);
+
+        app.glTrajectory->insert(glSegment);
+      }
+      prevPose = p;
+    }
+  }
+
+  app.glVizObjects->clear();
+  for (auto& evl : app.extraVizLayers)
+  {
+    evl.glObjects->setVisibility(evl.visible);
+    app.glVizObjects->insert(evl.glObjects);
+  }
+
+  app.sceneView.camera().setProjectiveModel(!app.viewOrtho && !app.view2D);
+
+  if (app.view2D)
+  {
+    app.sceneView.camera().setAzimuthDegrees(-90.0f);
+    app.sceneView.camera().setElevationDegrees(90.0f);
+  }
+
+  // Clip planes/FOV are refreshed every frame in updateCameraClipDistances(),
+  // since the "linear" clip mode needs the up-to-date camera pose.
+}
+
+/** "Map viewer" window: file header + Open/Export + mouse/camera coordinate footer.
+ *  Kept separate from the View/Maps/Travelling panels below so it can dock as a thin strip. */
+void renderMapViewerPanel()
+{
+  ImGui::Begin("Map viewer");
+
+  const std::string headerLine = app.theMapFileName + "  |  " + app.theMap.contents_summary();
+  ImGui::TextWrapped("%s", headerLine.c_str());
+  if (ImGui::Button("Open..."))
+  {
+    app.openDialog.open(
+        mp2p_icp_viz::SimpleFileDialog::Mode::Open,
+        {{"mm", "Metric maps (*.mm)"}, {"bin", "Serialized CGenericPointsMap (*.bin)"}},
+        "Open metric map");
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Export marked layers..."))
+  {
+    app.exportDialog.open(
+        mp2p_icp_viz::SimpleFileDialog::Mode::Save, {{"txt", "(*.txt)"}}, "Export layers");
+  }
+
+  if (auto path = app.openDialog.render(); path.has_value())
+  {
+    if (loadMapFile(*path))
+    {
+      updateGuiAfterLoadingNewMap();
+    }
+  }
+  if (auto path = app.exportDialog.render(); path.has_value())
+  {
+    onSaveLayers(*path);
+  }
+
+  ImGui::Separator();
+  ImGui::TextUnformatted(app.mouseCoordText.c_str());
+  ImGui::TextUnformatted(app.cameraLookText.c_str());
+
+  const bool  hasGeoref     = app.theMap.georeferencing.has_value();
+  const char* itemsGeoref[] = {"map", "enu", "lat/lon"};
+  const char* itemsPlain[]  = {"map"};
+  if (!hasGeoref)
+  {
+    app.mouseUnitsIdx = 0;
+  }
+  ImGui::SetNextItemWidth(100);
+  if (hasGeoref)
+  {
+    ImGui::Combo("##mouseUnits", &app.mouseUnitsIdx, itemsGeoref, 3);
+  }
+  else
+  {
+    ImGui::BeginDisabled();
+    int dummy = 0;
+    ImGui::Combo("##mouseUnits", &dummy, itemsPlain, 1);
+    ImGui::EndDisabled();
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Copy coords"))
+  {
+    const std::string text = app.mouseCoordText + "\n" + app.cameraLookText;
+    glfwSetClipboardString(app.shell.windowHandle(), text.c_str());
+  }
+
+  ImGui::End();
+}
+
+/** "View" window: camera/rendering options (mirrors the old nanogui "View" tab). */
+void renderViewPanel()
+{
+  ImGui::Begin("View");
+
+  ImGui::SliderFloat(
+      "Trajectory thickness", &app.trajectoryThicknessLog, std::log(0.005f), std::log(2.0f));
+  if (ImGui::IsItemEdited())
+  {
+    app.glTrajectory->clear();  // force rebuild
+  }
+
+  ImGui::Checkbox("Log scale", &app.depthLogScale);
+  if (ImGui::IsItemEdited())
+  {
+    if (app.depthLogScale)
+    {
+      app.clipNear = 0.1f;
+      app.clipFar  = 4.0f;
+    }
+    else
+    {
+      app.clipNear = -5.0f;
+      app.clipFar  = 25.0f;
+    }
+  }
+
+  if (app.depthLogScale)
+  {
+    ImGui::SliderFloat("Frustum center (log10 m)", &app.clipNear, -2.0f, 3.0f);
+    ImGui::SliderFloat("Frustum thickness (log10 m)", &app.clipFar, -2.0f, 6.0f);
+  }
+  else
+  {
+    ImGui::SliderFloat("Floor clip (near, m)", &app.clipNear, -5.0f, 25.0f);
+    ImGui::SliderFloat("Ceiling clip (far, m)", &app.clipFar, -5.0f, 25.0f);
+  }
+
+  ImGui::SliderFloat("Camera FOV", &app.cameraFOV, 20.0f, 170.0f);
+  ImGui::Checkbox("Orthogonal view", &app.viewOrtho);
+  ImGui::SameLine();
+  ImGui::Checkbox("Force 2D view", &app.view2D);
+
+  ImGui::Checkbox("Show ground grid", &app.showGroundGrid);
+  ImGui::SameLine();
+  if (ImGui::Button("Fit view to map"))
+  {
+    app.doFitView = true;
+  }
+
+  ImGui::TextUnformatted("Set view along axis:");
+  auto viewButton = [&](const char* caption, float az, float el)
+  {
+    if (ImGui::Button(caption))
+    {
+      app.view2D = false;
+      app.sceneView.camera().setAzimuthDegrees(az);
+      app.sceneView.camera().setElevationDegrees(el);
+    }
+    ImGui::SameLine();
+  };
+  viewButton("+X", 0.0f, 0.0f);
+  viewButton("-X", 180.0f, 0.0f);
+  viewButton("+Y", 90.0f, 0.0f);
+  viewButton("-Y", -90.0f, 0.0f);
+  viewButton("+Z", -90.0f, 90.0f);
+  viewButton("-Z", -90.0f, -90.0f);
+  ImGui::NewLine();
+
+  ImGui::BeginDisabled(!app.theMap.georeferencing.has_value());
+  ImGui::Checkbox("Apply georeferenced pose (if available)", &app.applyGeoRef);
+  ImGui::EndDisabled();
+
+  ImGui::End();
+}
+
+/** "Maps" window: layer list, visibility, and colorization options. */
+void renderMapsPanel()
+{
+  ImGui::Begin("Maps");
+
+  ImGui::SliderFloat("Point size", &app.pointSize, 1.0f, 10.0f);
+  ImGui::Checkbox("Render voxel maps as point clouds", &app.viewVoxelsAsPoints);
+  ImGui::Checkbox("Render free space of voxel maps", &app.viewVoxelsFreeSpace);
+
+  ImGui::Checkbox("Recolorize points", &app.colorizeMap);
+  ImGui::SameLine();
+  ImGui::TextUnformatted("by:");
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(140);
+  if (!app.knownPointFields.empty())
+  {
+    const char* preview = app.knownPointFields.at(static_cast<size_t>(app.recolorizeByFieldIdx)).c_str();
+    if (ImGui::BeginCombo("##recolorizeField", preview))
+    {
+      for (size_t i = 0; i < app.knownPointFields.size(); i++)
+      {
+        const bool sel = (static_cast<int>(i) == app.recolorizeByFieldIdx);
+        if (ImGui::Selectable(app.knownPointFields[i].c_str(), sel))
         {
-            std::cerr << "Warning: --georef-polygon given, but the loaded map has no "
-                         "georeferencing information. Ignoring it.\n";
+          app.recolorizeByFieldIdx = static_cast<int>(i);
+        }
+      }
+      ImGui::EndCombo();
+    }
+  }
+  ImGui::SetNextItemWidth(140);
+  ImGui::Combo("##colorMap", &app.colorIntensityIdx, kColorIntensityLabels, kNumColorIntensity);
+
+  ImGui::Checkbox("Keep native map colors", &app.keepNativeCloudColors);
+
+  ImGui::Checkbox("Outlier percentile:", &app.autoBBoxOutliers);
+  ImGui::SameLine();
+  ImGui::BeginDisabled(!app.autoBBoxOutliers);
+  ImGui::SetNextItemWidth(120);
+  ImGui::SliderFloat("##outlierPercentile", &app.autoBBoxOutliersPercentile, 0.0f, 0.25f, "%.3f");
+  ImGui::EndDisabled();
+
+  ImGui::Separator();
+  ImGui::TextUnformatted("Visible layers:");
+  ImGui::SameLine();
+  if (ImGui::SmallButton("All"))
+  {
+    for (auto& [name, vis] : app.layerVisible)
+    {
+      vis = true;
+    }
+    for (auto& evl : app.extraVizLayers)
+    {
+      evl.visible = true;
+    }
+  }
+  ImGui::SameLine();
+  if (ImGui::SmallButton("None"))
+  {
+    for (auto& [name, vis] : app.layerVisible)
+    {
+      vis = false;
+    }
+    for (auto& evl : app.extraVizLayers)
+    {
+      evl.visible = false;
+    }
+  }
+
+  if (ImGui::BeginChild("##layerList", ImVec2(0, 150), true))
+  {
+    for (const auto& lyName : app.layerNames)
+    {
+      std::string caption = lyName;
+      if (auto itL = app.theMap.layers.find(lyName); itL != app.theMap.layers.end())
+      {
+        if (auto pc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itL->second); pc)
+        {
+          caption = lyName + " | " +
+                    mrpt::system::unitsFormat(static_cast<double>(pc->size()), 2, false) +
+                    " points | class=" + pc->GetRuntimeClass()->className;
         }
         else
         {
-            try
-            {
-                const auto latLonPoints = readLatLonPolygonFile(arg_georefPolygon);
-
-                ExtraVizLayer evl;
-                evl.fileName = mrpt::system::extractFileName(arg_georefPolygon);
-                evl.glObjects =
-                    buildGeorefPolygonLayer(latLonPoints, theMap.georeferencing.value());
-                evl.glObjects->setName(evl.fileName);
-
-                extraVizLayers.push_back(evl);
-            }
-            catch (const std::exception& e)
-            {
-                std::cerr << "Warning: could not load georef polygon: " << e.what() << "\n";
-            }
+          caption = lyName + " | class=" + itL->second->GetRuntimeClass()->className;
         }
+      }
+      ImGui::Checkbox(caption.c_str(), &app.layerVisible[lyName]);
     }
-
-    // Get user app config file
-    char appCfgFile[1024];
-    ::get_user_config_file(appCfgFile, sizeof(appCfgFile), APP_NAME);
-    mrpt::config::CConfigFile appCfg(appCfgFile);
-
-    /*
-     * -------------------------------------------------------------------
-     * GUI
-     * --------------------------------------------------------------------
-     */
-    nanogui::init();
-
-    mrpt::gui::CDisplayWindowGUI_Params cp;
-    cp.maximized = true;
-    win          = mrpt::gui::CDisplayWindowGUI::Create(APP_NAME, 1024, 800, cp);
-
-    // Add a background scene:
-    auto scene = mrpt::opengl::COpenGLScene::Create();
+    for (auto& evl : app.extraVizLayers)
     {
-        glGrid->setColor_u8(0xff, 0xff, 0xff, 0x10);
-        scene->insert(glGrid);
+      ImGui::Checkbox(("(viz) " + evl.fileName).c_str(), &evl.visible);
     }
+  }
+  ImGui::EndChild();
 
-    glMapCorner = mrpt::opengl::stock_objects::CornerXYZ(1.0f);
-    glMapCorner->setName("map");
-    glMapCorner->enableShowName();
+  ImGui::End();
+}
 
-    glTrajectory = mrpt::opengl::CSetOfObjects::Create();
-    glVizObjects = mrpt::opengl::CSetOfObjects::Create();
+/** "Travelling" window: camera keyframe animation controls. */
+void renderTravellingPanel()
+{
+  ImGui::Begin("Travelling");
 
-    glENUCorner = mrpt::opengl::stock_objects::CornerXYZ(2.0f);
-    glENUCorner->setName("ENU");
-    glENUCorner->enableShowName();
-    scene->insert(glENUCorner);
+  ImGui::TextUnformatted("Define camera travelling paths");
 
-    scene->insert(glVizMap);
-
+  ImGui::SetNextItemWidth(-1);
+  if (!app.camTravellingLabels.empty())
+  {
+    const int   selected = static_cast<int>(app.camTravellingLabels.size()) - 1;
+    const char* preview   = app.camTravellingLabels[static_cast<size_t>(selected)].c_str();
+    if (ImGui::BeginCombo("##travellingKeys", preview))
     {
-        std::lock_guard<std::mutex> lck(win->background_scene_mtx);
-        win->background_scene = std::move(scene);
+      for (size_t i = 0; i < app.camTravellingLabels.size(); i++)
+      {
+        ImGui::Selectable(app.camTravellingLabels[i].c_str(), false);
+      }
+      ImGui::EndCombo();
     }
+  }
 
-    // Control GUI sub-window:
-    auto w = win->createManagedSubWindow("Map viewer");
-    w->setPosition({5, 25});
-    w->requestFocus();
-    w->setLayout(
-        new nanogui::BoxLayout(nanogui::Orientation::Vertical, nanogui::Alignment::Fill, 5, 2));
-    w->setFixedWidth(350);
+  ImGui::InputFloat("New keyframe time [s]", &app.newKeyframeTime);
+  ImGui::SameLine();
+  if (ImGui::Button("Add"))
+  {
+    auto&      cam = app.sceneView.camera();
+    const auto p   = mrpt::math::TPose3D(
+        cam.getPointingAtX(), cam.getPointingAtY(), cam.getPointingAtZ(),
+        mrpt::DEG2RAD(cam.getAzimuthDegrees()), mrpt::DEG2RAD(cam.getElevationDegrees()),
+        cam.getZoomDistance() * TRAVELING_ZOOM2ROLL);
+    app.camTravelling.insert(mrpt::Clock::fromDouble(static_cast<double>(app.newKeyframeTime)), p);
+    rebuildCamTravellingLabels();
+    app.newKeyframeTime += 1.0f;
+  }
 
-    for (size_t i = 0; i < lbMapStats.size(); i++)
+  const bool isPlaying = app.camTravellingCurrentTime.has_value();
+  ImGui::BeginDisabled(isPlaying || app.camTravelling.empty());
+  if (ImGui::Button("Play"))
+  {
+    app.camTravellingCurrentTime.emplace(mrpt::Clock::toDouble(app.camTravelling.begin()->first));
+  }
+  ImGui::EndDisabled();
+  ImGui::SameLine();
+  ImGui::BeginDisabled(!isPlaying);
+  if (ImGui::Button("Stop"))
+  {
+    camTravellingStop();
+  }
+  ImGui::EndDisabled();
+
+  ImGui::InputFloat("Animation FPS", &app.animFPS);
+
+  const char* interpItems[] = {"Linear", "Spline"};
+  ImGui::Combo("Interpolation", &app.travellingInterpIdx, interpItems, 2);
+
+  ImGui::BeginDisabled(true);
+  ImGui::SliderFloat("Progress", &app.animProgress, 0.0f, 1.0f);
+  ImGui::EndDisabled();
+
+  ImGui::End();
+}
+
+/** "3D View" window: fills the remaining (background) dockspace area. */
+void renderSceneWindow()
+{
+  ImGui::Begin("3D View");
+  app.sceneView.render();
+  ImGui::End();
+}
+
+void renderFrame()
+{
+  handleKeyboard();
+  processCameraTravelling();
+  rebuild_3d_view();
+  updateCameraClipDistances();
+
+  renderMapViewerPanel();
+  renderViewPanel();
+  renderMapsPanel();
+  renderTravellingPanel();
+  renderSceneWindow();
+}
+
+int mainShowGui()
+{
+  using namespace std::string_literals;
+
+  if (!argMapFile.empty())
+  {
+    if (!loadMapFile(argMapFile))
     {
-        auto& lb = lbMapStats[i];
-
-        if (i == 0)
-        {
-            auto pn = w->add<nanogui::Widget>();
-            pn->setLayout(
-                new nanogui::BoxLayout(nanogui::Orientation::Horizontal, nanogui::Alignment::Fill));
-            lb = pn->add<nanogui::TextBox>("  ");
-            lb->setFixedWidth(300);
-            auto btnLoad = pn->add<nanogui::Button>("", ENTYPO_ICON_ARCHIVE);
-            btnLoad->setCallback(
-                []()
-                {
-                    try
-                    {
-                        const auto fil = nanogui::file_dialog(
-                            {{"mm", "Metric maps (*.mm)"},
-                             {"bin", "Serialized CGenericPointsMap (*.bin)"}},
-                            false);
-                        if (fil.empty())
-                        {
-                            return;
-                        }
-
-                        loadMapFile(fil);
-                        updateGuiAfterLoadingNewMap();
-                        win->performLayout();
-                        rebuild_3d_view();
-                    }
-                    catch (const std::exception& e)
-                    {
-                        std::cerr << e.what() << std::endl;
-                    }
-                });
-        }
-        else
-        {
-            lb = w->add<nanogui::TextBox>("  ");
-        }
-
-        lb->setFontSize(MID_FONT_SIZE);
-        lb->setAlignment(nanogui::TextBox::Alignment::Left);
-        lb->setEditable(true);
+      return 1;
     }
+  }
 
-    //
-    w->add<nanogui::Label>(" ");  // separator
-
-    auto tabWidget = w->add<nanogui::TabWidget>();
-
-    auto* tab1 = tabWidget->createTab("View");
-    tab1->setLayout(new nanogui::GroupLayout());
-
-    auto* tab2 = tabWidget->createTab("Maps");
-    tab2->setLayout(
-        new nanogui::BoxLayout(nanogui::Orientation::Vertical, nanogui::Alignment::Fill));
-
-    auto* tab3 = tabWidget->createTab("Travelling");
-    tab3->setLayout(
-        new nanogui::BoxLayout(nanogui::Orientation::Vertical, nanogui::Alignment::Fill));
-
-    tabWidget->setActiveTab(0);
-
-    // --------------------------------------------------------------
-    // Tab: Map layers
-    // --------------------------------------------------------------
-    tab2->add<nanogui::Label>("Render options:");
-
+  if (!arg_georefPolygon.empty())
+  {
+    if (!app.theMap.georeferencing.has_value())
     {
-        auto pn = tab2->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 2, nanogui::Alignment::Fill));
-
-        lbPointSize = pn->add<nanogui::Label>("Point size");
-        lbPointSize->setFontSize(MID_FONT_SIZE);
-
-        slPointSize = pn->add<nanogui::Slider>();
-        slPointSize->setRange({1.0f, 10.0f});
-        slPointSize->setValue(2.0f);
-        slPointSize->setCallback([&](float) { rebuild_3d_view(); });
+      std::cerr << "Warning: --georef-polygon given, but the loaded map has no "
+                   "georeferencing information. Ignoring it.\n";
     }
-
-    cbViewVoxelsAsPoints = tab2->add<nanogui::CheckBox>("Render voxel maps as point clouds");
-    cbViewVoxelsAsPoints->setFontSize(MID_FONT_SIZE);
-    cbViewVoxelsAsPoints->setChecked(false);
-    cbViewVoxelsAsPoints->setCallback([&](bool) { rebuild_3d_view(); });
-
-    cbViewVoxelsFreeSpace = tab2->add<nanogui::CheckBox>("Render free space of voxel maps");
-    cbViewVoxelsFreeSpace->setFontSize(MID_FONT_SIZE);
-    cbViewVoxelsFreeSpace->setChecked(false);
-    cbViewVoxelsFreeSpace->setCallback([&](bool) { rebuild_3d_view(); });
-
+    else
     {
-        auto pn = tab2->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 4, nanogui::Alignment::Fill));
+      try
+      {
+        const auto latLonPoints = readLatLonPolygonFile(arg_georefPolygon);
 
-        cbColorizeMap = pn->add<nanogui::CheckBox>("Recolorize points");
-        cbColorizeMap->setFontSize(MID_FONT_SIZE);
-        cbColorizeMap->setChecked(true);
-        cbColorizeMap->setCallback([&](bool) { rebuild_3d_view(); });
+        ExtraVizLayer evl;
+        evl.fileName  = mrpt::system::extractFileName(arg_georefPolygon);
+        evl.glObjects = buildGeorefPolygonLayer(latLonPoints, app.theMap.georeferencing.value());
+        evl.glObjects->setName(evl.fileName);
 
-        auto lb = pn->add<nanogui::Label>("by:");
-        lb->setFontSize(MID_FONT_SIZE);
-
-        cmbRecolorizeByField = pn->add<nanogui::ComboBox>();
-        cmbRecolorizeByField->setItems({"intensity"});
-        cmbRecolorizeByField->setFontSize(MID_FONT_SIZE);
-        cmbRecolorizeByField->setSelectedIndex(0);
-        cmbRecolorizeByField->setCallback([&](int) { rebuild_3d_view(true); });
-
-        cmbColorIntensity = pn->add<nanogui::ComboBox>();
-        cmbColorIntensity->setItems(
-            {"cmNONE", "cmHOT", "cmJET", "cmGRAYSCALE"}, {"None", "Hot", "Jet", "Grayscale"});
-        cmbColorIntensity->setFontSize(MID_FONT_SIZE);
-        cmbColorIntensity->setSelectedIndex(2);
-        cmbColorIntensity->setCallback([&](int) { rebuild_3d_view(true); });
+        app.extraVizLayers.push_back(evl);
+      }
+      catch (const std::exception& e)
+      {
+        std::cerr << "Warning: could not load georef polygon: " << e.what() << "\n";
+      }
     }
-
-    cbKeepNativeCloudColors = tab2->add<nanogui::CheckBox>("Keep native map colors");
-    cbKeepNativeCloudColors->setFontSize(MID_FONT_SIZE);
-    cbKeepNativeCloudColors->setChecked(false);
-    cbKeepNativeCloudColors->setCallback([&](bool) { rebuild_3d_view(); });
-
-    {
-        auto pn = tab2->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 3, nanogui::Alignment::Fill));
-
-        cbAutoBBoxOutliers = pn->add<nanogui::CheckBox>("Outlier percentile:");
-        cbAutoBBoxOutliers->setFontSize(MID_FONT_SIZE);
-        cbAutoBBoxOutliers->setChecked(true);
-        cbAutoBBoxOutliers->setCallback(
-            [&](bool checked)
-            {
-                slAutoBBoxOutliersPercentile->setEnabled(checked);
-                lbAutoBBoxOutliersPercentile->setEnabled(checked);
-                rebuild_3d_view(true);
-            });
-
-        lbAutoBBoxOutliersPercentile = pn->add<nanogui::Label>("0.025");
-        lbAutoBBoxOutliersPercentile->setFontSize(MID_FONT_SIZE);
-
-        slAutoBBoxOutliersPercentile = pn->add<nanogui::Slider>();
-        slAutoBBoxOutliersPercentile->setRange({0.0f, 0.25f});
-        slAutoBBoxOutliersPercentile->setValue(0.025f);
-        slAutoBBoxOutliersPercentile->setCallback(
-            [&](float v)
-            {
-                lbAutoBBoxOutliersPercentile->setCaption(mrpt::format("%.3f", v));
-                rebuild_3d_view(true);
-            });
-    }
-
-    tab2->add<nanogui::Label>(" ");
-    {
-        auto pn = tab2->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 4, nanogui::Alignment::Fill));
-        pn->add<nanogui::Label>("Visible layers:");
-
-        auto* btnCheckAll = pn->add<nanogui::Button>("", ENTYPO_ICON_CHECK);
-        btnCheckAll->setFontSize(SMALL_FONT_SIZE);
-        btnCheckAll->setCallback(
-            []()
-            {
-                for (auto& [name, cb] : cbLayersByName)
-                {
-                    cb->setChecked(true);
-                }
-                for (auto& evl : extraVizLayers)
-                {
-                    evl.checkBox->setChecked(true);
-                    evl.glObjects->setVisibility(true);
-                }
-                rebuild_3d_view();
-            });
-
-        auto* btnCheckNone = pn->add<nanogui::Button>("", ENTYPO_ICON_CIRCLE_WITH_CROSS);
-        btnCheckNone->setFontSize(SMALL_FONT_SIZE);
-        btnCheckNone->setCallback(
-            []()
-            {
-                for (auto& [name, cb] : cbLayersByName)
-                {
-                    cb->setChecked(false);
-                }
-                for (auto& evl : extraVizLayers)
-                {
-                    evl.checkBox->setChecked(false);
-                    evl.glObjects->setVisibility(false);
-                }
-                rebuild_3d_view();
-            });
-    }
-
-    panelLayers = tab2->add<nanogui::Widget>();
-    panelLayers->setLayout(
-        new nanogui::BoxLayout(nanogui::Orientation::Vertical, nanogui::Alignment::Fill));
-
-    {
-        tab2->add<nanogui::Label>(" ");  // separator
-        auto btnSave = tab2->add<nanogui::Button>("Export marked layers...");
-        btnSave->setFontSize(MID_FONT_SIZE);
-        btnSave->setCallback([]() { onSaveLayers(); });
-    }
-
-    // --------------------------------------------------------------
-    // Tab: View
-    // --------------------------------------------------------------
-    {
-        auto pn = tab1->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 2, nanogui::Alignment::Fill));
-
-        lbTrajectoryThick = pn->add<nanogui::Label>("Trajectory thickness:");
-        lbTrajectoryThick->setFontSize(MID_FONT_SIZE);
-
-        slTrajectoryThickness = pn->add<nanogui::Slider>();
-        slTrajectoryThickness->setEnabled(trajectory.size() >= 2);
-        slTrajectoryThickness->setRange({std::log(0.005f), std::log(2.0f)});
-        slTrajectoryThickness->setValue(std::log(0.05f));
-        slTrajectoryThickness->setCallback(
-            [&](float)
-            {
-                glTrajectory->clear();  // force rebuild
-                rebuild_3d_view();
-            });
-    }
-
-    {
-        auto pn = tab1->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 2, nanogui::Alignment::Fill));
-
-        cbDepthLogScale = pn->add<nanogui::CheckBox>("Log scale");
-        cbDepthLogScale->setFontSize(MID_FONT_SIZE);
-        cbDepthLogScale->setChecked(true);
-        cbDepthLogScale->setCallback(
-            [&](bool logMode)
-            {
-                if (logMode)
-                {
-                    slClipNear->setRange({-2.0f, 3.0f});
-                    slClipNear->setValue(0.1f);
-                    slClipFar->setRange({-2.0f, 6.0f});
-                    slClipFar->setValue(4.0f);
-                    lbClipNear->setCaption("Frustum center (log10 m):");
-                    lbClipFar->setCaption("Frustum thickness (log10 m):");
-                }
-                else
-                {
-                    slClipNear->setRange({-5.0f, 25.0f});
-                    slClipNear->setValue(-5.0f);
-                    slClipFar->setRange({-5.0f, 25.0f});
-                    slClipFar->setValue(25.0f);
-                    lbClipNear->setCaption("Floor clip (near, m):");
-                    lbClipFar->setCaption("Ceiling clip (far, m):");
-                }
-                edClipNear->setValue(mrpt::format("%.2f", slClipNear->value()));
-                edClipFar->setValue(mrpt::format("%.2f", slClipFar->value()));
-                rebuild_3d_view();
-            });
-
-        lbDepthFieldValues = pn->add<nanogui::Label>(" ");
-        lbDepthFieldValues->setFontSize(MID_FONT_SIZE);
-    }
-
-    {
-        auto pn = tab1->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 3, nanogui::Alignment::Fill));
-
-        lbClipNear = pn->add<nanogui::Label>("Floor clip (near, m):");
-        lbClipNear->setFontSize(MID_FONT_SIZE);
-
-        slClipNear = pn->add<nanogui::Slider>();
-        slClipNear->setCallback(
-            [&](float v)
-            {
-                edClipNear->setValue(mrpt::format("%.2f", v));
-                rebuild_3d_view();
-            });
-
-        edClipNear = pn->add<nanogui::TextBox>(mrpt::format("%.2f", slClipNear->value()));
-        edClipNear->setFontSize(MID_FONT_SIZE);
-        edClipNear->setFixedWidth(60);
-        edClipNear->setFormat("[-0-9\\.]*");
-        edClipNear->setEditable(true);
-        edClipNear->setCallback(
-            [&](const std::string& s) -> bool
-            {
-                try
-                {
-                    const float v = std::stof(s);
-                    slClipNear->setValue(
-                        std::clamp(v, slClipNear->range().first, slClipNear->range().second));
-                    rebuild_3d_view();
-                    return true;
-                }
-                catch (...)
-                {
-                    return false;
-                }
-            });
-    }
-
-    {
-        auto pn = tab1->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 3, nanogui::Alignment::Fill));
-
-        lbClipFar = pn->add<nanogui::Label>("Ceiling clip (far, m):");
-        lbClipFar->setFontSize(MID_FONT_SIZE);
-
-        slClipFar = pn->add<nanogui::Slider>();
-        slClipFar->setCallback(
-            [&](float v)
-            {
-                edClipFar->setValue(mrpt::format("%.2f", v));
-                rebuild_3d_view();
-            });
-
-        edClipFar = pn->add<nanogui::TextBox>(mrpt::format("%.2f", slClipFar->value()));
-        edClipFar->setFontSize(MID_FONT_SIZE);
-        edClipFar->setFixedWidth(60);
-        edClipFar->setFormat("[-0-9\\.]*");
-        edClipFar->setEditable(true);
-        edClipFar->setCallback(
-            [&](const std::string& s) -> bool
-            {
-                try
-                {
-                    const float v = std::stof(s);
-                    slClipFar->setValue(
-                        std::clamp(v, slClipFar->range().first, slClipFar->range().second));
-                    rebuild_3d_view();
-                    return true;
-                }
-                catch (...)
-                {
-                    return false;
-                }
-            });
-    }
-
-    {
-        auto pn = tab1->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 2, nanogui::Alignment::Fill));
-
-        lbCameraFOV = pn->add<nanogui::Label>("Camera FOV:");
-        lbCameraFOV->setFontSize(MID_FONT_SIZE);
-        slCameraFOV = pn->add<nanogui::Slider>();
-        slCameraFOV->setRange({20.0f, 170.0f});
-        slCameraFOV->setValue(90.0f);
-        slCameraFOV->setCallback([&](float) { rebuild_3d_view(); });
-    }
-    {
-        auto pn = tab1->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 2, nanogui::Alignment::Fill));
-
-        cbViewOrtho = pn->add<nanogui::CheckBox>("Orthogonal view");
-        cbViewOrtho->setFontSize(MID_FONT_SIZE);
-        cbViewOrtho->setCallback([&](bool) { rebuild_3d_view(); });
-        cbViewOrtho->setFontSize(MID_FONT_SIZE);
-
-        cbView2D = pn->add<nanogui::CheckBox>("Force 2D view");
-        cbView2D->setFontSize(MID_FONT_SIZE);
-        cbView2D->setCallback([&](bool) { rebuild_3d_view(); });
-    }
-
-    {
-        auto pn = tab1->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 2, nanogui::Alignment::Fill));
-
-        cbShowGroundGrid = pn->add<nanogui::CheckBox>("Show ground grid");
-        cbShowGroundGrid->setFontSize(MID_FONT_SIZE);
-        cbShowGroundGrid->setChecked(true);
-        cbShowGroundGrid->setCallback([&](bool) { rebuild_3d_view(); });
-
-        auto btnFitView = pn->add<nanogui::Button>("Fit view to map");
-        btnFitView->setFontSize(MID_FONT_SIZE);
-        btnFitView->setCallback(
-            [&]()
-            {
-                doFitView = true;
-                rebuild_3d_view();
-            });
-    }
-
-    {
-        auto lb = tab1->add<nanogui::Label>("Set view along axis:");
-        lb->setFontSize(MID_FONT_SIZE);
-
-        auto pn = tab1->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 3, nanogui::Alignment::Fill));
-
-        auto addViewButton = [&](const std::string& caption, float az, float el)
-        {
-            auto* btn = pn->add<nanogui::Button>(caption);
-            btn->setFontSize(MID_FONT_SIZE);
-            btn->setCallback(
-                [az, el]()
-                {
-                    cbView2D->setChecked(false);
-                    win->camera().setAzimuthDegrees(az);
-                    win->camera().setElevationDegrees(el);
-                });
-        };
-
-        addViewButton("+X", 0.0f, 0.0f);
-        addViewButton("-X", 180.0f, 0.0f);
-        addViewButton("+Y", 90.0f, 0.0f);
-        addViewButton("-Y", -90.0f, 0.0f);
-        addViewButton("+Z", -90.0f, 90.0f);
-        addViewButton("-Z", -90.0f, -90.0f);
-    }
-
-    cbApplyGeoRef = tab1->add<nanogui::CheckBox>("Apply georeferenced pose (if available)");
-    cbApplyGeoRef->setFontSize(MID_FONT_SIZE);
-    cbApplyGeoRef->setCallback([&](bool) { rebuild_3d_view(); });
-
-    // --------------------------------------------------------------
-    // Tab: Travelling
-    // --------------------------------------------------------------
-    tab3->add<nanogui::Label>("Define camera travelling paths");
-
-    {
-        auto pn = tab3->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 2, nanogui::Alignment::Fill));
-
-        auto lb = pn->add<nanogui::Label>("Keyframes:");
-        lb->setFontSize(MID_FONT_SIZE);
-
-        cbTravellingKeys = tab3->add<nanogui::ComboBox>();
-        cbTravellingKeys->setFontSize(MID_FONT_SIZE);
-    }
-    rebuildCamTravellingCombo();
-
-    tab3->add<nanogui::Label>("");
-
-    nanogui::TextBox* edTime;
-    {
-        auto pn = tab3->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 3, nanogui::Alignment::Fill));
-
-        pn->add<nanogui::Label>("New keyframe:")->setFontSize(MID_FONT_SIZE);
-
-        edTime = pn->add<nanogui::TextBox>();
-        edTime->setAlignment(nanogui::TextBox::Alignment::Left);
-        edTime->setValue("0.0");
-        edTime->setEditable(true);
-        edTime->setPlaceholder("Time for this keyframe [s]");
-        edTime->setFormat("[0-9\\.]*");
-        edTime->setFontSize(MID_FONT_SIZE);
-
-        auto btnAdd = pn->add<nanogui::Button>("Add", ENTYPO_ICON_ADD_TO_LIST);
-        btnAdd->setFontSize(MID_FONT_SIZE);
-        btnAdd->setCallback(
-            [edTime]()
-            {
-                const auto p = mrpt::math::TPose3D(
-                    win->camera().cameraParams().cameraPointingX,
-                    win->camera().cameraParams().cameraPointingY,
-                    win->camera().cameraParams().cameraPointingZ,
-                    mrpt::DEG2RAD(win->camera().cameraParams().cameraAzimuthDeg),
-                    mrpt::DEG2RAD(win->camera().cameraParams().cameraElevationDeg),
-                    win->camera().cameraParams().cameraZoomDistance * TRAVELING_ZOOM2ROLL);
-                camTravelling.insert(mrpt::Clock::fromDouble(std::stod(edTime->value())), p);
-                rebuildCamTravellingCombo();
-
-                edTime->setValue(std::to_string(std::stod(edTime->value()) + 1));
-            });
-    }
-
-    tab3->add<nanogui::Label>("");
-
-    {
-        auto pn = tab3->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 3, nanogui::Alignment::Fill));
-
-        pn->add<nanogui::Label>("Playback:");
-        btnAnimate = pn->add<nanogui::Button>("", ENTYPO_ICON_CONTROLLER_PLAY);
-        btnAnimate->setFontSize(MID_FONT_SIZE);
-        btnAnimate->setCallback(
-            []()
-            {
-                if (camTravelling.empty())
-                {
-                    return;
-                }
-                camTravellingCurrentTime.emplace(
-                    mrpt::Clock::toDouble(camTravelling.begin()->first));
-                btnAnimate->setEnabled(false);
-                btnAnimStop->setEnabled(true);
-            });
-        btnAnimStop = pn->add<nanogui::Button>("", ENTYPO_ICON_CIRCLE_WITH_CROSS);
-        btnAnimStop->setFontSize(MID_FONT_SIZE);
-        btnAnimStop->setEnabled(false);
-        btnAnimStop->setCallback([]() { camTravellingStop(); });
-    }
-
-    {
-        auto pn = tab3->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 2, nanogui::Alignment::Fill));
-
-        auto lb = pn->add<nanogui::Label>("Animation FPS:");
-        lb->setFontSize(MID_FONT_SIZE);
-
-        edAnimFPS = pn->add<nanogui::TextBox>("30.0");
-        edAnimFPS->setFontSize(MID_FONT_SIZE);
-        edAnimFPS->setFormat("[0-9\\.]*");
-        edAnimFPS->setEditable(true);
-    }
-    {
-        auto pn = tab3->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Horizontal, 2, nanogui::Alignment::Fill));
-
-        auto lb = pn->add<nanogui::Label>("Interpolation:");
-        lb->setFontSize(MID_FONT_SIZE);
-
-        cbTravellingInterp = pn->add<nanogui::ComboBox>();
-        cbTravellingInterp->setFontSize(MID_FONT_SIZE);
-        cbTravellingInterp->setItems({"Linear", "Spline"});
-        cbTravellingInterp->setSelectedIndex(0);
-    }
-    slAnimProgress = tab3->add<nanogui::Slider>();
-    slAnimProgress->setEnabled(false);
-
-    // ---
-
-    {
-        auto pn = w->add<nanogui::Widget>();
-        pn->setLayout(
-            new nanogui::BoxLayout(nanogui::Orientation::Horizontal, nanogui::Alignment::Fill));
-
-        auto pnLeft = pn->add<nanogui::Widget>();
-        pnLeft->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Vertical, 2, nanogui::Alignment::Middle));
-
-        auto pnRight = pn->add<nanogui::Widget>();
-        pnRight->setLayout(
-            new nanogui::GridLayout(nanogui::Orientation::Vertical, 2, nanogui::Alignment::Fill));
-
-        lbMousePos = pnLeft->add<nanogui::Label>("Mouse pointing to:");
-        lbMousePos->setFontSize(SMALL_FONT_SIZE);
-        lbMousePos->setFixedWidth(280);
-        lbCameraPointing = pnLeft->add<nanogui::Label>("Camera looking at:");
-        lbCameraPointing->setFontSize(SMALL_FONT_SIZE);
-        lbCameraPointing->setFixedWidth(280);
-
-        cbMouseUnits =
-            pnRight->add<nanogui::ComboBox>(std::vector<std::string>({"map", "ENU", "lat/lon "}));
-        cbMouseUnits->setTooltip("Reference frame and format of coordinates");
-        cbMouseUnits->setFontSize(SMALL_FONT_SIZE);
-        cbMouseUnits->setFixedHeight(30);
-
-        btnCopyCoords = pnRight->add<nanogui::Button>("", ENTYPO_ICON_COPY);
-        btnCopyCoords->setTooltip("Copy coordinates to clipboard (CTRL+C)");
-        btnCopyCoords->setCallback(
-            [&]()
-            {
-                glfwSetClipboardString(
-                    win->glfwWindow(),
-                    (lbMousePos->caption() + std::string("\n") + lbCameraPointing->caption())
-                        .c_str());
-            });
-    }
-
-    w->add<nanogui::Button>("Quit", ENTYPO_ICON_ARROW_BOLD_LEFT)
-        ->setCallback([]() { win->setVisible(false); });
-
-    win->setKeyboardCallback(
-        [&](int key, [[maybe_unused]] int scancode, int action, int modifiers)
-        {
-            if (action != GLFW_PRESS && action != GLFW_REPEAT)
-            {
-                return false;
-            }
-            onKeyboardAction(key, modifiers);
-            return false;
-        });
-
-    // Auto-set slider ranges:
-    cbDepthLogScale->callback()(cbDepthLogScale->checked());
-
-    updateGuiAfterLoadingNewMap();
-
-    // --------------------------------------------------------------
-    // ^^^^^^^^ GUI definition done ^^^^^^^^
-    // --------------------------------------------------------------
-    win->performLayout();
-    win->camera().setCameraPointing(8.0f, .0f, .0f);
-    win->camera().setAzimuthDegrees(110.0f);
-    win->camera().setElevationDegrees(15.0f);
-    win->camera().setZoomDistance(50.0f);
-
-    // save and load UI state:
-#define LOAD_CB_STATE(CB_NAME__) do_cb(CB_NAME__, #CB_NAME__)
-#define SAVE_CB_STATE(CB_NAME__) appCfg.write("", #CB_NAME__, (CB_NAME__)->checked())
-
-#define LOAD_SL_STATE(SL_NAME__) do_sl(SL_NAME__, #SL_NAME__)
-#define SAVE_SL_STATE(SL_NAME__) appCfg.write("", #SL_NAME__, (SL_NAME__)->value())
-
-    auto load_UI_state_from_user_config = [&]()
-    {
-        auto do_cb = [&](nanogui::CheckBox* cb, const std::string& name)
-        { cb->setChecked(appCfg.read_bool("", name, cb->checked())); };
-        auto do_sl = [&](nanogui::Slider* sl, const std::string& name)
-        { sl->setValue(appCfg.read_float("", name, sl->value())); };
-
-        LOAD_CB_STATE(cbApplyGeoRef);
-        LOAD_CB_STATE(cbViewOrtho);
-        LOAD_CB_STATE(cbView2D);
-        LOAD_CB_STATE(cbViewVoxelsAsPoints);
-        LOAD_CB_STATE(cbViewVoxelsFreeSpace);
-        LOAD_CB_STATE(cbColorizeMap);
-        LOAD_CB_STATE(cbKeepNativeCloudColors);
-        LOAD_CB_STATE(cbAutoBBoxOutliers);
-        LOAD_CB_STATE(cbShowGroundGrid);
-        LOAD_CB_STATE(cbDepthLogScale);
-
-        LOAD_SL_STATE(slPointSize);
-        LOAD_SL_STATE(slAutoBBoxOutliersPercentile);
-        LOAD_SL_STATE(slTrajectoryThickness);
-        LOAD_SL_STATE(slClipNear);
-        LOAD_SL_STATE(slClipFar);
-        LOAD_SL_STATE(slCameraFOV);
-
-        win->camera().setCameraPointing(
-            appCfg.read_float("", "cam_x", win->camera().getCameraPointingX()),
-            appCfg.read_float("", "cam_y", win->camera().getCameraPointingY()),
-            appCfg.read_float("", "cam_z", win->camera().getCameraPointingZ()));
-        win->camera().setAzimuthDegrees(
-            appCfg.read_float("", "cam_az", win->camera().getAzimuthDegrees()));
-        win->camera().setElevationDegrees(
-            appCfg.read_float("", "cam_el", win->camera().getElevationDegrees()));
-        win->camera().setZoomDistance(
-            appCfg.read_float("", "cam_d", win->camera().getZoomDistance()));
-    };
-    auto save_UI_state_to_user_config = [&]()
-    {
-        SAVE_CB_STATE(cbApplyGeoRef);
-        SAVE_CB_STATE(cbViewOrtho);
-        SAVE_CB_STATE(cbView2D);
-        SAVE_CB_STATE(cbViewVoxelsAsPoints);
-        SAVE_CB_STATE(cbViewVoxelsFreeSpace);
-        SAVE_CB_STATE(cbColorizeMap);
-        SAVE_CB_STATE(cbKeepNativeCloudColors);
-        SAVE_CB_STATE(cbAutoBBoxOutliers);
-        SAVE_CB_STATE(cbShowGroundGrid);
-        SAVE_CB_STATE(cbDepthLogScale);
-
-        SAVE_SL_STATE(slPointSize);
-        SAVE_SL_STATE(slAutoBBoxOutliersPercentile);
-        SAVE_SL_STATE(slTrajectoryThickness);
-        SAVE_SL_STATE(slClipNear);
-        SAVE_SL_STATE(slClipFar);
-        SAVE_SL_STATE(slCameraFOV);
-
-        appCfg.write("", "cam_x", win->camera().getCameraPointingX());
-        appCfg.write("", "cam_y", win->camera().getCameraPointingY());
-        appCfg.write("", "cam_z", win->camera().getCameraPointingZ());
-        appCfg.write("", "cam_az", win->camera().getAzimuthDegrees());
-        appCfg.write("", "cam_el", win->camera().getElevationDegrees());
-        appCfg.write("", "cam_d", win->camera().getZoomDistance());
-    };
-
-    // load UI state from last session:
-    load_UI_state_from_user_config();
-
-    // Sync derived widget states after load:
-    lbAutoBBoxOutliersPercentile->setCaption(
-        mrpt::format("%.3f", slAutoBBoxOutliersPercentile->value()));
-    slAutoBBoxOutliersPercentile->setEnabled(cbAutoBBoxOutliers->checked());
-    lbAutoBBoxOutliersPercentile->setEnabled(cbAutoBBoxOutliers->checked());
-
-    // Build 3D:
-    rebuild_3d_view();
-
-    // Main loop
-    // ---------------------
-    win->drawAll();
-    win->setVisible(true);
-
-    win->addLoopCallback(
-        [&]()
-        {
-            updateMouseCoordinates();
-            updateCameraLookCoordinates();
-            observeViewOptions();
-            updateMiniCornerView();
-            processCameraTravelling();
-            updateCameraClipDistances();
-        });
-
-    nanogui::mainloop(1000 /*idleLoopPeriod ms*/, 25 /* minRepaintPeriod ms */);
-
-    nanogui::shutdown();
-
-    // save UI state:
-    save_UI_state_to_user_config();
+  }
+
+  if (!app.shell.init(APP_NAME, 1280, 800))
+  {
+    return 1;
+  }
+
+  // Default docking layout (only applied once, when no imgui.ini layout exists yet):
+  // "Map viewer" as a thin left strip, View/Maps/Travelling tabbed below it, and the 3D
+  // scene filling the remaining (background) area.
+  app.shell.setupDefaultLayout = [](unsigned int dockspaceId)
+  {
+    ImGuiID rightId = 0;
+    ImGuiID leftId  = ImGui::DockBuilderSplitNode(dockspaceId, ImGuiDir_Left, 0.28f, nullptr, &rightId);
+
+    ImGuiID leftBottomId = 0;
+    ImGuiID leftTopId =
+        ImGui::DockBuilderSplitNode(leftId, ImGuiDir_Up, 0.32f, nullptr, &leftBottomId);
+
+    ImGui::DockBuilderDockWindow("Map viewer", leftTopId);
+    ImGui::DockBuilderDockWindow("View", leftBottomId);
+    ImGui::DockBuilderDockWindow("Maps", leftBottomId);
+    ImGui::DockBuilderDockWindow("Travelling", leftBottomId);
+    ImGui::DockBuilderDockWindow("3D View", rightId);
+  };
+
+  // Background scene:
+  app.glGrid->setColor_u8(0xff, 0xff, 0xff, 0x10);
+  app.scene->insert(app.glGrid);
+
+  app.glMapCorner = mrpt::opengl::stock_objects::CornerXYZ(1.0f);
+  app.glMapCorner->setName("map");
+  app.glMapCorner->enableShowName();
+
+  app.glENUCorner = mrpt::opengl::stock_objects::CornerXYZ(2.0f);
+  app.glENUCorner->setName("ENU");
+  app.glENUCorner->enableShowName();
+  app.scene->insert(app.glENUCorner);
+
+  app.scene->insert(app.glVizMap);
+
+  app.sceneView.setScene(app.scene);
+  app.sceneView.onOverlayGui = &renderSceneOverlay;
+
+  app.sceneView.camera().setPointingAt(8.0f, 0.0f, 0.0f);
+  app.sceneView.camera().setAzimuthDegrees(110.0f);
+  app.sceneView.camera().setElevationDegrees(15.0f);
+  app.sceneView.camera().setZoomDistance(50.0f);
+
+  updateGuiAfterLoadingNewMap();
+  rebuildCamTravellingLabels();
+
+  // Load/save persistent UI+camera state across sessions (separate from imgui.ini, which
+  // only remembers panel docking):
+  char appCfgFile[1024];
+  ::get_user_config_file(appCfgFile, sizeof(appCfgFile), APP_NAME);
+  mrpt::config::CConfigFile appCfg(appCfgFile);
+
+  auto& cam = app.sceneView.camera();
+  app.applyGeoRef           = appCfg.read_bool("", "applyGeoRef", app.applyGeoRef);
+  app.viewOrtho             = appCfg.read_bool("", "viewOrtho", app.viewOrtho);
+  app.view2D                = appCfg.read_bool("", "view2D", app.view2D);
+  app.viewVoxelsAsPoints    = appCfg.read_bool("", "viewVoxelsAsPoints", app.viewVoxelsAsPoints);
+  app.viewVoxelsFreeSpace   = appCfg.read_bool("", "viewVoxelsFreeSpace", app.viewVoxelsFreeSpace);
+  app.colorizeMap           = appCfg.read_bool("", "colorizeMap", app.colorizeMap);
+  app.keepNativeCloudColors = appCfg.read_bool("", "keepNativeCloudColors", app.keepNativeCloudColors);
+  app.autoBBoxOutliers      = appCfg.read_bool("", "autoBBoxOutliers", app.autoBBoxOutliers);
+  app.showGroundGrid        = appCfg.read_bool("", "showGroundGrid", app.showGroundGrid);
+  app.depthLogScale         = appCfg.read_bool("", "depthLogScale", app.depthLogScale);
+
+  app.pointSize                  = appCfg.read_float("", "pointSize", app.pointSize);
+  app.autoBBoxOutliersPercentile = appCfg.read_float(
+      "", "autoBBoxOutliersPercentile", app.autoBBoxOutliersPercentile);
+  app.trajectoryThicknessLog = appCfg.read_float("", "trajectoryThicknessLog", app.trajectoryThicknessLog);
+  app.clipNear               = appCfg.read_float("", "clipNear", app.clipNear);
+  app.clipFar                = appCfg.read_float("", "clipFar", app.clipFar);
+  app.cameraFOV              = appCfg.read_float("", "cameraFOV", app.cameraFOV);
+
+  cam.setPointingAt(
+      appCfg.read_float("", "cam_x", cam.getPointingAtX()),
+      appCfg.read_float("", "cam_y", cam.getPointingAtY()),
+      appCfg.read_float("", "cam_z", cam.getPointingAtZ()));
+  cam.setAzimuthDegrees(appCfg.read_float("", "cam_az", cam.getAzimuthDegrees()));
+  cam.setElevationDegrees(appCfg.read_float("", "cam_el", cam.getElevationDegrees()));
+  cam.setZoomDistance(appCfg.read_float("", "cam_d", cam.getZoomDistance()));
+
+  app.shell.run(&renderFrame);
+
+  appCfg.write("", "applyGeoRef", app.applyGeoRef);
+  appCfg.write("", "viewOrtho", app.viewOrtho);
+  appCfg.write("", "view2D", app.view2D);
+  appCfg.write("", "viewVoxelsAsPoints", app.viewVoxelsAsPoints);
+  appCfg.write("", "viewVoxelsFreeSpace", app.viewVoxelsFreeSpace);
+  appCfg.write("", "colorizeMap", app.colorizeMap);
+  appCfg.write("", "keepNativeCloudColors", app.keepNativeCloudColors);
+  appCfg.write("", "autoBBoxOutliers", app.autoBBoxOutliers);
+  appCfg.write("", "showGroundGrid", app.showGroundGrid);
+  appCfg.write("", "depthLogScale", app.depthLogScale);
+
+  appCfg.write("", "pointSize", app.pointSize);
+  appCfg.write("", "autoBBoxOutliersPercentile", app.autoBBoxOutliersPercentile);
+  appCfg.write("", "trajectoryThicknessLog", app.trajectoryThicknessLog);
+  appCfg.write("", "clipNear", app.clipNear);
+  appCfg.write("", "clipFar", app.clipFar);
+  appCfg.write("", "cameraFOV", app.cameraFOV);
+
+  appCfg.write("", "cam_x", cam.getPointingAtX());
+  appCfg.write("", "cam_y", cam.getPointingAtY());
+  appCfg.write("", "cam_z", cam.getPointingAtZ());
+  appCfg.write("", "cam_az", cam.getAzimuthDegrees());
+  appCfg.write("", "cam_el", cam.getElevationDegrees());
+  appCfg.write("", "cam_d", cam.getZoomDistance());
+
+  app.shell.shutdown();
+  return 0;
 }
 
 }  // namespace
 
-// ==============================
-// rebuild_3d_view
-// ==============================
-void rebuild_3d_view(bool force_rebuild_view)
-{
-    using namespace std::string_literals;
-
-    lbMapStats[0]->setValue(theMapFileName);
-    lbMapStats[1]->setValue("Map: "s + theMap.contents_summary());
-
-    cbApplyGeoRef->setEnabled(theMap.georeferencing.has_value());
-
-    // 3D objects -------------------
-    std::optional<mrpt::math::TBoundingBoxf> mapBbox;
-
-    // the map:
-    mp2p_icp::render_params_t rpMap;
-
-    rpMap.points.visible = false;
-    for (const auto& [lyName, cb] : cbLayersByName)
-    {
-        // Update stats in the cb label:
-        cb->setCaption(lyName);  // default
-        if (auto itL = theMap.layers.find(lyName); itL != theMap.layers.end())
-        {
-            if (auto pc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itL->second); pc)
-            {
-                cb->setCaption(
-                    lyName + " | "s +
-                    mrpt::system::unitsFormat(static_cast<double>(pc->size()), 2, false) +
-                    " points"s + " | class="s + pc->GetRuntimeClass()->className);
-
-                const auto bb = pc->boundingBox();
-                if (!mapBbox.has_value())
-                {
-                    mapBbox = bb;
-                }
-                else
-                {
-                    mapBbox = mapBbox->unionWith(bb);
-                }
-            }
-            else
-            {
-                cb->setCaption(lyName + " | class="s + itL->second->GetRuntimeClass()->className);
-            }
-        }
-
-        // show/hide:
-        if (!cb->checked())
-        {
-            continue;  // hidden
-        }
-        rpMap.points.visible = true;
-
-        auto& rpL                       = rpMap.points.perLayer[lyName];
-        rpL.pointSize                   = slPointSize->value();
-        rpL.render_voxelmaps_as_points  = cbViewVoxelsAsPoints->checked();
-        rpL.render_voxelmaps_free_space = cbViewVoxelsFreeSpace->checked();
-
-        lbPointSize->setCaption("Point size: " + std::to_string(rpL.pointSize));
-
-        if (cbColorizeMap->checked())
-        {
-            auto& cm    = rpL.colorMode.emplace();
-            cm.colorMap = mrpt::typemeta::str2enum<mrpt::img::TColormap>(
-                cmbColorIntensity->items().at(cmbColorIntensity->selectedIndex()));
-
-            cm.recolorizeByField =
-                cmbRecolorizeByField->items().at(cmbRecolorizeByField->selectedIndex());
-
-            if (cbAutoBBoxOutliers->checked())
-            {
-                cm.autoBoundingBoxOutliersPercentile = slAutoBBoxOutliersPercentile->value();
-            }
-        }
-        if (cbKeepNativeCloudColors->checked())
-        {
-            auto& cm                     = rpL.colorMode.emplace();
-            cm.keep_original_cloud_color = true;
-            rpL.force_alpha_channel      = true;
-        }
-    }
-
-    // Default color:
-    for (auto& [layer, rp] : rpMap.points.perLayer)
-    {
-        rp.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0x80);
-    }
-
-    // Regenerate points opengl representation only if some parameter changed:
-    static std::optional<mp2p_icp::render_params_t> prevRenderParams;
-
-    if (!prevRenderParams.has_value() || prevRenderParams.value() != rpMap || force_rebuild_view)
-    {
-        prevRenderParams = rpMap;
-        glVizMap->clear();
-
-        auto glPts = theMap.get_visualization(rpMap);
-
-        // Show all or selected layers:
-        rpMap.points.allLayers.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0xff);
-
-        glVizMap->insert(glPts);
-        glVizMap->insert(glMapCorner);
-        glVizMap->insert(glTrajectory);
-        glVizMap->insert(glVizObjects);
-    }
-
-    // XY plane of the map: leave in the "map" frame or "enu" frame, whatever is the root,
-    // so no need to change pose of glGrid
-
-    if (cbApplyGeoRef->checked() && theMap.georeferencing.has_value())
-    {
-        glVizMap->setPose(theMap.georeferencing->T_enu_to_map.mean);
-        glENUCorner->setVisibility(true);
-    }
-    else
-    {
-        glVizMap->setPose(mrpt::poses::CPose3D::Identity());
-        glENUCorner->setVisibility(false);
-    }
-
-    // ground grid:
-    if (mapBbox)
-    {
-        glGrid->setPlaneLimits(mapBbox->min.x, mapBbox->max.x, mapBbox->min.y, mapBbox->max.y);
-
-        constexpr float MAX_GRID_LINES = 20.0f;
-
-        const auto bboxDiagonal = (mapBbox->max - mapBbox->min).cast<float>().norm();
-        glGrid->setGridFrequency(std::max<float>(1.0f, std::round(bboxDiagonal / MAX_GRID_LINES)));
-    }
-    glGrid->setVisibility(cbShowGroundGrid->checked());
-
-    // Fit view to map:
-    if (mapBbox && doFitView)
-    {
-        const auto midPt  = (mapBbox->min + mapBbox->max) * 0.5;
-        const auto mapLen = (mapBbox->max - mapBbox->min).norm();
-
-        win->camera().setCameraPointing(midPt.x, midPt.y, midPt.z);
-        win->camera().setZoomDistance(mapLen);
-    }
-    doFitView = false;
-
-    // glTrajectory:
-    if (glTrajectory->empty() && trajectory.size() >= 2)
-    {
-        const float trajectoryCylRadius = std::exp(slTrajectoryThickness->value());
-        lbTrajectoryThick->setCaption(
-            "Trajectory thickness: " + std::to_string(trajectoryCylRadius));
-
-        std::optional<mrpt::math::TPose3D> prevPose;
-        for (const auto& [t, p] : trajectory)
-        {
-            if (prevPose)
-            {
-                const auto& p0 = prevPose.value();
-
-                auto glSegment = mrpt::opengl::CArrow::Create();
-                glSegment->setArrowEnds(p0.translation(), p.translation());
-                glSegment->setHeadRatio(.0);
-                glSegment->setLargeRadius(trajectoryCylRadius);
-                glSegment->setSmallRadius(trajectoryCylRadius);
-                glSegment->setColor_u8(0x30, 0x30, 0x30, 0xff);
-
-                glTrajectory->insert(glSegment);
-            }
-            prevPose = p;
-        }
-    }
-
-    // glVizObjects
-    glVizObjects->clear();
-    for (auto& evl : extraVizLayers)
-    {
-        glVizObjects->insert(evl.glObjects);
-    }
-
-    // XYZ corner overlay viewports: one for "Map", another for "ENU"
-    if (!win->background_scene->getViewport(FIRST_MINI_VIEW_NAME))
-    {
-        auto gl_view = win->background_scene->createViewport(FIRST_MINI_VIEW_NAME);
-
-        gl_view->setViewportPosition(0, 0, 0.1, 0.1 * 16.0 / 9.0);
-        gl_view->setTransparent(true);
-        {
-            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("X");
-            obj->setLocation(1.1, 0, 0);
-            gl_view->insert(obj);
-        }
-        {
-            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Y");
-            obj->setLocation(0, 1.1, 0);
-            gl_view->insert(obj);
-        }
-        {
-            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Z");
-            obj->setLocation(0, 0, 1.1);
-            gl_view->insert(obj);
-        }
-        gl_view->insert(mrpt::opengl::stock_objects::CornerXYZ());
-    }
-    if (!win->background_scene->getViewport(SECOND_MINI_VIEW_NAME))
-    {
-        auto gl_view = win->background_scene->createViewport(SECOND_MINI_VIEW_NAME);
-
-        gl_view->setViewportPosition(0.1, 0, 0.1, 0.1 * 16.0 / 9.0);
-        gl_view->setTransparent(true);
-
-        auto glRoot = mrpt::opengl::CSetOfObjects::Create();
-        gl_view->insert(glRoot);
-
-        {
-            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("X");
-            obj->setLocation(1.1, 0, 0);
-            glRoot->insert(obj);
-        }
-        {
-            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Y");
-            obj->setLocation(0, 1.1, 0);
-            glRoot->insert(obj);
-        }
-        {
-            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Z");
-            obj->setLocation(0, 0, 1.1);
-            glRoot->insert(obj);
-        }
-        glRoot->insert(mrpt::opengl::stock_objects::CornerXYZ());
-    }
-
-    // Global view options:
-    {
-        std::lock_guard<std::mutex> lck(win->background_scene_mtx);
-        win->camera().setCameraProjective(!cbViewOrtho->checked() && !cbView2D->checked());
-
-        // Clip plane calculation is delegated to be done in the idle loop so it's refreshed as the
-        // user zooms/pans, etc. since the camera data is needed for the "linear" mode.
-        // See updateCameraClipDistances();
-    }
-}
-
-void onSaveLayers()
-{
-    const std::string outFile = nanogui::file_dialog({{"txt", "(*.txt)"}}, true /*save*/);
-    if (outFile.empty())
-    {
-        return;
-    }
-
-    for (const auto& [lyName, cb] : cbLayersByName)
-    {
-        if (auto itL = theMap.layers.find(lyName); itL != theMap.layers.end())
-        {
-            itL->second->saveMetricMapRepresentationToFile(outFile);
-        }
-    }
-}
-
-#else  // MRPT_HAS_NANOGUI
-static void main_show_gui()
-{
-    THROW_EXCEPTION(
-        "This application requires a version of MRPT built with nanogui "
-        "support.");
-}
-
-#endif  // MRPT_HAS_NANOGUI
-
 int main(int argc, char** argv)
 {
-    cmd.add_option("input", argMapFile, "Load this metric map file (*.mm)");
-    cmd.add_option(
-        "-l,--load-plugins", arg_plugins,
-        "One or more (comma separated) *.so files to load as plugins");
-    cmd.add_option(
-        "-t,--trajectory", arg_tumTrajectory,
-        "Also draw a trajectory, given by a TUM file trajectory.");
-    cmd.add_option(
-        "-s,--add-3d-scene", arg_add3dScenes,
-        "Adds an extra 3D scene file (*.3dscene) for visualization.");
-    cmd.add_option(
-        "-g,--georef-polygon", arg_georefPolygon,
-        "Overlay a polygon given by a text file with one \"lat,lon\" vertex (WGS84 degrees) per "
-        "line. Ignored if the loaded map has no georeferencing information.");
+  cmd.add_option("input", argMapFile, "Load this metric map file (*.mm)");
+  cmd.add_option(
+      "-l,--load-plugins", arg_plugins, "One or more (comma separated) *.so files to load as plugins");
+  cmd.add_option(
+      "-t,--trajectory", arg_tumTrajectory, "Also draw a trajectory, given by a TUM file trajectory.");
+  cmd.add_option(
+      "-s,--add-3d-scene", arg_add3dScenes, "Adds an extra 3D scene file (*.3dscene) for visualization.");
+  cmd.add_option(
+      "-g,--georef-polygon", arg_georefPolygon,
+      "Overlay a polygon given by a text file with one \"lat,lon\" vertex (WGS84 degrees) per "
+      "line. Ignored if the loaded map has no georeferencing information.");
 
-    CLI11_PARSE(cmd, argc, argv);
+  CLI11_PARSE(cmd, argc, argv);
 
-    try
+  try
+  {
+    if (!arg_plugins.empty())
     {
-        // Load plugins:
-        if (!arg_plugins.empty())
-        {
-            if (!load_plugins(arg_plugins))
-            {
-                return 1;
-            }
-        }
-
-        // load trajectory?
-        if (!arg_tumTrajectory.empty())
-        {
-            ASSERT_FILE_EXISTS_(arg_tumTrajectory);
-            bool trajectoryReadOk = trajectory.loadFromTextFile_TUM(arg_tumTrajectory);
-            ASSERT_(trajectoryReadOk);
-            std::cout << "Read trajectory with " << trajectory.size() << " keyframes.\n";
-        }
-
-        // load 3D files:
-        for (const auto& path : arg_add3dScenes)
-        {
-            ASSERT_FILE_EXISTS_(path);
-            auto scene  = mrpt::opengl::Scene::Create();
-            bool readOk = scene->loadFromFile(path);
-            ASSERT_(readOk);
-
-            ExtraVizLayer evl;
-            evl.fileName  = mrpt::system::extractFileName(path);
-            evl.glObjects = mrpt::opengl::CSetOfObjects::Create();
-            evl.glObjects->setName(evl.fileName);
-
-            // Move all objects from the loaded scene into our set
-            for (const auto& obj : *scene->getViewport())
-            {
-                evl.glObjects->insert(obj);
-            }
-
-            extraVizLayers.push_back(evl);
-        }
-
-        main_show_gui();
-
-        // Clean up OpenGL objects before closing the window:
-        glVizMap.reset();
-        glGrid.reset();
-        glENUCorner.reset();
-        glMapCorner.reset();
-        glTrajectory.reset();
-        // then, the window:
-        win.reset();
-
-        return 0;
-    }
-    catch (std::exception& e)
-    {
-        std::cerr << "Exit due to exception:\n" << mrpt::exception_to_str(e) << std::endl;
+      if (!load_plugins(arg_plugins))
+      {
         return 1;
+      }
     }
+
+    if (!arg_tumTrajectory.empty())
+    {
+      ASSERT_FILE_EXISTS_(arg_tumTrajectory);
+      const bool trajectoryReadOk = app.trajectory.loadFromTextFile_TUM(arg_tumTrajectory);
+      ASSERT_(trajectoryReadOk);
+      std::cout << "Read trajectory with " << app.trajectory.size() << " keyframes.\n";
+    }
+
+    for (const auto& path : arg_add3dScenes)
+    {
+      ASSERT_FILE_EXISTS_(path);
+      auto scene  = mrpt::opengl::Scene::Create();
+      bool readOk = scene->loadFromFile(path);
+      ASSERT_(readOk);
+
+      ExtraVizLayer evl;
+      evl.fileName  = mrpt::system::extractFileName(path);
+      evl.glObjects = mrpt::opengl::CSetOfObjects::Create();
+      evl.glObjects->setName(evl.fileName);
+
+      for (const auto& obj : *scene->getViewport())
+      {
+        evl.glObjects->insert(obj);
+      }
+
+      app.extraVizLayers.push_back(evl);
+    }
+
+    return mainShowGui();
+  }
+  catch (std::exception& e)
+  {
+    std::cerr << "Exit due to exception:\n" << mrpt::exception_to_str(e) << std::endl;
+    return 1;
+  }
 }

--- a/mp2p_icp_viz/apps/mm-viewer/main.cpp
+++ b/mp2p_icp_viz/apps/mm-viewer/main.cpp
@@ -17,6 +17,12 @@
 #include <mrpt/imgui/CImGuiSceneView.h>
 
 // other deps:
+#include <GLFW/glfw3.h>
+#include <imgui.h>
+#include <imgui_app_common/ImGuiAppShell.h>
+#include <imgui_app_common/SimpleFileDialog.h>
+#include <imgui_internal.h>  // DockBuilder* API (default docking layout)
+#include <imgui_stdlib.h>  // ImGui::InputText(std::string*)
 #include <mp2p_icp/pointcloud_sanity_check.h>
 #include <mrpt/config.h>
 #include <mrpt/config/CConfigFile.h>
@@ -38,14 +44,6 @@
 #include <mrpt/system/string_utils.h>  // unitsFormat()
 #include <mrpt/topography/conversions.h>
 #include <mrpt/version.h>
-
-#include <imgui.h>
-#include <imgui_app_common/ImGuiAppShell.h>
-#include <imgui_app_common/SimpleFileDialog.h>
-#include <imgui_internal.h>  // DockBuilder* API (default docking layout)
-#include <imgui_stdlib.h>  // ImGui::InputText(std::string*)
-
-#include <GLFW/glfw3.h>
 
 #include <CLI/CLI.hpp>
 #include <cmath>
@@ -72,7 +70,7 @@ constexpr const char* SECOND_MINI_VIEW_NAME = "small-view-2";
 
 const char* const kColorIntensityNames[]  = {"cmNONE", "cmHOT", "cmJET", "cmGRAYSCALE"};
 const char* const kColorIntensityLabels[] = {"None", "Hot", "Jet", "Grayscale"};
-constexpr int      kNumColorIntensity     = 4;
+constexpr int     kNumColorIntensity      = 4;
 
 // =========== Declare supported cli switches ===========
 CLI::App cmd{APP_NAME};
@@ -86,9 +84,9 @@ std::string              arg_georefPolygon;
 /** Extra viz layer loaded from a *.3dscene file, or from --georef-polygon. */
 struct ExtraVizLayer
 {
-  std::string                      fileName;
-  mrpt::opengl::CSetOfObjects::Ptr glObjects;
-  bool                             visible = true;
+    std::string                      fileName;
+    mrpt::opengl::CSetOfObjects::Ptr glObjects;
+    bool                             visible = true;
 };
 
 /** All mutable application state, replacing the individual nanogui widget
@@ -96,79 +94,79 @@ struct ExtraVizLayer
  *  an immediate-mode GUI: widgets read/write these each frame). */
 struct AppState
 {
-  mp2p_icp_viz::ImGuiAppShell  shell;
-  mrpt::imgui::CImGuiSceneView sceneView;
-  mrpt::opengl::Scene::Ptr     scene = mrpt::opengl::COpenGLScene::Create();
+    mp2p_icp_viz::ImGuiAppShell  shell;
+    mrpt::imgui::CImGuiSceneView sceneView;
+    mrpt::opengl::Scene::Ptr     scene = mrpt::opengl::COpenGLScene::Create();
 
-  mrpt::opengl::CSetOfObjects::Ptr glVizMap     = mrpt::opengl::CSetOfObjects::Create();
-  mrpt::opengl::CGridPlaneXY::Ptr  glGrid       = mrpt::opengl::CGridPlaneXY::Create();
-  mrpt::opengl::CSetOfObjects::Ptr glENUCorner;
-  mrpt::opengl::CSetOfObjects::Ptr glMapCorner;
-  mrpt::opengl::CSetOfObjects::Ptr glTrajectory = mrpt::opengl::CSetOfObjects::Create();
-  mrpt::opengl::CSetOfObjects::Ptr glVizObjects = mrpt::opengl::CSetOfObjects::Create();
+    mrpt::opengl::CSetOfObjects::Ptr glVizMap = mrpt::opengl::CSetOfObjects::Create();
+    mrpt::opengl::CGridPlaneXY::Ptr  glGrid   = mrpt::opengl::CGridPlaneXY::Create();
+    mrpt::opengl::CSetOfObjects::Ptr glENUCorner;
+    mrpt::opengl::CSetOfObjects::Ptr glMapCorner;
+    mrpt::opengl::CSetOfObjects::Ptr glTrajectory = mrpt::opengl::CSetOfObjects::Create();
+    mrpt::opengl::CSetOfObjects::Ptr glVizObjects = mrpt::opengl::CSetOfObjects::Create();
 
-  mp2p_icp::metric_map_t theMap;
-  std::string            theMapFileName = "unnamed.mm";
+    mp2p_icp::metric_map_t theMap;
+    std::string            theMapFileName = "unnamed.mm";
 
-  std::vector<std::string>    layerNames;
-  std::vector<std::string>    knownPointFields;
-  std::map<std::string, bool> layerVisible;
+    std::vector<std::string>    layerNames;
+    std::vector<std::string>    knownPointFields;
+    std::map<std::string, bool> layerVisible;
 
-  std::vector<ExtraVizLayer> extraVizLayers;
+    std::vector<ExtraVizLayer> extraVizLayers;
 
-  mrpt::poses::CPose3DInterpolator trajectory;
+    mrpt::poses::CPose3DInterpolator trajectory;
 
-  // Camera travelling:
-  mrpt::poses::CPose3DInterpolator camTravelling;
-  std::optional<double>            camTravellingCurrentTime;
-  std::vector<std::string>         camTravellingLabels;
-  float                            animFPS             = 30.0f;
-  float                            animProgress        = 0.0f;
-  int                              travellingInterpIdx = 0;  // 0=Linear, 1=Spline
-  float                            newKeyframeTime      = 0.0f;
+    // Camera travelling:
+    mrpt::poses::CPose3DInterpolator camTravelling;
+    std::optional<double>            camTravellingCurrentTime;
+    std::vector<std::string>         camTravellingLabels;
+    float                            animFPS             = 30.0f;
+    float                            animProgress        = 0.0f;
+    int                              travellingInterpIdx = 0;  // 0=Linear, 1=Spline
+    float                            newKeyframeTime     = 0.0f;
 
-  // View options (mirrors the old nanogui side panel):
-  bool  applyGeoRef                = false;
-  bool  viewOrtho                  = false;
-  bool  view2D                     = false;
-  bool  viewVoxelsAsPoints         = false;
-  bool  viewVoxelsFreeSpace        = false;
-  bool  colorizeMap                = true;
-  bool  keepNativeCloudColors      = false;
-  bool  autoBBoxOutliers           = true;
-  float autoBBoxOutliersPercentile = 0.025f;
-  bool  showGroundGrid             = true;
-  bool  depthLogScale              = true;
-  float pointSize                  = 2.0f;
-  float trajectoryThicknessLog     = std::log(0.05f);
-  float clipNear                   = 0.1f;
-  float clipFar                    = 4.0f;
-  float cameraFOV                  = 90.0f;
+    // View options (mirrors the old nanogui side panel):
+    bool  applyGeoRef                = false;
+    bool  viewOrtho                  = false;
+    bool  view2D                     = false;
+    bool  viewVoxelsAsPoints         = false;
+    bool  viewVoxelsFreeSpace        = false;
+    bool  colorizeMap                = true;
+    bool  keepNativeCloudColors      = false;
+    bool  autoBBoxOutliers           = true;
+    float autoBBoxOutliersPercentile = 0.025f;
+    bool  showGroundGrid             = true;
+    bool  depthLogScale              = true;
+    float pointSize                  = 2.0f;
+    float trajectoryThicknessLog     = std::log(0.05f);
+    float clipNear                   = 0.1f;
+    float clipFar                    = 4.0f;
+    float cameraFOV                  = 90.0f;
 
-  int recolorizeByFieldIdx = 0;
-  int colorIntensityIdx    = 2;  // cmJET
-  int mouseUnitsIdx        = 0;  // map / enu / lat-lon
+    int recolorizeByFieldIdx = 0;
+    int colorIntensityIdx    = 2;  // cmJET
+    int mouseUnitsIdx        = 0;  // map / enu / lat-lon
 
-  bool doFitView = false;
+    bool doFitView = false;
 
-  std::string mouseCoordText = "Mouse pointing to: -";
-  std::string cameraLookText = "Camera looking at: -";
+    std::string mouseCoordText = "Mouse pointing to: -";
+    std::string cameraLookText = "Camera looking at: -";
 
-  mp2p_icp_viz::SimpleFileDialog openDialog;
-  mp2p_icp_viz::SimpleFileDialog exportDialog;
+    mp2p_icp_viz::SimpleFileDialog openDialog;
+    mp2p_icp_viz::SimpleFileDialog exportDialog;
 };
 
 AppState app;
 
 bool load_plugins(const std::string& plugins)
 {
-  std::string errMsg;
-  if (!mrpt::system::loadPluginModules(plugins, errMsg))
-  {
-    std::cerr << errMsg << std::endl;
-    return false;
-  }
-  return true;
+    std::string errMsg;
+    if (!mrpt::system::loadPluginModules(plugins, errMsg))
+    {
+        std::cerr << errMsg << std::endl;
+        return false;
+    }
+    return true;
 }
 
 /** Reads a text file with one "lat,lon" (WGS84 degrees) vertex per line
@@ -177,44 +175,44 @@ bool load_plugins(const std::string& plugins)
  */
 std::vector<mrpt::math::TPoint2D> readLatLonPolygonFile(const std::string& filePath)
 {
-  std::vector<mrpt::math::TPoint2D> latLonPoints;
+    std::vector<mrpt::math::TPoint2D> latLonPoints;
 
-  std::ifstream f(filePath);
-  ASSERTMSG_(
-      f.is_open(), mrpt::format("Cannot open georef polygon file: '%s'", filePath.c_str()));
+    std::ifstream f(filePath);
+    ASSERTMSG_(
+        f.is_open(), mrpt::format("Cannot open georef polygon file: '%s'", filePath.c_str()));
 
-  std::string line;
-  while (std::getline(f, line))
-  {
-    for (char& c : line)
+    std::string line;
+    while (std::getline(f, line))
     {
-      if (c == ',')
-      {
-        c = ' ';
-      }
+        for (char& c : line)
+        {
+            if (c == ',')
+            {
+                c = ' ';
+            }
+        }
+
+        std::istringstream iss(line);
+        std::string        firstTok;
+        if (!(iss >> firstTok) || firstTok.empty() || firstTok[0] == '#')
+        {
+            continue;  // blank or comment line
+        }
+
+        double lat = 0;
+        double lon = 0;
+        std::istringstream(firstTok) >> lat;
+        if (!(iss >> lon))
+        {
+            std::cerr << "Warning: malformed line in georef polygon file, skipping: \"" << line
+                      << "\"\n";
+            continue;
+        }
+
+        latLonPoints.emplace_back(lat, lon);
     }
 
-    std::istringstream iss(line);
-    std::string        firstTok;
-    if (!(iss >> firstTok) || firstTok.empty() || firstTok[0] == '#')
-    {
-      continue;  // blank or comment line
-    }
-
-    double lat = 0;
-    double lon = 0;
-    std::istringstream(firstTok) >> lat;
-    if (!(iss >> lon))
-    {
-      std::cerr << "Warning: malformed line in georef polygon file, skipping: \"" << line
-                 << "\"\n";
-      continue;
-    }
-
-    latLonPoints.emplace_back(lat, lon);
-  }
-
-  return latLonPoints;
+    return latLonPoints;
 }
 
 /** Builds a closed polygon outline, in the metric map's local ("map") frame,
@@ -225,349 +223,350 @@ mrpt::opengl::CSetOfObjects::Ptr buildGeorefPolygonLayer(
     const std::vector<mrpt::math::TPoint2D>&      latLonPoints,
     const mp2p_icp::metric_map_t::Georeferencing& georef)
 {
-  auto glLayer = mrpt::opengl::CSetOfObjects::Create();
+    auto glLayer = mrpt::opengl::CSetOfObjects::Create();
 
-  std::vector<mrpt::math::TPoint3D> mapPoints;
-  mapPoints.reserve(latLonPoints.size());
-  for (const auto& ll : latLonPoints)
-  {
-    const mrpt::topography::TGeodeticCoords geodeticPt(
-        ll.x /*lat*/, ll.y /*lon*/, georef.geo_coord.height);
-
-    mrpt::math::TPoint3D enuPt;
-    mrpt::topography::geodeticToENU_WGS84(geodeticPt, enuPt, georef.geo_coord);
-
-    mapPoints.push_back(georef.T_enu_to_map.mean.inverseComposePoint(enuPt));
-  }
-
-  if (mapPoints.size() >= 2)
-  {
-    auto glLines = mrpt::opengl::CSetOfLines::Create();
-    glLines->setColor_u8(0xff, 0xd0, 0x00, 0xff);
-    glLines->setLineWidth(3.0f);
-
-    for (size_t i = 0; i < mapPoints.size(); i++)
+    std::vector<mrpt::math::TPoint3D> mapPoints;
+    mapPoints.reserve(latLonPoints.size());
+    for (const auto& ll : latLonPoints)
     {
-      const auto& p0 = mapPoints[i];
-      const auto& p1 = mapPoints[(i + 1) % mapPoints.size()];
-      glLines->appendLine(p0, p1);
-    }
-    glLayer->insert(glLines);
-  }
+        const mrpt::topography::TGeodeticCoords geodeticPt(
+            ll.x /*lat*/, ll.y /*lon*/, georef.geo_coord.height);
 
-  return glLayer;
+        mrpt::math::TPoint3D enuPt;
+        mrpt::topography::geodeticToENU_WGS84(geodeticPt, enuPt, georef.geo_coord);
+
+        mapPoints.push_back(georef.T_enu_to_map.mean.inverseComposePoint(enuPt));
+    }
+
+    if (mapPoints.size() >= 2)
+    {
+        auto glLines = mrpt::opengl::CSetOfLines::Create();
+        glLines->setColor_u8(0xff, 0xd0, 0x00, 0xff);
+        glLines->setLineWidth(3.0f);
+
+        for (size_t i = 0; i < mapPoints.size(); i++)
+        {
+            const auto& p0 = mapPoints[i];
+            const auto& p1 = mapPoints[(i + 1) % mapPoints.size()];
+            glLines->appendLine(p0, p1);
+        }
+        glLayer->insert(glLines);
+    }
+
+    return glLayer;
 }
 
 void rebuildCamTravellingLabels()
 {
-  app.camTravellingLabels.clear();
-  for (size_t i = 0; i < app.camTravelling.size(); i++)
-  {
-    auto it = app.camTravelling.begin();
-    std::advance(it, static_cast<std::ptrdiff_t>(i));
+    app.camTravellingLabels.clear();
+    for (size_t i = 0; i < app.camTravelling.size(); i++)
+    {
+        auto it = app.camTravelling.begin();
+        std::advance(it, static_cast<std::ptrdiff_t>(i));
 
-    app.camTravellingLabels.push_back(mrpt::format(
-        "[%02u] t=%.02fs pose=%s", static_cast<unsigned int>(i),
-        mrpt::Clock::toDouble(it->first), it->second.asString().c_str()));
-  }
+        app.camTravellingLabels.push_back(mrpt::format(
+            "[%02u] t=%.02fs pose=%s", static_cast<unsigned int>(i),
+            mrpt::Clock::toDouble(it->first), it->second.asString().c_str()));
+    }
 }
 
 bool loadMapFile(const std::string& mapFile)
 {
-  std::cout << "Loading map file: " << mapFile << std::endl;
+    std::cout << "Loading map file: " << mapFile << std::endl;
 
-  app.theMap = mp2p_icp::metric_map_t();  // reset
+    app.theMap = mp2p_icp::metric_map_t();  // reset
 
-  if (mrpt::system::extractFileExtension(mapFile) == "bin")
-  {
-    try
+    if (mrpt::system::extractFileExtension(mapFile) == "bin")
     {
-      mrpt::io::CCompressedInputStream        f(mapFile);
-      auto                                    arch = mrpt::serialization::archiveFrom(f);
-      mrpt::serialization::CSerializable::Ptr obj  = arch.ReadObject();
-      auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(obj);
-      if (!pts)
-      {
-        std::cerr << "Error: .bin file did not deserialize to a CPointsMap-derived object"
-                   << (obj ? std::string(" (got: ") + obj->GetRuntimeClass()->className + ")"
-                           : std::string(" (null object)"))
-                   << std::endl;
-        return false;
-      }
-      const std::string layerName  = mrpt::system::extractFileName(mapFile);
-      app.theMap.layers[layerName] = pts;
-    }
-    catch (const std::exception& e)
-    {
-      std::cerr << "Error loading .bin file: " << e.what() << std::endl;
-      return false;
-    }
-  }
-  else
-  {
-    std::string loadErrorMsg;
-
-    if (!app.theMap.load_from_file(mapFile, loadErrorMsg))
-    {
-      bool retry_was_successful = false;
-
-      if (loadErrorMsg.find("which is not registered") != std::string::npos &&
-          arg_plugins.empty())
-      {
-        std::cout << "The map file requires plugins for missing C++ classes.\n"
-                     "Trying to load 'libmola_metric_maps.so' and retrying.\n"
-                     "Note that you can directly use '-l libmola_metric_maps.so' or any other "
-                     "custom plugin next time.\n";
-
-        if (!load_plugins("libmola_metric_maps.so"))
+        try
         {
-          return false;
+            mrpt::io::CCompressedInputStream        f(mapFile);
+            auto                                    arch = mrpt::serialization::archiveFrom(f);
+            mrpt::serialization::CSerializable::Ptr obj  = arch.ReadObject();
+            auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(obj);
+            if (!pts)
+            {
+                std::cerr << "Error: .bin file did not deserialize to a CPointsMap-derived object"
+                          << (obj ? std::string(" (got: ") + obj->GetRuntimeClass()->className + ")"
+                                  : std::string(" (null object)"))
+                          << std::endl;
+                return false;
+            }
+            const std::string layerName  = mrpt::system::extractFileName(mapFile);
+            app.theMap.layers[layerName] = pts;
         }
-        retry_was_successful = app.theMap.load_from_file(mapFile, loadErrorMsg);
-      }
-
-      if (!retry_was_successful)
-      {
-        std::cerr << "Error loading metric map from file!:\n" << loadErrorMsg << std::endl;
-        return false;
-      }
+        catch (const std::exception& e)
+        {
+            std::cerr << "Error loading .bin file: " << e.what() << std::endl;
+            return false;
+        }
     }
-  }
+    else
+    {
+        std::string loadErrorMsg;
 
-  app.theMapFileName = mapFile;
+        if (!app.theMap.load_from_file(mapFile, loadErrorMsg))
+        {
+            bool retry_was_successful = false;
 
-  std::cout << "Loaded map: " << app.theMap.contents_summary() << std::endl;
+            if (loadErrorMsg.find("which is not registered") != std::string::npos &&
+                arg_plugins.empty())
+            {
+                std::cout
+                    << "The map file requires plugins for missing C++ classes.\n"
+                       "Trying to load 'libmola_metric_maps.so' and retrying.\n"
+                       "Note that you can directly use '-l libmola_metric_maps.so' or any other "
+                       "custom plugin next time.\n";
 
-  app.layerNames.clear();
-  for (const auto& [name, map] : app.theMap.layers)
-  {
-    app.layerNames.push_back(name);
-  }
+                if (!load_plugins("libmola_metric_maps.so"))
+                {
+                    return false;
+                }
+                retry_was_successful = app.theMap.load_from_file(mapFile, loadErrorMsg);
+            }
 
-  // Find point cloud field names:
-  {
-    std::set<std::string> fields;
-    fields.insert("x");
-    fields.insert("y");
-    fields.insert("z");
+            if (!retry_was_successful)
+            {
+                std::cerr << "Error loading metric map from file!:\n" << loadErrorMsg << std::endl;
+                return false;
+            }
+        }
+    }
 
+    app.theMapFileName = mapFile;
+
+    std::cout << "Loaded map: " << app.theMap.contents_summary() << std::endl;
+
+    app.layerNames.clear();
     for (const auto& [name, map] : app.theMap.layers)
     {
-      auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(map);
-      if (!pts)
-      {
-        continue;
-      }
-      for (const auto& f : pts->getPointFieldNames_float())
-      {
-        fields.insert(std::string(f));
-      }
-      for (const auto& f : pts->getPointFieldNames_uint16())
-      {
-        fields.insert(std::string(f));
-      }
+        app.layerNames.push_back(name);
+    }
+
+    // Find point cloud field names:
+    {
+        std::set<std::string> fields;
+        fields.insert("x");
+        fields.insert("y");
+        fields.insert("z");
+
+        for (const auto& [name, map] : app.theMap.layers)
+        {
+            auto pts = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(map);
+            if (!pts)
+            {
+                continue;
+            }
+            for (const auto& f : pts->getPointFieldNames_float())
+            {
+                fields.insert(std::string(f));
+            }
+            for (const auto& f : pts->getPointFieldNames_uint16())
+            {
+                fields.insert(std::string(f));
+            }
 #if MRPT_VERSION >= 0x020f03  // 2.15.3
-      for (const auto& f : pts->getPointFieldNames_double())
-      {
-        fields.insert(std::string(f));
-      }
-      for (const auto& f : pts->getPointFieldNames_uint8())
-      {
-        fields.insert(std::string(f));
-      }
+            for (const auto& f : pts->getPointFieldNames_double())
+            {
+                fields.insert(std::string(f));
+            }
+            for (const auto& f : pts->getPointFieldNames_uint8())
+            {
+                fields.insert(std::string(f));
+            }
 #endif
+        }
+
+        if (fields.count("color_r") && fields.count("color_g") && fields.count("color_b"))
+        {
+            fields.erase("color_r");
+            fields.erase("color_g");
+            fields.erase("color_b");
+            fields.insert("rgb");
+        }
+        if (fields.count("color_rf") && fields.count("color_gf") && fields.count("color_bf"))
+        {
+            fields.erase("color_rf");
+            fields.erase("color_gf");
+            fields.erase("color_bf");
+            fields.insert("rgbf");
+        }
+
+        app.knownPointFields.clear();
+        for (const auto& f : fields)
+        {
+            app.knownPointFields.push_back(f);
+        }
     }
 
-    if (fields.count("color_r") && fields.count("color_g") && fields.count("color_b"))
+    // sanity checks:
+    for (const auto& [name, map] : app.theMap.layers)
     {
-      fields.erase("color_r");
-      fields.erase("color_g");
-      fields.erase("color_b");
-      fields.insert("rgb");
-    }
-    if (fields.count("color_rf") && fields.count("color_gf") && fields.count("color_bf"))
-    {
-      fields.erase("color_rf");
-      fields.erase("color_gf");
-      fields.erase("color_bf");
-      fields.insert("rgbf");
+        const auto* pc = mp2p_icp::MapToPointsMap(*map);
+        if (!pc)
+        {
+            continue;  // not a point map
+        }
+        const bool sanityPassed = mp2p_icp::pointcloud_sanity_check(*pc);
+        ASSERTMSG_(
+            sanityPassed, mrpt::format("sanity check did not pass for layer: '%s'", name.c_str()));
     }
 
-    app.knownPointFields.clear();
-    for (const auto& f : fields)
-    {
-      app.knownPointFields.push_back(f);
-    }
-  }
-
-  // sanity checks:
-  for (const auto& [name, map] : app.theMap.layers)
-  {
-    const auto* pc = mp2p_icp::MapToPointsMap(*map);
-    if (!pc)
-    {
-      continue;  // not a point map
-    }
-    const bool sanityPassed = mp2p_icp::pointcloud_sanity_check(*pc);
-    ASSERTMSG_(
-        sanityPassed, mrpt::format("sanity check did not pass for layer: '%s'", name.c_str()));
-  }
-
-  return true;
+    return true;
 }
 
 /** Transform to show in the selected frame of reference and units: "map", "enu", or "lat/lon" */
 std::string transformAndFormatSelectedPoint(const mrpt::math::TPoint3D& pt)
 {
-  const bool hasGeoref = app.theMap.georeferencing.has_value();
-  const bool ptIsENU   = hasGeoref && app.applyGeoRef;
-  const int  idx       = hasGeoref ? app.mouseUnitsIdx : 0;
+    const bool hasGeoref = app.theMap.georeferencing.has_value();
+    const bool ptIsENU   = hasGeoref && app.applyGeoRef;
+    const int  idx       = hasGeoref ? app.mouseUnitsIdx : 0;
 
-  switch (idx)
-  {
-    case 0:  // show in map
+    switch (idx)
     {
-      mrpt::math::TPoint3D ptViz;
-      if (ptIsENU)
-      {
-        ptViz = app.theMap.georeferencing->T_enu_to_map.mean.inverseComposePoint(pt);
-      }
-      else
-      {
-        ptViz = pt;
-      }
-      return mrpt::format("X=%6.03f Y=%6.03f Z=%6.03f", ptViz.x, ptViz.y, ptViz.z);
-    }
-    case 1:  // show in enu
-      return mrpt::format("X=%6.03f Y=%6.03f Z=%6.03f", pt.x, pt.y, pt.z);
-    case 2:  // show as lat/lon
-    {
-      try
-      {
-        mrpt::topography::TGeocentricCoords geocentricPt;
-        mrpt::topography::ENUToGeocentric(
-            pt, app.theMap.georeferencing->geo_coord, geocentricPt,
-            mrpt::topography::TEllipsoid::Ellipsoid_WGS84());
+        case 0:  // show in map
+        {
+            mrpt::math::TPoint3D ptViz;
+            if (ptIsENU)
+            {
+                ptViz = app.theMap.georeferencing->T_enu_to_map.mean.inverseComposePoint(pt);
+            }
+            else
+            {
+                ptViz = pt;
+            }
+            return mrpt::format("X=%6.03f Y=%6.03f Z=%6.03f", ptViz.x, ptViz.y, ptViz.z);
+        }
+        case 1:  // show in enu
+            return mrpt::format("X=%6.03f Y=%6.03f Z=%6.03f", pt.x, pt.y, pt.z);
+        case 2:  // show as lat/lon
+        {
+            try
+            {
+                mrpt::topography::TGeocentricCoords geocentricPt;
+                mrpt::topography::ENUToGeocentric(
+                    pt, app.theMap.georeferencing->geo_coord, geocentricPt,
+                    mrpt::topography::TEllipsoid::Ellipsoid_WGS84());
 
-        mrpt::topography::TGeodeticCoords outCoords;
-        mrpt::topography::geocentricToGeodetic(geocentricPt, outCoords);
+                mrpt::topography::TGeodeticCoords outCoords;
+                mrpt::topography::geocentricToGeodetic(geocentricPt, outCoords);
 
-        return mrpt::format(
-            "%.06f, %.06f, h=%.03f", outCoords.lat.getDecimalValue(),
-            outCoords.lon.getDecimalValue(), outCoords.height);
-      }
-      catch (const std::exception& e)
-      {
-        std::cerr << "[transformAndFormatSelectedPoint] " << e.what() << "\n";
-        return {};
-      }
+                return mrpt::format(
+                    "%.06f, %.06f, h=%.03f", outCoords.lat.getDecimalValue(),
+                    outCoords.lon.getDecimalValue(), outCoords.height);
+            }
+            catch (const std::exception& e)
+            {
+                std::cerr << "[transformAndFormatSelectedPoint] " << e.what() << "\n";
+                return {};
+            }
+        }
+        default:
+            return {};
     }
-    default:
-      return {};
-  }
 }
 
 void updateCameraLookCoordinates()
 {
-  const auto& cam = app.sceneView.camera();
-  const mrpt::math::TPoint3D pt(cam.getPointingAtX(), cam.getPointingAtY(), cam.getPointingAtZ());
-  app.cameraLookText = "Camera looking at: " + transformAndFormatSelectedPoint(pt);
+    const auto&                cam = app.sceneView.camera();
+    const mrpt::math::TPoint3D pt(cam.getPointingAtX(), cam.getPointingAtY(), cam.getPointingAtZ());
+    app.cameraLookText = "Camera looking at: " + transformAndFormatSelectedPoint(pt);
 }
 
 /** Wired as `sceneView.onOverlayGui`: runs right after the 3-D canvas is drawn, while it is
  * still the last ImGui item, so `ImGui::IsItemHovered()`/`GetItemRect*()` refer to it. */
 void renderSceneOverlay()
 {
-  updateCameraLookCoordinates();
+    updateCameraLookCoordinates();
 
-  const bool   hovered  = ImGui::IsItemHovered();
-  const ImVec2 rectMin  = ImGui::GetItemRectMin();
-  const ImVec2 rectSize = ImGui::GetItemRectSize();
+    const bool   hovered  = ImGui::IsItemHovered();
+    const ImVec2 rectMin  = ImGui::GetItemRectMin();
+    const ImVec2 rectSize = ImGui::GetItemRectSize();
 
-  if (!hovered)
-  {
-    app.mouseCoordText = "Mouse pointing to: -";
-    return;
-  }
+    if (!hovered)
+    {
+        app.mouseCoordText = "Mouse pointing to: -";
+        return;
+    }
 
-  const ImVec2 mouse  = ImGui::GetMousePos();
-  const double localX = static_cast<double>(mouse.x - rectMin.x);
-  const double localY = static_cast<double>(mouse.y - rectMin.y);
-  if (localX < 0 || localY < 0 || localX >= rectSize.x || localY >= rectSize.y)
-  {
-    app.mouseCoordText = "Mouse pointing to: -";
-    return;
-  }
+    const ImVec2 mouse  = ImGui::GetMousePos();
+    const double localX = static_cast<double>(mouse.x - rectMin.x);
+    const double localY = static_cast<double>(mouse.y - rectMin.y);
+    if (localX < 0 || localY < 0 || localX >= rectSize.x || localY >= rectSize.y)
+    {
+        app.mouseCoordText = "Mouse pointing to: -";
+        return;
+    }
 
-  mrpt::math::TLine3D mouseRay;
-  app.scene->getViewport("main")->get3DRayForPixelCoord(localX, localY, mouseRay);
+    mrpt::math::TLine3D mouseRay;
+    app.scene->getViewport("main")->get3DRayForPixelCoord(localX, localY, mouseRay);
 
-  using mrpt::math::TPoint3D;
-  const mrpt::math::TPlane groundPlane(TPoint3D(0, 0, 0), TPoint3D(1, 0, 0), TPoint3D(0, 1, 0));
-  mrpt::math::TObject3D    inters;
-  mrpt::math::intersect(mouseRay, groundPlane, inters);
-  mrpt::math::TPoint3D intersPt;
-  if (inters.getPoint(intersPt))
-  {
-    app.mouseCoordText = "Mouse pointing to: " + transformAndFormatSelectedPoint(intersPt);
-  }
+    using mrpt::math::TPoint3D;
+    const mrpt::math::TPlane groundPlane(TPoint3D(0, 0, 0), TPoint3D(1, 0, 0), TPoint3D(0, 1, 0));
+    mrpt::math::TObject3D    inters;
+    mrpt::math::intersect(mouseRay, groundPlane, inters);
+    mrpt::math::TPoint3D intersPt;
+    if (inters.getPoint(intersPt))
+    {
+        app.mouseCoordText = "Mouse pointing to: " + transformAndFormatSelectedPoint(intersPt);
+    }
 }
 
 /** Creates the "Map frame"/"ENU frame" axis-corner gizmo viewports once. See the comment next to
  * FIRST_MINI_VIEW_NAME/SECOND_MINI_VIEW_NAME above: not currently rendered under MRPT 2.x. */
 void ensureMiniCornerViewports()
 {
-  if (!app.scene->getViewport(FIRST_MINI_VIEW_NAME))
-  {
-    auto gl_view = app.scene->createViewport(FIRST_MINI_VIEW_NAME);
+    if (!app.scene->getViewport(FIRST_MINI_VIEW_NAME))
+    {
+        auto gl_view = app.scene->createViewport(FIRST_MINI_VIEW_NAME);
 
-    gl_view->setViewportPosition(0, 0, 0.1, 0.1 * 16.0 / 9.0);
-    gl_view->setTransparent(true);
-    {
-      mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("X");
-      obj->setLocation(1.1, 0, 0);
-      gl_view->insert(obj);
+        gl_view->setViewportPosition(0, 0, 0.1, 0.1 * 16.0 / 9.0);
+        gl_view->setTransparent(true);
+        {
+            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("X");
+            obj->setLocation(1.1, 0, 0);
+            gl_view->insert(obj);
+        }
+        {
+            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Y");
+            obj->setLocation(0, 1.1, 0);
+            gl_view->insert(obj);
+        }
+        {
+            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Z");
+            obj->setLocation(0, 0, 1.1);
+            gl_view->insert(obj);
+        }
+        gl_view->insert(mrpt::opengl::stock_objects::CornerXYZ());
     }
-    {
-      mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Y");
-      obj->setLocation(0, 1.1, 0);
-      gl_view->insert(obj);
-    }
-    {
-      mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Z");
-      obj->setLocation(0, 0, 1.1);
-      gl_view->insert(obj);
-    }
-    gl_view->insert(mrpt::opengl::stock_objects::CornerXYZ());
-  }
 
-  if (!app.scene->getViewport(SECOND_MINI_VIEW_NAME))
-  {
-    auto gl_view = app.scene->createViewport(SECOND_MINI_VIEW_NAME);
-
-    gl_view->setViewportPosition(0.1, 0, 0.1, 0.1 * 16.0 / 9.0);
-    gl_view->setTransparent(true);
-
-    auto glRoot = mrpt::opengl::CSetOfObjects::Create();
-    gl_view->insert(glRoot);
-
+    if (!app.scene->getViewport(SECOND_MINI_VIEW_NAME))
     {
-      mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("X");
-      obj->setLocation(1.1, 0, 0);
-      glRoot->insert(obj);
+        auto gl_view = app.scene->createViewport(SECOND_MINI_VIEW_NAME);
+
+        gl_view->setViewportPosition(0.1, 0, 0.1, 0.1 * 16.0 / 9.0);
+        gl_view->setTransparent(true);
+
+        auto glRoot = mrpt::opengl::CSetOfObjects::Create();
+        gl_view->insert(glRoot);
+
+        {
+            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("X");
+            obj->setLocation(1.1, 0, 0);
+            glRoot->insert(obj);
+        }
+        {
+            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Y");
+            obj->setLocation(0, 1.1, 0);
+            glRoot->insert(obj);
+        }
+        {
+            mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Z");
+            obj->setLocation(0, 0, 1.1);
+            glRoot->insert(obj);
+        }
+        glRoot->insert(mrpt::opengl::stock_objects::CornerXYZ());
     }
-    {
-      mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Y");
-      obj->setLocation(0, 1.1, 0);
-      glRoot->insert(obj);
-    }
-    {
-      mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Z");
-      obj->setLocation(0, 0, 1.1);
-      glRoot->insert(obj);
-    }
-    glRoot->insert(mrpt::opengl::stock_objects::CornerXYZ());
-  }
 }
 
 /** Keeps the mini-corner viewport cameras/labels in sync with the main camera each frame.
@@ -575,99 +574,99 @@ void ensureMiniCornerViewports()
  * rendered under MRPT 2.x. */
 void updateMiniCornerView()
 {
-  auto gl_view1 = app.scene->getViewport(FIRST_MINI_VIEW_NAME);
-  if (!gl_view1)
-  {
-    return;
-  }
+    auto gl_view1 = app.scene->getViewport(FIRST_MINI_VIEW_NAME);
+    if (!gl_view1)
+    {
+        return;
+    }
 
-  mrpt::opengl::TFontParams fp;
-  fp.draw_shadow = true;
-  fp.vfont_scale = 9.0f;
+    mrpt::opengl::TFontParams fp;
+    fp.draw_shadow = true;
+    fp.vfont_scale = 9.0f;
 
-  {
-    mrpt::opengl::CCamera& view_cam = gl_view1->getCamera();
-    view_cam.setAzimuthDegrees(app.sceneView.camera().getAzimuthDegrees());
-    view_cam.setElevationDegrees(app.sceneView.camera().getElevationDegrees());
-    view_cam.setZoomDistance(5);
-  }
+    {
+        mrpt::opengl::CCamera& view_cam = gl_view1->getCamera();
+        view_cam.setAzimuthDegrees(app.sceneView.camera().getAzimuthDegrees());
+        view_cam.setElevationDegrees(app.sceneView.camera().getElevationDegrees());
+        view_cam.setZoomDistance(5);
+    }
 
-  const bool show_two_corners = app.applyGeoRef && app.theMap.georeferencing.has_value();
+    const bool show_two_corners = app.applyGeoRef && app.theMap.georeferencing.has_value();
 
-  gl_view1->clearTextMessages();
-  gl_view1->addTextMessage(5, 5, show_two_corners ? "ENU frame" : "Map frame", 0, fp);
+    gl_view1->clearTextMessages();
+    gl_view1->addTextMessage(5, 5, show_two_corners ? "ENU frame" : "Map frame", 0, fp);
 
-  auto gl_view2 = app.scene->getViewport(SECOND_MINI_VIEW_NAME);
-  if (!gl_view2 || gl_view2->empty())
-  {
-    return;
-  }
+    auto gl_view2 = app.scene->getViewport(SECOND_MINI_VIEW_NAME);
+    if (!gl_view2 || gl_view2->empty())
+    {
+        return;
+    }
 
-  auto glRoot = *gl_view2->begin();
-  if (!glRoot)
-  {
-    return;
-  }
-  glRoot->setVisibility(show_two_corners);
+    auto glRoot = *gl_view2->begin();
+    if (!glRoot)
+    {
+        return;
+    }
+    glRoot->setVisibility(show_two_corners);
 
-  if (!show_two_corners)
-  {
+    if (!show_two_corners)
+    {
+        gl_view2->clearTextMessages();
+        return;
+    }
+
+    glRoot->setPose(mrpt::poses::CPose3D::FromRotationAndTranslation(
+        app.theMap.georeferencing->T_enu_to_map.mean.getRotationMatrix(),
+        mrpt::math::TVector3D(0, 0, 0)));
+
+    {
+        mrpt::opengl::CCamera& view_cam = gl_view2->getCamera();
+        view_cam.setAzimuthDegrees(app.sceneView.camera().getAzimuthDegrees());
+        view_cam.setElevationDegrees(app.sceneView.camera().getElevationDegrees());
+        view_cam.setZoomDistance(5);
+    }
+
     gl_view2->clearTextMessages();
-    return;
-  }
-
-  glRoot->setPose(mrpt::poses::CPose3D::FromRotationAndTranslation(
-      app.theMap.georeferencing->T_enu_to_map.mean.getRotationMatrix(),
-      mrpt::math::TVector3D(0, 0, 0)));
-
-  {
-    mrpt::opengl::CCamera& view_cam = gl_view2->getCamera();
-    view_cam.setAzimuthDegrees(app.sceneView.camera().getAzimuthDegrees());
-    view_cam.setElevationDegrees(app.sceneView.camera().getElevationDegrees());
-    view_cam.setZoomDistance(5);
-  }
-
-  gl_view2->clearTextMessages();
-  gl_view2->addTextMessage(5, 5, "Map frame", 0, fp);
+    gl_view2->addTextMessage(5, 5, "Map frame", 0, fp);
 }
 
 void updateGuiAfterLoadingNewMap()
 {
-  app.layerVisible.clear();
-  for (const auto& name : app.layerNames)
-  {
-    app.layerVisible[name] = true;
-  }
-
-  for (auto& evl : app.extraVizLayers)
-  {
-    evl.visible = true;
-  }
-
-  app.recolorizeByFieldIdx = 0;
-
-  // Auto-range clip sliders from map Z bounds (linear mode only):
-  if (!app.depthLogScale)
-  {
-    float zMin = std::numeric_limits<float>::max();
-    float zMax = -std::numeric_limits<float>::max();
-    for (const auto& [name, map] : app.theMap.layers)
+    app.layerVisible.clear();
+    for (const auto& name : app.layerNames)
     {
-      const auto* pc = mp2p_icp::MapToPointsMap(*map);
-      if (!pc || pc->empty())
-      {
-        continue;
-      }
-      const auto bb = pc->boundingBox();
-      zMin          = std::min(zMin, bb.min.z);
-      zMax          = std::max(zMax, bb.max.z);
+        app.layerVisible[name] = true;
     }
-    if (zMin < zMax)
+
+    for (auto& evl : app.extraVizLayers)
     {
-      app.clipNear = zMin;
-      app.clipFar  = zMax;
+        evl.visible = true;
     }
-  }
+
+    app.recolorizeByFieldIdx = 0;
+
+    // Auto-range clip sliders from map Z bounds (linear mode only):
+    if (!app.depthLogScale)
+    {
+        float zMin = std::numeric_limits<float>::max();
+        float zMax = -std::numeric_limits<float>::max();
+        for (const auto& [name, map] : app.theMap.layers)
+        {
+            const auto* pc = mp2p_icp::MapToPointsMap(*map);
+            if (!pc || pc->empty())
+            {
+                continue;
+            }
+            const auto bb = pc->boundingBox();
+            zMin          = std::min(zMin, bb.min.z);
+            zMax          = std::max(zMax, bb.max.z);
+        }
+        if (zMin < zMax)
+        {
+            app.clipNear = zMin;
+            app.clipFar  = zMax;
+        }
+    }
 }
 
 void camTravellingStop() { app.camTravellingCurrentTime.reset(); }
@@ -676,903 +675,920 @@ void camTravellingStop() { app.camTravellingCurrentTime.reset(); }
  * the current camera pose). */
 void updateCameraClipDistances()
 {
-  auto& cam = app.sceneView.camera();
+    auto& cam = app.sceneView.camera();
 
-  float clipNear = 0;
-  float clipFar  = 0;
-  if (app.depthLogScale)
-  {
-    const auto depthFieldMid       = std::pow(10.0, app.clipNear);
-    const auto depthFieldThickness = std::pow(10.0, app.clipFar);
-    clipNear = static_cast<float>(std::max(1e-2, depthFieldMid - 0.5 * depthFieldThickness));
-    clipFar  = static_cast<float>(depthFieldMid + 0.5 * depthFieldThickness);
-  }
-  else
-  {
-    // Linear mode: slider values are world Z coordinates.
-    // Convert to frustum distances using the camera elevation and zoom.
-    const float elDeg   = cam.getElevationDegrees();
-    const float sinEl   = std::sin(mrpt::DEG2RAD(elDeg));
-    const float cameraZ = cam.getPointingAtZ() + cam.getZoomDistance() * sinEl;
-
-    const float orthoFactor = cam.isProjective() ? 1.0f : 2.0f;
-    const float zFloor      = orthoFactor * app.clipNear;
-    const float zCeiling    = orthoFactor * app.clipFar;
-
-    if (std::abs(sinEl) > 0.05f)
+    float clipNear = 0;
+    float clipFar  = 0;
+    if (app.depthLogScale)
     {
-      clipFar  = std::max(0.01f, (cameraZ - zFloor) / sinEl);
-      clipNear = std::max(0.01f, std::min(clipFar - 0.01f, (cameraZ - zCeiling) / sinEl));
+        const auto depthFieldMid       = std::pow(10.0, app.clipNear);
+        const auto depthFieldThickness = std::pow(10.0, app.clipFar);
+        clipNear = static_cast<float>(std::max(1e-2, depthFieldMid - 0.5 * depthFieldThickness));
+        clipFar  = static_cast<float>(depthFieldMid + 0.5 * depthFieldThickness);
     }
     else
     {
-      clipNear = std::max(0.01f, std::abs(zFloor));
-      clipFar  = std::max(clipNear + 0.01f, std::abs(zCeiling));
+        // Linear mode: slider values are world Z coordinates.
+        // Convert to frustum distances using the camera elevation and zoom.
+        const float elDeg   = cam.getElevationDegrees();
+        const float sinEl   = std::sin(mrpt::DEG2RAD(elDeg));
+        const float cameraZ = cam.getPointingAtZ() + cam.getZoomDistance() * sinEl;
+
+        const float orthoFactor = cam.isProjective() ? 1.0f : 2.0f;
+        const float zFloor      = orthoFactor * app.clipNear;
+        const float zCeiling    = orthoFactor * app.clipFar;
+
+        if (std::abs(sinEl) > 0.05f)
+        {
+            clipFar  = std::max(0.01f, (cameraZ - zFloor) / sinEl);
+            clipNear = std::max(0.01f, std::min(clipFar - 0.01f, (cameraZ - zCeiling) / sinEl));
+        }
+        else
+        {
+            clipNear = std::max(0.01f, std::abs(zFloor));
+            clipFar  = std::max(clipNear + 0.01f, std::abs(zCeiling));
+        }
     }
-  }
 
-  cam.setProjectiveFOVdeg(app.cameraFOV);
+    cam.setProjectiveFOVdeg(app.cameraFOV);
 
-  app.scene->getViewport("main")->setViewportClipDistances(clipNear, clipFar);
+    app.scene->getViewport("main")->setViewportClipDistances(clipNear, clipFar);
 }
 
 void processCameraTravelling()
 {
-  if (!app.camTravellingCurrentTime.has_value())
-  {
-    return;
-  }
-  double& t = app.camTravellingCurrentTime.value();
+    if (!app.camTravellingCurrentTime.has_value())
+    {
+        return;
+    }
+    double& t = app.camTravellingCurrentTime.value();
 
-  const double t0 = mrpt::Clock::toDouble(app.camTravelling.begin()->first);
-  const double t1 = mrpt::Clock::toDouble(app.camTravelling.rbegin()->first);
-  app.animProgress = (t1 > t0) ? static_cast<float>((t - t0) / (t1 - t0)) : 0.0f;
+    const double t0  = mrpt::Clock::toDouble(app.camTravelling.begin()->first);
+    const double t1  = mrpt::Clock::toDouble(app.camTravelling.rbegin()->first);
+    app.animProgress = (t1 > t0) ? static_cast<float>((t - t0) / (t1 - t0)) : 0.0f;
 
-  if (t >= t1)
-  {
-    camTravellingStop();
-    return;
-  }
+    if (t >= t1)
+    {
+        camTravellingStop();
+        return;
+    }
 
-  const auto interpMethod = app.travellingInterpIdx == 0 ? mrpt::poses::TInterpolatorMethod::imLinear2Neig
-                                                          : mrpt::poses::TInterpolatorMethod::imSSLSLL;
-  app.camTravelling.setInterpolationMethod(interpMethod);
+    const auto interpMethod = app.travellingInterpIdx == 0
+                                  ? mrpt::poses::TInterpolatorMethod::imLinear2Neig
+                                  : mrpt::poses::TInterpolatorMethod::imSSLSLL;
+    app.camTravelling.setInterpolationMethod(interpMethod);
 
-  mrpt::math::TPose3D p;
-  bool                valid = false;
-  app.camTravelling.interpolate(mrpt::Clock::fromDouble(t), p, valid);
-  if (valid)
-  {
-    auto& cam = app.sceneView.camera();
-    cam.setPointingAt(static_cast<float>(p.x), static_cast<float>(p.y), static_cast<float>(p.z));
-    cam.setAzimuthDegrees(static_cast<float>(mrpt::RAD2DEG(p.yaw)));
-    cam.setElevationDegrees(static_cast<float>(mrpt::RAD2DEG(p.pitch)));
-    cam.setZoomDistance(static_cast<float>(p.roll / TRAVELING_ZOOM2ROLL));
-  }
+    mrpt::math::TPose3D p;
+    bool                valid = false;
+    app.camTravelling.interpolate(mrpt::Clock::fromDouble(t), p, valid);
+    if (valid)
+    {
+        auto& cam = app.sceneView.camera();
+        cam.setPointingAt(
+            static_cast<float>(p.x), static_cast<float>(p.y), static_cast<float>(p.z));
+        cam.setAzimuthDegrees(static_cast<float>(mrpt::RAD2DEG(p.yaw)));
+        cam.setElevationDegrees(static_cast<float>(mrpt::RAD2DEG(p.pitch)));
+        cam.setZoomDistance(static_cast<float>(p.roll / TRAVELING_ZOOM2ROLL));
+    }
 
-  const double dt = app.animFPS > 0 ? 1.0 / app.animFPS : 1.0 / 30.0;
-  t += dt;
+    const double dt = app.animFPS > 0 ? 1.0 / app.animFPS : 1.0 / 30.0;
+    t += dt;
 }
 
 void handleKeyboard()
 {
-  ImGuiIO& io = ImGui::GetIO();
-  if (io.WantTextInput)
-  {
-    return;
-  }
-
-  constexpr float SLIDE_VELOCITY     = 0.01f;
-  constexpr float SENSIBILITY_ROTATE = 1.0f;
-  auto&           cam                = app.sceneView.camera();
-
-  auto doStrideSides = [&](bool toTheRight)
-  {
-    const float az   = cam.getAzimuthDegrees();
-    const float dx   = std::cos(mrpt::DEG2RAD(az + 90.f));
-    const float dy   = std::sin(mrpt::DEG2RAD(az + 90.f));
-    const float d    = toTheRight ? 1.0f : -1.0f;
-    const float dist = cam.getZoomDistance();
-    cam.setPointingAt(
-        cam.getPointingAtX() + d * dx * dist * SLIDE_VELOCITY,
-        cam.getPointingAtY() + d * dy * dist * SLIDE_VELOCITY, cam.getPointingAtZ());
-  };
-
-  auto doRotateEyeYaw = [&](bool toTheRight)
-  {
-    const float dis = std::max(0.01f, cam.getZoomDistance());
-    const float az0 = cam.getAzimuthDegrees();
-    const float el0 = cam.getElevationDegrees();
-
-    const float eyeX = cam.getPointingAtX() +
-                        dis * std::cos(mrpt::DEG2RAD(az0)) * std::cos(mrpt::DEG2RAD(el0));
-    const float eyeY = cam.getPointingAtY() +
-                        dis * std::sin(mrpt::DEG2RAD(az0)) * std::cos(mrpt::DEG2RAD(el0));
-    const float eyeZ = cam.getPointingAtZ() + dis * std::sin(mrpt::DEG2RAD(el0));
-
-    const float newAz = az0 + (toTheRight ? -SENSIBILITY_ROTATE : SENSIBILITY_ROTATE);
-    cam.setAzimuthDegrees(newAz);
-
-    cam.setPointingAt(
-        eyeX - dis * std::cos(mrpt::DEG2RAD(newAz)) * std::cos(mrpt::DEG2RAD(el0)),
-        eyeY - dis * std::sin(mrpt::DEG2RAD(newAz)) * std::cos(mrpt::DEG2RAD(el0)),
-        eyeZ - dis * std::sin(mrpt::DEG2RAD(el0)));
-  };
-
-  auto doRotateEyeUpDown = [&](bool toUp)
-  {
-    const float az   = cam.getAzimuthDegrees();
-    const float dx   = std::cos(mrpt::DEG2RAD(az));
-    const float dy   = std::sin(mrpt::DEG2RAD(az));
-    const float d    = toUp ? -1.0f : 1.0f;
-    const float dist = cam.getZoomDistance();
-    cam.setPointingAt(
-        cam.getPointingAtX() + d * dx * dist * SLIDE_VELOCITY,
-        cam.getPointingAtY() + d * dy * dist * SLIDE_VELOCITY, cam.getPointingAtZ());
-  };
-
-  auto doMoveVertically = [&](bool toUp)
-  {
-    const float d    = toUp ? 1.0f : -1.0f;
-    const float dist = cam.getZoomDistance();
-    cam.setPointingAt(
-        cam.getPointingAtX(), cam.getPointingAtY(), cam.getPointingAtZ() + d * dist * SLIDE_VELOCITY);
-  };
-
-  const bool up   = ImGui::IsKeyPressed(ImGuiKey_UpArrow, true) || ImGui::IsKeyPressed(ImGuiKey_W, true);
-  const bool down = ImGui::IsKeyPressed(ImGuiKey_DownArrow, true) || ImGui::IsKeyPressed(ImGuiKey_S, true);
-  if (up || down)
-  {
-    if (io.KeyShift)
+    ImGuiIO& io = ImGui::GetIO();
+    if (io.WantTextInput)
     {
-      doMoveVertically(up);
+        return;
     }
-    else
-    {
-      doRotateEyeUpDown(up);
-    }
-  }
 
-  if (ImGui::IsKeyPressed(ImGuiKey_A, true))
-  {
-    doStrideSides(false);
-  }
-  if (ImGui::IsKeyPressed(ImGuiKey_D, true))
-  {
-    doStrideSides(true);
-  }
+    constexpr float SLIDE_VELOCITY     = 0.01f;
+    constexpr float SENSIBILITY_ROTATE = 1.0f;
+    auto&           cam                = app.sceneView.camera();
 
-  const bool right = ImGui::IsKeyPressed(ImGuiKey_RightArrow, true);
-  const bool left   = ImGui::IsKeyPressed(ImGuiKey_LeftArrow, true);
-  if (right || left)
-  {
-    if (io.KeyShift)
+    auto doStrideSides = [&](bool toTheRight)
     {
-      doStrideSides(right);
-    }
-    else
-    {
-      doRotateEyeYaw(right);
-    }
-  }
+        const float az   = cam.getAzimuthDegrees();
+        const float dx   = std::cos(mrpt::DEG2RAD(az + 90.f));
+        const float dy   = std::sin(mrpt::DEG2RAD(az + 90.f));
+        const float d    = toTheRight ? 1.0f : -1.0f;
+        const float dist = cam.getZoomDistance();
+        cam.setPointingAt(
+            cam.getPointingAtX() + d * dx * dist * SLIDE_VELOCITY,
+            cam.getPointingAtY() + d * dy * dist * SLIDE_VELOCITY, cam.getPointingAtZ());
+    };
 
-  // CTRL+C copies the coordinates
-  if (io.KeyCtrl && ImGui::IsKeyPressed(ImGuiKey_C, false))
-  {
-    const std::string text = app.mouseCoordText + "\n" + app.cameraLookText;
-    glfwSetClipboardString(app.shell.windowHandle(), text.c_str());
-  }
+    auto doRotateEyeYaw = [&](bool toTheRight)
+    {
+        const float dis = std::max(0.01f, cam.getZoomDistance());
+        const float az0 = cam.getAzimuthDegrees();
+        const float el0 = cam.getElevationDegrees();
+
+        const float eyeX = cam.getPointingAtX() +
+                           dis * std::cos(mrpt::DEG2RAD(az0)) * std::cos(mrpt::DEG2RAD(el0));
+        const float eyeY = cam.getPointingAtY() +
+                           dis * std::sin(mrpt::DEG2RAD(az0)) * std::cos(mrpt::DEG2RAD(el0));
+        const float eyeZ = cam.getPointingAtZ() + dis * std::sin(mrpt::DEG2RAD(el0));
+
+        const float newAz = az0 + (toTheRight ? -SENSIBILITY_ROTATE : SENSIBILITY_ROTATE);
+        cam.setAzimuthDegrees(newAz);
+
+        cam.setPointingAt(
+            eyeX - dis * std::cos(mrpt::DEG2RAD(newAz)) * std::cos(mrpt::DEG2RAD(el0)),
+            eyeY - dis * std::sin(mrpt::DEG2RAD(newAz)) * std::cos(mrpt::DEG2RAD(el0)),
+            eyeZ - dis * std::sin(mrpt::DEG2RAD(el0)));
+    };
+
+    auto doRotateEyeUpDown = [&](bool toUp)
+    {
+        const float az   = cam.getAzimuthDegrees();
+        const float dx   = std::cos(mrpt::DEG2RAD(az));
+        const float dy   = std::sin(mrpt::DEG2RAD(az));
+        const float d    = toUp ? -1.0f : 1.0f;
+        const float dist = cam.getZoomDistance();
+        cam.setPointingAt(
+            cam.getPointingAtX() + d * dx * dist * SLIDE_VELOCITY,
+            cam.getPointingAtY() + d * dy * dist * SLIDE_VELOCITY, cam.getPointingAtZ());
+    };
+
+    auto doMoveVertically = [&](bool toUp)
+    {
+        const float d    = toUp ? 1.0f : -1.0f;
+        const float dist = cam.getZoomDistance();
+        cam.setPointingAt(
+            cam.getPointingAtX(), cam.getPointingAtY(),
+            cam.getPointingAtZ() + d * dist * SLIDE_VELOCITY);
+    };
+
+    const bool up =
+        ImGui::IsKeyPressed(ImGuiKey_UpArrow, true) || ImGui::IsKeyPressed(ImGuiKey_W, true);
+    const bool down =
+        ImGui::IsKeyPressed(ImGuiKey_DownArrow, true) || ImGui::IsKeyPressed(ImGuiKey_S, true);
+    if (up || down)
+    {
+        if (io.KeyShift)
+        {
+            doMoveVertically(up);
+        }
+        else
+        {
+            doRotateEyeUpDown(up);
+        }
+    }
+
+    if (ImGui::IsKeyPressed(ImGuiKey_A, true))
+    {
+        doStrideSides(false);
+    }
+    if (ImGui::IsKeyPressed(ImGuiKey_D, true))
+    {
+        doStrideSides(true);
+    }
+
+    const bool right = ImGui::IsKeyPressed(ImGuiKey_RightArrow, true);
+    const bool left  = ImGui::IsKeyPressed(ImGuiKey_LeftArrow, true);
+    if (right || left)
+    {
+        if (io.KeyShift)
+        {
+            doStrideSides(right);
+        }
+        else
+        {
+            doRotateEyeYaw(right);
+        }
+    }
+
+    // CTRL+C copies the coordinates
+    if (io.KeyCtrl && ImGui::IsKeyPressed(ImGuiKey_C, false))
+    {
+        const std::string text = app.mouseCoordText + "\n" + app.cameraLookText;
+        glfwSetClipboardString(app.shell.windowHandle(), text.c_str());
+    }
 }
 
 void onSaveLayers(const std::string& outFile)
 {
-  for (const auto& lyName : app.layerNames)
-  {
-    if (auto itL = app.theMap.layers.find(lyName); itL != app.theMap.layers.end())
+    for (const auto& lyName : app.layerNames)
     {
-      itL->second->saveMetricMapRepresentationToFile(outFile);
+        if (auto itL = app.theMap.layers.find(lyName); itL != app.theMap.layers.end())
+        {
+            itL->second->saveMetricMapRepresentationToFile(outFile);
+        }
     }
-  }
 }
 
 void rebuild_3d_view()
 {
-  std::optional<mrpt::math::TBoundingBoxf> mapBbox;
+    std::optional<mrpt::math::TBoundingBoxf> mapBbox;
 
-  mp2p_icp::render_params_t rpMap;
-  rpMap.points.visible = false;
+    mp2p_icp::render_params_t rpMap;
+    rpMap.points.visible = false;
 
-  for (const auto& lyName : app.layerNames)
-  {
-    if (auto itL = app.theMap.layers.find(lyName); itL != app.theMap.layers.end())
+    for (const auto& lyName : app.layerNames)
     {
-      if (auto pc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itL->second); pc)
-      {
-        const auto bb = pc->boundingBox();
-        mapBbox        = mapBbox.has_value() ? mapBbox->unionWith(bb) : bb;
-      }
+        if (auto itL = app.theMap.layers.find(lyName); itL != app.theMap.layers.end())
+        {
+            if (auto pc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itL->second); pc)
+            {
+                const auto bb = pc->boundingBox();
+                mapBbox       = mapBbox.has_value() ? mapBbox->unionWith(bb) : bb;
+            }
+        }
+
+        if (!app.layerVisible[lyName])
+        {
+            continue;  // hidden
+        }
+        rpMap.points.visible = true;
+
+        auto& rpL                       = rpMap.points.perLayer[lyName];
+        rpL.pointSize                   = app.pointSize;
+        rpL.render_voxelmaps_as_points  = app.viewVoxelsAsPoints;
+        rpL.render_voxelmaps_free_space = app.viewVoxelsFreeSpace;
+
+        if (app.colorizeMap)
+        {
+            auto& cm    = rpL.colorMode.emplace();
+            cm.colorMap = mrpt::typemeta::str2enum<mrpt::img::TColormap>(
+                kColorIntensityNames[app.colorIntensityIdx]);
+
+            if (!app.knownPointFields.empty())
+            {
+                cm.recolorizeByField =
+                    app.knownPointFields.at(static_cast<size_t>(app.recolorizeByFieldIdx));
+            }
+
+            if (app.autoBBoxOutliers)
+            {
+                cm.autoBoundingBoxOutliersPercentile = app.autoBBoxOutliersPercentile;
+            }
+        }
+        if (app.keepNativeCloudColors)
+        {
+            auto& cm                     = rpL.colorMode.emplace();
+            cm.keep_original_cloud_color = true;
+            rpL.force_alpha_channel      = true;
+        }
     }
 
-    if (!app.layerVisible[lyName])
+    for (auto& [layer, rp] : rpMap.points.perLayer)
     {
-      continue;  // hidden
+        rp.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0x80);
     }
-    rpMap.points.visible = true;
 
-    auto& rpL                       = rpMap.points.perLayer[lyName];
-    rpL.pointSize                   = app.pointSize;
-    rpL.render_voxelmaps_as_points  = app.viewVoxelsAsPoints;
-    rpL.render_voxelmaps_free_space = app.viewVoxelsFreeSpace;
+    // Regenerate points opengl representation only if some parameter changed:
+    static std::optional<mp2p_icp::render_params_t> prevRenderParams;
 
-    if (app.colorizeMap)
+    if (!prevRenderParams.has_value() || prevRenderParams.value() != rpMap)
     {
-      auto& cm    = rpL.colorMode.emplace();
-      cm.colorMap = mrpt::typemeta::str2enum<mrpt::img::TColormap>(
-          kColorIntensityNames[app.colorIntensityIdx]);
+        prevRenderParams = rpMap;
+        app.glVizMap->clear();
 
-      if (!app.knownPointFields.empty())
-      {
-        cm.recolorizeByField =
-            app.knownPointFields.at(static_cast<size_t>(app.recolorizeByFieldIdx));
-      }
+        auto glPts = app.theMap.get_visualization(rpMap);
 
-      if (app.autoBBoxOutliers)
-      {
-        cm.autoBoundingBoxOutliersPercentile = app.autoBBoxOutliersPercentile;
-      }
+        app.glVizMap->insert(glPts);
+        app.glVizMap->insert(app.glMapCorner);
+        app.glVizMap->insert(app.glTrajectory);
+        app.glVizMap->insert(app.glVizObjects);
     }
-    if (app.keepNativeCloudColors)
+
+    if (app.applyGeoRef && app.theMap.georeferencing.has_value())
     {
-      auto& cm                     = rpL.colorMode.emplace();
-      cm.keep_original_cloud_color = true;
-      rpL.force_alpha_channel      = true;
+        app.glVizMap->setPose(app.theMap.georeferencing->T_enu_to_map.mean);
+        app.glENUCorner->setVisibility(true);
     }
-  }
-
-  for (auto& [layer, rp] : rpMap.points.perLayer)
-  {
-    rp.color = mrpt::img::TColor(0xff, 0x00, 0x00, 0x80);
-  }
-
-  // Regenerate points opengl representation only if some parameter changed:
-  static std::optional<mp2p_icp::render_params_t> prevRenderParams;
-
-  if (!prevRenderParams.has_value() || prevRenderParams.value() != rpMap)
-  {
-    prevRenderParams = rpMap;
-    app.glVizMap->clear();
-
-    auto glPts = app.theMap.get_visualization(rpMap);
-
-    app.glVizMap->insert(glPts);
-    app.glVizMap->insert(app.glMapCorner);
-    app.glVizMap->insert(app.glTrajectory);
-    app.glVizMap->insert(app.glVizObjects);
-  }
-
-  if (app.applyGeoRef && app.theMap.georeferencing.has_value())
-  {
-    app.glVizMap->setPose(app.theMap.georeferencing->T_enu_to_map.mean);
-    app.glENUCorner->setVisibility(true);
-  }
-  else
-  {
-    app.glVizMap->setPose(mrpt::poses::CPose3D::Identity());
-    app.glENUCorner->setVisibility(false);
-  }
-
-  if (mapBbox)
-  {
-    app.glGrid->setPlaneLimits(mapBbox->min.x, mapBbox->max.x, mapBbox->min.y, mapBbox->max.y);
-
-    constexpr float MAX_GRID_LINES = 20.0f;
-    const auto      bboxDiagonal   = (mapBbox->max - mapBbox->min).cast<float>().norm();
-    app.glGrid->setGridFrequency(std::max<float>(1.0f, std::round(bboxDiagonal / MAX_GRID_LINES)));
-  }
-  app.glGrid->setVisibility(app.showGroundGrid);
-
-  if (mapBbox && app.doFitView)
-  {
-    const auto midPt  = (mapBbox->min + mapBbox->max) * 0.5;
-    const auto mapLen = (mapBbox->max - mapBbox->min).norm();
-
-    app.sceneView.camera().setPointingAt(midPt.x, midPt.y, midPt.z);
-    app.sceneView.camera().setZoomDistance(mapLen);
-  }
-  app.doFitView = false;
-
-  if (app.glTrajectory->empty() && app.trajectory.size() >= 2)
-  {
-    const float trajectoryCylRadius = std::exp(app.trajectoryThicknessLog);
-
-    std::optional<mrpt::math::TPose3D> prevPose;
-    for (const auto& [t, p] : app.trajectory)
+    else
     {
-      if (prevPose)
-      {
-        const auto& p0 = prevPose.value();
-
-        auto glSegment = mrpt::opengl::CArrow::Create();
-        glSegment->setArrowEnds(p0.translation(), p.translation());
-        glSegment->setHeadRatio(.0);
-        glSegment->setLargeRadius(trajectoryCylRadius);
-        glSegment->setSmallRadius(trajectoryCylRadius);
-        glSegment->setColor_u8(0x30, 0x30, 0x30, 0xff);
-
-        app.glTrajectory->insert(glSegment);
-      }
-      prevPose = p;
+        app.glVizMap->setPose(mrpt::poses::CPose3D::Identity());
+        app.glENUCorner->setVisibility(false);
     }
-  }
 
-  app.glVizObjects->clear();
-  for (auto& evl : app.extraVizLayers)
-  {
-    evl.glObjects->setVisibility(evl.visible);
-    app.glVizObjects->insert(evl.glObjects);
-  }
+    if (mapBbox)
+    {
+        app.glGrid->setPlaneLimits(mapBbox->min.x, mapBbox->max.x, mapBbox->min.y, mapBbox->max.y);
 
-  app.sceneView.camera().setProjectiveModel(!app.viewOrtho && !app.view2D);
+        constexpr float MAX_GRID_LINES = 20.0f;
+        const auto      bboxDiagonal   = (mapBbox->max - mapBbox->min).cast<float>().norm();
+        app.glGrid->setGridFrequency(
+            std::max<float>(1.0f, std::round(bboxDiagonal / MAX_GRID_LINES)));
+    }
+    app.glGrid->setVisibility(app.showGroundGrid);
 
-  if (app.view2D)
-  {
-    app.sceneView.camera().setAzimuthDegrees(-90.0f);
-    app.sceneView.camera().setElevationDegrees(90.0f);
-  }
+    if (mapBbox && app.doFitView)
+    {
+        const auto midPt  = (mapBbox->min + mapBbox->max) * 0.5;
+        const auto mapLen = (mapBbox->max - mapBbox->min).norm();
 
-  ensureMiniCornerViewports();
+        app.sceneView.camera().setPointingAt(midPt.x, midPt.y, midPt.z);
+        app.sceneView.camera().setZoomDistance(mapLen);
+    }
+    app.doFitView = false;
 
-  // Clip planes/FOV are refreshed every frame in updateCameraClipDistances(),
-  // since the "linear" clip mode needs the up-to-date camera pose.
+    if (app.glTrajectory->empty() && app.trajectory.size() >= 2)
+    {
+        const float trajectoryCylRadius = std::exp(app.trajectoryThicknessLog);
+
+        std::optional<mrpt::math::TPose3D> prevPose;
+        for (const auto& [t, p] : app.trajectory)
+        {
+            if (prevPose)
+            {
+                const auto& p0 = prevPose.value();
+
+                auto glSegment = mrpt::opengl::CArrow::Create();
+                glSegment->setArrowEnds(p0.translation(), p.translation());
+                glSegment->setHeadRatio(.0);
+                glSegment->setLargeRadius(trajectoryCylRadius);
+                glSegment->setSmallRadius(trajectoryCylRadius);
+                glSegment->setColor_u8(0x30, 0x30, 0x30, 0xff);
+
+                app.glTrajectory->insert(glSegment);
+            }
+            prevPose = p;
+        }
+    }
+
+    app.glVizObjects->clear();
+    for (auto& evl : app.extraVizLayers)
+    {
+        evl.glObjects->setVisibility(evl.visible);
+        app.glVizObjects->insert(evl.glObjects);
+    }
+
+    app.sceneView.camera().setProjectiveModel(!app.viewOrtho && !app.view2D);
+
+    if (app.view2D)
+    {
+        app.sceneView.camera().setAzimuthDegrees(-90.0f);
+        app.sceneView.camera().setElevationDegrees(90.0f);
+    }
+
+    ensureMiniCornerViewports();
+
+    // Clip planes/FOV are refreshed every frame in updateCameraClipDistances(),
+    // since the "linear" clip mode needs the up-to-date camera pose.
 }
 
 /** "Map viewer" window: file header + Open/Export + mouse/camera coordinate footer.
  *  Kept separate from the View/Maps/Travelling panels below so it can dock as a thin strip. */
 void renderMapViewerPanel()
 {
-  ImGui::Begin("Map viewer");
+    ImGui::Begin("Map viewer");
 
-  const std::string headerLine = app.theMapFileName + "  |  " + app.theMap.contents_summary();
-  ImGui::TextWrapped("%s", headerLine.c_str());
-  if (ImGui::Button("Open..."))
-  {
-    app.openDialog.open(
-        mp2p_icp_viz::SimpleFileDialog::Mode::Open,
-        {{"mm", "Metric maps (*.mm)"}, {"bin", "Serialized CGenericPointsMap (*.bin)"}},
-        "Open metric map");
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Export marked layers..."))
-  {
-    app.exportDialog.open(
-        mp2p_icp_viz::SimpleFileDialog::Mode::Save, {{"txt", "(*.txt)"}}, "Export layers");
-  }
-
-  if (auto path = app.openDialog.render(); path.has_value())
-  {
-    if (loadMapFile(*path))
+    const std::string headerLine = app.theMapFileName + "  |  " + app.theMap.contents_summary();
+    ImGui::TextWrapped("%s", headerLine.c_str());
+    if (ImGui::Button("Open..."))
     {
-      updateGuiAfterLoadingNewMap();
+        app.openDialog.open(
+            mp2p_icp_viz::SimpleFileDialog::Mode::Open,
+            {{"mm", "Metric maps (*.mm)"}, {"bin", "Serialized CGenericPointsMap (*.bin)"}},
+            "Open metric map");
     }
-  }
-  if (auto path = app.exportDialog.render(); path.has_value())
-  {
-    onSaveLayers(*path);
-  }
+    ImGui::SameLine();
+    if (ImGui::Button("Export marked layers..."))
+    {
+        app.exportDialog.open(
+            mp2p_icp_viz::SimpleFileDialog::Mode::Save, {{"txt", "(*.txt)"}}, "Export layers");
+    }
 
-  ImGui::Separator();
-  ImGui::TextUnformatted(app.mouseCoordText.c_str());
-  ImGui::TextUnformatted(app.cameraLookText.c_str());
+    if (auto path = app.openDialog.render(); path.has_value())
+    {
+        if (loadMapFile(*path))
+        {
+            updateGuiAfterLoadingNewMap();
+        }
+    }
+    if (auto path = app.exportDialog.render(); path.has_value())
+    {
+        onSaveLayers(*path);
+    }
 
-  const bool  hasGeoref     = app.theMap.georeferencing.has_value();
-  const char* itemsGeoref[] = {"map", "enu", "lat/lon"};
-  const char* itemsPlain[]  = {"map"};
-  if (!hasGeoref)
-  {
-    app.mouseUnitsIdx = 0;
-  }
-  ImGui::SetNextItemWidth(100);
-  if (hasGeoref)
-  {
-    ImGui::Combo("##mouseUnits", &app.mouseUnitsIdx, itemsGeoref, 3);
-  }
-  else
-  {
-    ImGui::BeginDisabled();
-    int dummy = 0;
-    ImGui::Combo("##mouseUnits", &dummy, itemsPlain, 1);
-    ImGui::EndDisabled();
-  }
-  ImGui::SameLine();
-  if (ImGui::Button("Copy coords"))
-  {
-    const std::string text = app.mouseCoordText + "\n" + app.cameraLookText;
-    glfwSetClipboardString(app.shell.windowHandle(), text.c_str());
-  }
+    ImGui::Separator();
+    ImGui::TextUnformatted(app.mouseCoordText.c_str());
+    ImGui::TextUnformatted(app.cameraLookText.c_str());
 
-  ImGui::End();
+    const bool  hasGeoref     = app.theMap.georeferencing.has_value();
+    const char* itemsGeoref[] = {"map", "enu", "lat/lon"};
+    const char* itemsPlain[]  = {"map"};
+    if (!hasGeoref)
+    {
+        app.mouseUnitsIdx = 0;
+    }
+    ImGui::SetNextItemWidth(100);
+    if (hasGeoref)
+    {
+        ImGui::Combo("##mouseUnits", &app.mouseUnitsIdx, itemsGeoref, 3);
+    }
+    else
+    {
+        ImGui::BeginDisabled();
+        int dummy = 0;
+        ImGui::Combo("##mouseUnits", &dummy, itemsPlain, 1);
+        ImGui::EndDisabled();
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Copy coords"))
+    {
+        const std::string text = app.mouseCoordText + "\n" + app.cameraLookText;
+        glfwSetClipboardString(app.shell.windowHandle(), text.c_str());
+    }
+
+    ImGui::End();
 }
 
 /** "View" window: camera/rendering options (mirrors the old nanogui "View" tab). */
 void renderViewPanel()
 {
-  ImGui::Begin("View");
+    ImGui::Begin("View");
 
-  ImGui::SliderFloat(
-      "Trajectory thickness", &app.trajectoryThicknessLog, std::log(0.005f), std::log(2.0f));
-  if (ImGui::IsItemEdited())
-  {
-    app.glTrajectory->clear();  // force rebuild
-  }
+    ImGui::SliderFloat(
+        "Trajectory thickness", &app.trajectoryThicknessLog, std::log(0.005f), std::log(2.0f));
+    if (ImGui::IsItemEdited())
+    {
+        app.glTrajectory->clear();  // force rebuild
+    }
 
-  ImGui::Checkbox("Log scale", &app.depthLogScale);
-  if (ImGui::IsItemEdited())
-  {
+    ImGui::Checkbox("Log scale", &app.depthLogScale);
+    if (ImGui::IsItemEdited())
+    {
+        if (app.depthLogScale)
+        {
+            app.clipNear = 0.1f;
+            app.clipFar  = 4.0f;
+        }
+        else
+        {
+            app.clipNear = -5.0f;
+            app.clipFar  = 25.0f;
+        }
+    }
+
     if (app.depthLogScale)
     {
-      app.clipNear = 0.1f;
-      app.clipFar  = 4.0f;
+        ImGui::SliderFloat("Frustum center (log10 m)", &app.clipNear, -2.0f, 3.0f);
+        ImGui::SliderFloat("Frustum thickness (log10 m)", &app.clipFar, -2.0f, 6.0f);
     }
     else
     {
-      app.clipNear = -5.0f;
-      app.clipFar  = 25.0f;
+        ImGui::SliderFloat("Floor clip (near, m)", &app.clipNear, -5.0f, 25.0f);
+        ImGui::SliderFloat("Ceiling clip (far, m)", &app.clipFar, -5.0f, 25.0f);
     }
-  }
 
-  if (app.depthLogScale)
-  {
-    ImGui::SliderFloat("Frustum center (log10 m)", &app.clipNear, -2.0f, 3.0f);
-    ImGui::SliderFloat("Frustum thickness (log10 m)", &app.clipFar, -2.0f, 6.0f);
-  }
-  else
-  {
-    ImGui::SliderFloat("Floor clip (near, m)", &app.clipNear, -5.0f, 25.0f);
-    ImGui::SliderFloat("Ceiling clip (far, m)", &app.clipFar, -5.0f, 25.0f);
-  }
-
-  ImGui::SliderFloat("Camera FOV", &app.cameraFOV, 20.0f, 170.0f);
-  ImGui::Checkbox("Orthogonal view", &app.viewOrtho);
-  ImGui::SameLine();
-  ImGui::Checkbox("Force 2D view", &app.view2D);
-
-  ImGui::Checkbox("Show ground grid", &app.showGroundGrid);
-  ImGui::SameLine();
-  if (ImGui::Button("Fit view to map"))
-  {
-    app.doFitView = true;
-  }
-
-  ImGui::TextUnformatted("Set view along axis:");
-  auto viewButton = [&](const char* caption, float az, float el)
-  {
-    if (ImGui::Button(caption))
-    {
-      app.view2D = false;
-      app.sceneView.camera().setAzimuthDegrees(az);
-      app.sceneView.camera().setElevationDegrees(el);
-    }
+    ImGui::SliderFloat("Camera FOV", &app.cameraFOV, 20.0f, 170.0f);
+    ImGui::Checkbox("Orthogonal view", &app.viewOrtho);
     ImGui::SameLine();
-  };
-  viewButton("+X", 0.0f, 0.0f);
-  viewButton("-X", 180.0f, 0.0f);
-  viewButton("+Y", 90.0f, 0.0f);
-  viewButton("-Y", -90.0f, 0.0f);
-  viewButton("+Z", -90.0f, 90.0f);
-  viewButton("-Z", -90.0f, -90.0f);
-  ImGui::NewLine();
+    ImGui::Checkbox("Force 2D view", &app.view2D);
 
-  ImGui::BeginDisabled(!app.theMap.georeferencing.has_value());
-  ImGui::Checkbox("Apply georeferenced pose (if available)", &app.applyGeoRef);
-  ImGui::EndDisabled();
+    ImGui::Checkbox("Show ground grid", &app.showGroundGrid);
+    ImGui::SameLine();
+    if (ImGui::Button("Fit view to map"))
+    {
+        app.doFitView = true;
+    }
 
-  ImGui::End();
+    ImGui::TextUnformatted("Set view along axis:");
+    auto viewButton = [&](const char* caption, float az, float el)
+    {
+        if (ImGui::Button(caption))
+        {
+            app.view2D = false;
+            app.sceneView.camera().setAzimuthDegrees(az);
+            app.sceneView.camera().setElevationDegrees(el);
+        }
+        ImGui::SameLine();
+    };
+    viewButton("+X", 0.0f, 0.0f);
+    viewButton("-X", 180.0f, 0.0f);
+    viewButton("+Y", 90.0f, 0.0f);
+    viewButton("-Y", -90.0f, 0.0f);
+    viewButton("+Z", -90.0f, 90.0f);
+    viewButton("-Z", -90.0f, -90.0f);
+    ImGui::NewLine();
+
+    ImGui::BeginDisabled(!app.theMap.georeferencing.has_value());
+    ImGui::Checkbox("Apply georeferenced pose (if available)", &app.applyGeoRef);
+    ImGui::EndDisabled();
+
+    ImGui::End();
 }
 
 /** "Maps" window: layer list, visibility, and colorization options. */
 void renderMapsPanel()
 {
-  ImGui::Begin("Maps");
+    ImGui::Begin("Maps");
 
-  ImGui::SliderFloat("Point size", &app.pointSize, 1.0f, 10.0f);
-  ImGui::Checkbox("Render voxel maps as point clouds", &app.viewVoxelsAsPoints);
-  ImGui::Checkbox("Render free space of voxel maps", &app.viewVoxelsFreeSpace);
+    ImGui::SliderFloat("Point size", &app.pointSize, 1.0f, 10.0f);
+    ImGui::Checkbox("Render voxel maps as point clouds", &app.viewVoxelsAsPoints);
+    ImGui::Checkbox("Render free space of voxel maps", &app.viewVoxelsFreeSpace);
 
-  ImGui::Checkbox("Recolorize points", &app.colorizeMap);
-  ImGui::SameLine();
-  ImGui::TextUnformatted("by:");
-  ImGui::SameLine();
-  ImGui::SetNextItemWidth(140);
-  if (!app.knownPointFields.empty())
-  {
-    const char* preview = app.knownPointFields.at(static_cast<size_t>(app.recolorizeByFieldIdx)).c_str();
-    if (ImGui::BeginCombo("##recolorizeField", preview))
+    ImGui::Checkbox("Recolorize points", &app.colorizeMap);
+    ImGui::SameLine();
+    ImGui::TextUnformatted("by:");
+    ImGui::SameLine();
+    ImGui::SetNextItemWidth(140);
+    if (!app.knownPointFields.empty())
     {
-      for (size_t i = 0; i < app.knownPointFields.size(); i++)
-      {
-        const bool sel = (static_cast<int>(i) == app.recolorizeByFieldIdx);
-        if (ImGui::Selectable(app.knownPointFields[i].c_str(), sel))
+        const char* preview =
+            app.knownPointFields.at(static_cast<size_t>(app.recolorizeByFieldIdx)).c_str();
+        if (ImGui::BeginCombo("##recolorizeField", preview))
         {
-          app.recolorizeByFieldIdx = static_cast<int>(i);
+            for (size_t i = 0; i < app.knownPointFields.size(); i++)
+            {
+                const bool sel = (static_cast<int>(i) == app.recolorizeByFieldIdx);
+                if (ImGui::Selectable(app.knownPointFields[i].c_str(), sel))
+                {
+                    app.recolorizeByFieldIdx = static_cast<int>(i);
+                }
+            }
+            ImGui::EndCombo();
         }
-      }
-      ImGui::EndCombo();
     }
-  }
-  ImGui::SetNextItemWidth(140);
-  ImGui::Combo("##colorMap", &app.colorIntensityIdx, kColorIntensityLabels, kNumColorIntensity);
+    ImGui::SetNextItemWidth(140);
+    ImGui::Combo("##colorMap", &app.colorIntensityIdx, kColorIntensityLabels, kNumColorIntensity);
 
-  ImGui::Checkbox("Keep native map colors", &app.keepNativeCloudColors);
+    ImGui::Checkbox("Keep native map colors", &app.keepNativeCloudColors);
 
-  ImGui::Checkbox("Outlier percentile:", &app.autoBBoxOutliers);
-  ImGui::SameLine();
-  ImGui::BeginDisabled(!app.autoBBoxOutliers);
-  ImGui::SetNextItemWidth(120);
-  ImGui::SliderFloat("##outlierPercentile", &app.autoBBoxOutliersPercentile, 0.0f, 0.25f, "%.3f");
-  ImGui::EndDisabled();
+    ImGui::Checkbox("Outlier percentile:", &app.autoBBoxOutliers);
+    ImGui::SameLine();
+    ImGui::BeginDisabled(!app.autoBBoxOutliers);
+    ImGui::SetNextItemWidth(120);
+    ImGui::SliderFloat("##outlierPercentile", &app.autoBBoxOutliersPercentile, 0.0f, 0.25f, "%.3f");
+    ImGui::EndDisabled();
 
-  ImGui::Separator();
-  ImGui::TextUnformatted("Visible layers:");
-  ImGui::SameLine();
-  if (ImGui::SmallButton("All"))
-  {
-    for (auto& [name, vis] : app.layerVisible)
+    ImGui::Separator();
+    ImGui::TextUnformatted("Visible layers:");
+    ImGui::SameLine();
+    if (ImGui::SmallButton("All"))
     {
-      vis = true;
-    }
-    for (auto& evl : app.extraVizLayers)
-    {
-      evl.visible = true;
-    }
-  }
-  ImGui::SameLine();
-  if (ImGui::SmallButton("None"))
-  {
-    for (auto& [name, vis] : app.layerVisible)
-    {
-      vis = false;
-    }
-    for (auto& evl : app.extraVizLayers)
-    {
-      evl.visible = false;
-    }
-  }
-
-  if (ImGui::BeginChild("##layerList", ImVec2(0, 150), true))
-  {
-    for (const auto& lyName : app.layerNames)
-    {
-      std::string caption = lyName;
-      if (auto itL = app.theMap.layers.find(lyName); itL != app.theMap.layers.end())
-      {
-        if (auto pc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itL->second); pc)
+        for (auto& [name, vis] : app.layerVisible)
         {
-          caption = lyName + " | " +
-                    mrpt::system::unitsFormat(static_cast<double>(pc->size()), 2, false) +
-                    " points | class=" + pc->GetRuntimeClass()->className;
+            vis = true;
         }
-        else
+        for (auto& evl : app.extraVizLayers)
         {
-          caption = lyName + " | class=" + itL->second->GetRuntimeClass()->className;
+            evl.visible = true;
         }
-      }
-      ImGui::Checkbox(caption.c_str(), &app.layerVisible[lyName]);
     }
-    for (auto& evl : app.extraVizLayers)
+    ImGui::SameLine();
+    if (ImGui::SmallButton("None"))
     {
-      ImGui::Checkbox(("(viz) " + evl.fileName).c_str(), &evl.visible);
+        for (auto& [name, vis] : app.layerVisible)
+        {
+            vis = false;
+        }
+        for (auto& evl : app.extraVizLayers)
+        {
+            evl.visible = false;
+        }
     }
-  }
-  ImGui::EndChild();
 
-  ImGui::End();
+    if (ImGui::BeginChild("##layerList", ImVec2(0, 150), true))
+    {
+        for (const auto& lyName : app.layerNames)
+        {
+            std::string caption = lyName;
+            if (auto itL = app.theMap.layers.find(lyName); itL != app.theMap.layers.end())
+            {
+                if (auto pc = std::dynamic_pointer_cast<mrpt::maps::CPointsMap>(itL->second); pc)
+                {
+                    caption = lyName + " | " +
+                              mrpt::system::unitsFormat(static_cast<double>(pc->size()), 2, false) +
+                              " points | class=" + pc->GetRuntimeClass()->className;
+                }
+                else
+                {
+                    caption = lyName + " | class=" + itL->second->GetRuntimeClass()->className;
+                }
+            }
+            ImGui::Checkbox(caption.c_str(), &app.layerVisible[lyName]);
+        }
+        for (auto& evl : app.extraVizLayers)
+        {
+            ImGui::Checkbox(("(viz) " + evl.fileName).c_str(), &evl.visible);
+        }
+    }
+    ImGui::EndChild();
+
+    ImGui::End();
 }
 
 /** "Travelling" window: camera keyframe animation controls. */
 void renderTravellingPanel()
 {
-  ImGui::Begin("Travelling");
+    ImGui::Begin("Travelling");
 
-  ImGui::TextUnformatted("Define camera travelling paths");
+    ImGui::TextUnformatted("Define camera travelling paths");
 
-  ImGui::SetNextItemWidth(-1);
-  if (!app.camTravellingLabels.empty())
-  {
-    const int   selected = static_cast<int>(app.camTravellingLabels.size()) - 1;
-    const char* preview   = app.camTravellingLabels[static_cast<size_t>(selected)].c_str();
-    if (ImGui::BeginCombo("##travellingKeys", preview))
+    ImGui::SetNextItemWidth(-1);
+    if (!app.camTravellingLabels.empty())
     {
-      for (size_t i = 0; i < app.camTravellingLabels.size(); i++)
-      {
-        ImGui::Selectable(app.camTravellingLabels[i].c_str(), false);
-      }
-      ImGui::EndCombo();
+        const int   selected = static_cast<int>(app.camTravellingLabels.size()) - 1;
+        const char* preview  = app.camTravellingLabels[static_cast<size_t>(selected)].c_str();
+        if (ImGui::BeginCombo("##travellingKeys", preview))
+        {
+            for (size_t i = 0; i < app.camTravellingLabels.size(); i++)
+            {
+                ImGui::Selectable(app.camTravellingLabels[i].c_str(), false);
+            }
+            ImGui::EndCombo();
+        }
     }
-  }
 
-  ImGui::InputFloat("New keyframe time [s]", &app.newKeyframeTime);
-  ImGui::SameLine();
-  if (ImGui::Button("Add"))
-  {
-    auto&      cam = app.sceneView.camera();
-    const auto p   = mrpt::math::TPose3D(
-        cam.getPointingAtX(), cam.getPointingAtY(), cam.getPointingAtZ(),
-        mrpt::DEG2RAD(cam.getAzimuthDegrees()), mrpt::DEG2RAD(cam.getElevationDegrees()),
-        cam.getZoomDistance() * TRAVELING_ZOOM2ROLL);
-    app.camTravelling.insert(mrpt::Clock::fromDouble(static_cast<double>(app.newKeyframeTime)), p);
-    rebuildCamTravellingLabels();
-    app.newKeyframeTime += 1.0f;
-  }
+    ImGui::InputFloat("New keyframe time [s]", &app.newKeyframeTime);
+    ImGui::SameLine();
+    if (ImGui::Button("Add"))
+    {
+        auto&      cam = app.sceneView.camera();
+        const auto p   = mrpt::math::TPose3D(
+              cam.getPointingAtX(), cam.getPointingAtY(), cam.getPointingAtZ(),
+              mrpt::DEG2RAD(cam.getAzimuthDegrees()), mrpt::DEG2RAD(cam.getElevationDegrees()),
+              cam.getZoomDistance() * TRAVELING_ZOOM2ROLL);
+        app.camTravelling.insert(
+            mrpt::Clock::fromDouble(static_cast<double>(app.newKeyframeTime)), p);
+        rebuildCamTravellingLabels();
+        app.newKeyframeTime += 1.0f;
+    }
 
-  const bool isPlaying = app.camTravellingCurrentTime.has_value();
-  ImGui::BeginDisabled(isPlaying || app.camTravelling.empty());
-  if (ImGui::Button("Play"))
-  {
-    app.camTravellingCurrentTime.emplace(mrpt::Clock::toDouble(app.camTravelling.begin()->first));
-  }
-  ImGui::EndDisabled();
-  ImGui::SameLine();
-  ImGui::BeginDisabled(!isPlaying);
-  if (ImGui::Button("Stop"))
-  {
-    camTravellingStop();
-  }
-  ImGui::EndDisabled();
+    const bool isPlaying = app.camTravellingCurrentTime.has_value();
+    ImGui::BeginDisabled(isPlaying || app.camTravelling.empty());
+    if (ImGui::Button("Play"))
+    {
+        app.camTravellingCurrentTime.emplace(
+            mrpt::Clock::toDouble(app.camTravelling.begin()->first));
+    }
+    ImGui::EndDisabled();
+    ImGui::SameLine();
+    ImGui::BeginDisabled(!isPlaying);
+    if (ImGui::Button("Stop"))
+    {
+        camTravellingStop();
+    }
+    ImGui::EndDisabled();
 
-  ImGui::InputFloat("Animation FPS", &app.animFPS);
+    ImGui::InputFloat("Animation FPS", &app.animFPS);
 
-  const char* interpItems[] = {"Linear", "Spline"};
-  ImGui::Combo("Interpolation", &app.travellingInterpIdx, interpItems, 2);
+    const char* interpItems[] = {"Linear", "Spline"};
+    ImGui::Combo("Interpolation", &app.travellingInterpIdx, interpItems, 2);
 
-  ImGui::BeginDisabled(true);
-  ImGui::SliderFloat("Progress", &app.animProgress, 0.0f, 1.0f);
-  ImGui::EndDisabled();
+    ImGui::BeginDisabled(true);
+    ImGui::SliderFloat("Progress", &app.animProgress, 0.0f, 1.0f);
+    ImGui::EndDisabled();
 
-  ImGui::End();
+    ImGui::End();
 }
 
 /** "3D View" window: fills the remaining (background) dockspace area. */
 void renderSceneWindow()
 {
-  ImGui::Begin("3D View");
-  app.sceneView.render();
-  ImGui::End();
+    ImGui::Begin("3D View");
+    app.sceneView.render();
+    ImGui::End();
 }
 
 void renderFrame()
 {
-  handleKeyboard();
-  processCameraTravelling();
-  rebuild_3d_view();
-  updateCameraClipDistances();
-  updateMiniCornerView();
+    handleKeyboard();
+    processCameraTravelling();
+    rebuild_3d_view();
+    updateCameraClipDistances();
+    updateMiniCornerView();
 
-  renderMapViewerPanel();
-  renderViewPanel();
-  renderMapsPanel();
-  renderTravellingPanel();
-  renderSceneWindow();
+    renderMapViewerPanel();
+    renderViewPanel();
+    renderMapsPanel();
+    renderTravellingPanel();
+    renderSceneWindow();
 }
 
 int mainShowGui()
 {
-  using namespace std::string_literals;
+    using namespace std::string_literals;
 
-  if (!argMapFile.empty())
-  {
-    if (!loadMapFile(argMapFile))
+    if (!argMapFile.empty())
     {
-      return 1;
+        if (!loadMapFile(argMapFile))
+        {
+            return 1;
+        }
     }
-  }
 
-  if (!arg_georefPolygon.empty())
-  {
-    if (!app.theMap.georeferencing.has_value())
+    if (!arg_georefPolygon.empty())
     {
-      std::cerr << "Warning: --georef-polygon given, but the loaded map has no "
-                   "georeferencing information. Ignoring it.\n";
+        if (!app.theMap.georeferencing.has_value())
+        {
+            std::cerr << "Warning: --georef-polygon given, but the loaded map has no "
+                         "georeferencing information. Ignoring it.\n";
+        }
+        else
+        {
+            try
+            {
+                const auto latLonPoints = readLatLonPolygonFile(arg_georefPolygon);
+
+                ExtraVizLayer evl;
+                evl.fileName = mrpt::system::extractFileName(arg_georefPolygon);
+                evl.glObjects =
+                    buildGeorefPolygonLayer(latLonPoints, app.theMap.georeferencing.value());
+                evl.glObjects->setName(evl.fileName);
+
+                app.extraVizLayers.push_back(evl);
+            }
+            catch (const std::exception& e)
+            {
+                std::cerr << "Warning: could not load georef polygon: " << e.what() << "\n";
+            }
+        }
     }
-    else
+
+    if (!app.shell.init(APP_NAME, 1280, 800))
     {
-      try
-      {
-        const auto latLonPoints = readLatLonPolygonFile(arg_georefPolygon);
-
-        ExtraVizLayer evl;
-        evl.fileName  = mrpt::system::extractFileName(arg_georefPolygon);
-        evl.glObjects = buildGeorefPolygonLayer(latLonPoints, app.theMap.georeferencing.value());
-        evl.glObjects->setName(evl.fileName);
-
-        app.extraVizLayers.push_back(evl);
-      }
-      catch (const std::exception& e)
-      {
-        std::cerr << "Warning: could not load georef polygon: " << e.what() << "\n";
-      }
+        return 1;
     }
-  }
 
-  if (!app.shell.init(APP_NAME, 1280, 800))
-  {
-    return 1;
-  }
+    // Default docking layout (only applied once, when no imgui.ini layout exists yet):
+    // "Map viewer" as a thin left strip, View/Maps/Travelling tabbed below it, and the 3D
+    // scene filling the remaining (background) area.
+    app.shell.setupDefaultLayout = [](unsigned int dockspaceId)
+    {
+        ImGuiID rightId = 0;
+        ImGuiID leftId =
+            ImGui::DockBuilderSplitNode(dockspaceId, ImGuiDir_Left, 0.28f, nullptr, &rightId);
 
-  // Default docking layout (only applied once, when no imgui.ini layout exists yet):
-  // "Map viewer" as a thin left strip, View/Maps/Travelling tabbed below it, and the 3D
-  // scene filling the remaining (background) area.
-  app.shell.setupDefaultLayout = [](unsigned int dockspaceId)
-  {
-    ImGuiID rightId = 0;
-    ImGuiID leftId  = ImGui::DockBuilderSplitNode(dockspaceId, ImGuiDir_Left, 0.28f, nullptr, &rightId);
+        ImGuiID leftBottomId = 0;
+        ImGuiID leftTopId =
+            ImGui::DockBuilderSplitNode(leftId, ImGuiDir_Up, 0.32f, nullptr, &leftBottomId);
 
-    ImGuiID leftBottomId = 0;
-    ImGuiID leftTopId =
-        ImGui::DockBuilderSplitNode(leftId, ImGuiDir_Up, 0.32f, nullptr, &leftBottomId);
+        // "Maps" gets its own independent docked panel, separate from the View/Travelling tab
+        // group.
+        ImGuiID leftMapsId =
+            ImGui::DockBuilderSplitNode(leftBottomId, ImGuiDir_Down, 0.45f, nullptr, &leftBottomId);
 
-    // "Maps" gets its own independent docked panel, separate from the View/Travelling tab group.
-    ImGuiID leftMapsId =
-        ImGui::DockBuilderSplitNode(leftBottomId, ImGuiDir_Down, 0.45f, nullptr, &leftBottomId);
+        ImGui::DockBuilderDockWindow("Map viewer", leftTopId);
+        ImGui::DockBuilderDockWindow("View", leftBottomId);
+        ImGui::DockBuilderDockWindow("Travelling", leftBottomId);
+        ImGui::DockBuilderDockWindow("Maps", leftMapsId);
+        ImGui::DockBuilderDockWindow("3D View", rightId);
+    };
 
-    ImGui::DockBuilderDockWindow("Map viewer", leftTopId);
-    ImGui::DockBuilderDockWindow("View", leftBottomId);
-    ImGui::DockBuilderDockWindow("Travelling", leftBottomId);
-    ImGui::DockBuilderDockWindow("Maps", leftMapsId);
-    ImGui::DockBuilderDockWindow("3D View", rightId);
-  };
+    // Background scene:
+    app.glGrid->setColor_u8(0xff, 0xff, 0xff, 0x10);
+    app.scene->insert(app.glGrid);
 
-  // Background scene:
-  app.glGrid->setColor_u8(0xff, 0xff, 0xff, 0x10);
-  app.scene->insert(app.glGrid);
+    app.glMapCorner = mrpt::opengl::stock_objects::CornerXYZ(1.0f);
+    app.glMapCorner->setName("map");
+    app.glMapCorner->enableShowName();
 
-  app.glMapCorner = mrpt::opengl::stock_objects::CornerXYZ(1.0f);
-  app.glMapCorner->setName("map");
-  app.glMapCorner->enableShowName();
+    app.glENUCorner = mrpt::opengl::stock_objects::CornerXYZ(2.0f);
+    app.glENUCorner->setName("ENU");
+    app.glENUCorner->enableShowName();
+    app.scene->insert(app.glENUCorner);
 
-  app.glENUCorner = mrpt::opengl::stock_objects::CornerXYZ(2.0f);
-  app.glENUCorner->setName("ENU");
-  app.glENUCorner->enableShowName();
-  app.scene->insert(app.glENUCorner);
+    app.scene->insert(app.glVizMap);
 
-  app.scene->insert(app.glVizMap);
+    app.sceneView.setScene(app.scene);
+    app.sceneView.onOverlayGui = &renderSceneOverlay;
 
-  app.sceneView.setScene(app.scene);
-  app.sceneView.onOverlayGui = &renderSceneOverlay;
+    app.sceneView.camera().setPointingAt(8.0f, 0.0f, 0.0f);
+    app.sceneView.camera().setAzimuthDegrees(110.0f);
+    app.sceneView.camera().setElevationDegrees(15.0f);
+    app.sceneView.camera().setZoomDistance(50.0f);
 
-  app.sceneView.camera().setPointingAt(8.0f, 0.0f, 0.0f);
-  app.sceneView.camera().setAzimuthDegrees(110.0f);
-  app.sceneView.camera().setElevationDegrees(15.0f);
-  app.sceneView.camera().setZoomDistance(50.0f);
+    updateGuiAfterLoadingNewMap();
+    rebuildCamTravellingLabels();
 
-  updateGuiAfterLoadingNewMap();
-  rebuildCamTravellingLabels();
+    // Load/save persistent UI+camera state across sessions (separate from imgui.ini, which
+    // only remembers panel docking):
+    char appCfgFile[1024];
+    ::get_user_config_file(appCfgFile, sizeof(appCfgFile), APP_NAME);
+    mrpt::config::CConfigFile appCfg(appCfgFile);
 
-  // Load/save persistent UI+camera state across sessions (separate from imgui.ini, which
-  // only remembers panel docking):
-  char appCfgFile[1024];
-  ::get_user_config_file(appCfgFile, sizeof(appCfgFile), APP_NAME);
-  mrpt::config::CConfigFile appCfg(appCfgFile);
+    auto& cam               = app.sceneView.camera();
+    app.applyGeoRef         = appCfg.read_bool("", "applyGeoRef", app.applyGeoRef);
+    app.viewOrtho           = appCfg.read_bool("", "viewOrtho", app.viewOrtho);
+    app.view2D              = appCfg.read_bool("", "view2D", app.view2D);
+    app.viewVoxelsAsPoints  = appCfg.read_bool("", "viewVoxelsAsPoints", app.viewVoxelsAsPoints);
+    app.viewVoxelsFreeSpace = appCfg.read_bool("", "viewVoxelsFreeSpace", app.viewVoxelsFreeSpace);
+    app.colorizeMap         = appCfg.read_bool("", "colorizeMap", app.colorizeMap);
+    app.keepNativeCloudColors =
+        appCfg.read_bool("", "keepNativeCloudColors", app.keepNativeCloudColors);
+    app.autoBBoxOutliers = appCfg.read_bool("", "autoBBoxOutliers", app.autoBBoxOutliers);
+    app.showGroundGrid   = appCfg.read_bool("", "showGroundGrid", app.showGroundGrid);
+    app.depthLogScale    = appCfg.read_bool("", "depthLogScale", app.depthLogScale);
 
-  auto& cam = app.sceneView.camera();
-  app.applyGeoRef           = appCfg.read_bool("", "applyGeoRef", app.applyGeoRef);
-  app.viewOrtho             = appCfg.read_bool("", "viewOrtho", app.viewOrtho);
-  app.view2D                = appCfg.read_bool("", "view2D", app.view2D);
-  app.viewVoxelsAsPoints    = appCfg.read_bool("", "viewVoxelsAsPoints", app.viewVoxelsAsPoints);
-  app.viewVoxelsFreeSpace   = appCfg.read_bool("", "viewVoxelsFreeSpace", app.viewVoxelsFreeSpace);
-  app.colorizeMap           = appCfg.read_bool("", "colorizeMap", app.colorizeMap);
-  app.keepNativeCloudColors = appCfg.read_bool("", "keepNativeCloudColors", app.keepNativeCloudColors);
-  app.autoBBoxOutliers      = appCfg.read_bool("", "autoBBoxOutliers", app.autoBBoxOutliers);
-  app.showGroundGrid        = appCfg.read_bool("", "showGroundGrid", app.showGroundGrid);
-  app.depthLogScale         = appCfg.read_bool("", "depthLogScale", app.depthLogScale);
+    app.pointSize = appCfg.read_float("", "pointSize", app.pointSize);
+    app.autoBBoxOutliersPercentile =
+        appCfg.read_float("", "autoBBoxOutliersPercentile", app.autoBBoxOutliersPercentile);
+    app.trajectoryThicknessLog =
+        appCfg.read_float("", "trajectoryThicknessLog", app.trajectoryThicknessLog);
+    app.clipNear  = appCfg.read_float("", "clipNear", app.clipNear);
+    app.clipFar   = appCfg.read_float("", "clipFar", app.clipFar);
+    app.cameraFOV = appCfg.read_float("", "cameraFOV", app.cameraFOV);
 
-  app.pointSize                  = appCfg.read_float("", "pointSize", app.pointSize);
-  app.autoBBoxOutliersPercentile = appCfg.read_float(
-      "", "autoBBoxOutliersPercentile", app.autoBBoxOutliersPercentile);
-  app.trajectoryThicknessLog = appCfg.read_float("", "trajectoryThicknessLog", app.trajectoryThicknessLog);
-  app.clipNear               = appCfg.read_float("", "clipNear", app.clipNear);
-  app.clipFar                = appCfg.read_float("", "clipFar", app.clipFar);
-  app.cameraFOV              = appCfg.read_float("", "cameraFOV", app.cameraFOV);
+    cam.setPointingAt(
+        appCfg.read_float("", "cam_x", cam.getPointingAtX()),
+        appCfg.read_float("", "cam_y", cam.getPointingAtY()),
+        appCfg.read_float("", "cam_z", cam.getPointingAtZ()));
+    cam.setAzimuthDegrees(appCfg.read_float("", "cam_az", cam.getAzimuthDegrees()));
+    cam.setElevationDegrees(appCfg.read_float("", "cam_el", cam.getElevationDegrees()));
+    cam.setZoomDistance(appCfg.read_float("", "cam_d", cam.getZoomDistance()));
 
-  cam.setPointingAt(
-      appCfg.read_float("", "cam_x", cam.getPointingAtX()),
-      appCfg.read_float("", "cam_y", cam.getPointingAtY()),
-      appCfg.read_float("", "cam_z", cam.getPointingAtZ()));
-  cam.setAzimuthDegrees(appCfg.read_float("", "cam_az", cam.getAzimuthDegrees()));
-  cam.setElevationDegrees(appCfg.read_float("", "cam_el", cam.getElevationDegrees()));
-  cam.setZoomDistance(appCfg.read_float("", "cam_d", cam.getZoomDistance()));
+    app.shell.run(&renderFrame);
 
-  app.shell.run(&renderFrame);
+    appCfg.write("", "applyGeoRef", app.applyGeoRef);
+    appCfg.write("", "viewOrtho", app.viewOrtho);
+    appCfg.write("", "view2D", app.view2D);
+    appCfg.write("", "viewVoxelsAsPoints", app.viewVoxelsAsPoints);
+    appCfg.write("", "viewVoxelsFreeSpace", app.viewVoxelsFreeSpace);
+    appCfg.write("", "colorizeMap", app.colorizeMap);
+    appCfg.write("", "keepNativeCloudColors", app.keepNativeCloudColors);
+    appCfg.write("", "autoBBoxOutliers", app.autoBBoxOutliers);
+    appCfg.write("", "showGroundGrid", app.showGroundGrid);
+    appCfg.write("", "depthLogScale", app.depthLogScale);
 
-  appCfg.write("", "applyGeoRef", app.applyGeoRef);
-  appCfg.write("", "viewOrtho", app.viewOrtho);
-  appCfg.write("", "view2D", app.view2D);
-  appCfg.write("", "viewVoxelsAsPoints", app.viewVoxelsAsPoints);
-  appCfg.write("", "viewVoxelsFreeSpace", app.viewVoxelsFreeSpace);
-  appCfg.write("", "colorizeMap", app.colorizeMap);
-  appCfg.write("", "keepNativeCloudColors", app.keepNativeCloudColors);
-  appCfg.write("", "autoBBoxOutliers", app.autoBBoxOutliers);
-  appCfg.write("", "showGroundGrid", app.showGroundGrid);
-  appCfg.write("", "depthLogScale", app.depthLogScale);
+    appCfg.write("", "pointSize", app.pointSize);
+    appCfg.write("", "autoBBoxOutliersPercentile", app.autoBBoxOutliersPercentile);
+    appCfg.write("", "trajectoryThicknessLog", app.trajectoryThicknessLog);
+    appCfg.write("", "clipNear", app.clipNear);
+    appCfg.write("", "clipFar", app.clipFar);
+    appCfg.write("", "cameraFOV", app.cameraFOV);
 
-  appCfg.write("", "pointSize", app.pointSize);
-  appCfg.write("", "autoBBoxOutliersPercentile", app.autoBBoxOutliersPercentile);
-  appCfg.write("", "trajectoryThicknessLog", app.trajectoryThicknessLog);
-  appCfg.write("", "clipNear", app.clipNear);
-  appCfg.write("", "clipFar", app.clipFar);
-  appCfg.write("", "cameraFOV", app.cameraFOV);
+    appCfg.write("", "cam_x", cam.getPointingAtX());
+    appCfg.write("", "cam_y", cam.getPointingAtY());
+    appCfg.write("", "cam_z", cam.getPointingAtZ());
+    appCfg.write("", "cam_az", cam.getAzimuthDegrees());
+    appCfg.write("", "cam_el", cam.getElevationDegrees());
+    appCfg.write("", "cam_d", cam.getZoomDistance());
 
-  appCfg.write("", "cam_x", cam.getPointingAtX());
-  appCfg.write("", "cam_y", cam.getPointingAtY());
-  appCfg.write("", "cam_z", cam.getPointingAtZ());
-  appCfg.write("", "cam_az", cam.getAzimuthDegrees());
-  appCfg.write("", "cam_el", cam.getElevationDegrees());
-  appCfg.write("", "cam_d", cam.getZoomDistance());
-
-  app.shell.shutdown();
-  return 0;
+    app.shell.shutdown();
+    return 0;
 }
 
 }  // namespace
 
 int main(int argc, char** argv)
 {
-  cmd.add_option("input", argMapFile, "Load this metric map file (*.mm)");
-  cmd.add_option(
-      "-l,--load-plugins", arg_plugins, "One or more (comma separated) *.so files to load as plugins");
-  cmd.add_option(
-      "-t,--trajectory", arg_tumTrajectory, "Also draw a trajectory, given by a TUM file trajectory.");
-  cmd.add_option(
-      "-s,--add-3d-scene", arg_add3dScenes, "Adds an extra 3D scene file (*.3dscene) for visualization.");
-  cmd.add_option(
-      "-g,--georef-polygon", arg_georefPolygon,
-      "Overlay a polygon given by a text file with one \"lat,lon\" vertex (WGS84 degrees) per "
-      "line. Ignored if the loaded map has no georeferencing information.");
+    cmd.add_option("input", argMapFile, "Load this metric map file (*.mm)");
+    cmd.add_option(
+        "-l,--load-plugins", arg_plugins,
+        "One or more (comma separated) *.so files to load as plugins");
+    cmd.add_option(
+        "-t,--trajectory", arg_tumTrajectory,
+        "Also draw a trajectory, given by a TUM file trajectory.");
+    cmd.add_option(
+        "-s,--add-3d-scene", arg_add3dScenes,
+        "Adds an extra 3D scene file (*.3dscene) for visualization.");
+    cmd.add_option(
+        "-g,--georef-polygon", arg_georefPolygon,
+        "Overlay a polygon given by a text file with one \"lat,lon\" vertex (WGS84 degrees) per "
+        "line. Ignored if the loaded map has no georeferencing information.");
 
-  CLI11_PARSE(cmd, argc, argv);
+    CLI11_PARSE(cmd, argc, argv);
 
-  try
-  {
-    if (!arg_plugins.empty())
+    try
     {
-      if (!load_plugins(arg_plugins))
-      {
+        if (!arg_plugins.empty())
+        {
+            if (!load_plugins(arg_plugins))
+            {
+                return 1;
+            }
+        }
+
+        if (!arg_tumTrajectory.empty())
+        {
+            ASSERT_FILE_EXISTS_(arg_tumTrajectory);
+            const bool trajectoryReadOk = app.trajectory.loadFromTextFile_TUM(arg_tumTrajectory);
+            ASSERT_(trajectoryReadOk);
+            std::cout << "Read trajectory with " << app.trajectory.size() << " keyframes.\n";
+        }
+
+        for (const auto& path : arg_add3dScenes)
+        {
+            ASSERT_FILE_EXISTS_(path);
+            auto scene  = mrpt::opengl::Scene::Create();
+            bool readOk = scene->loadFromFile(path);
+            ASSERT_(readOk);
+
+            ExtraVizLayer evl;
+            evl.fileName  = mrpt::system::extractFileName(path);
+            evl.glObjects = mrpt::opengl::CSetOfObjects::Create();
+            evl.glObjects->setName(evl.fileName);
+
+            for (const auto& obj : *scene->getViewport())
+            {
+                evl.glObjects->insert(obj);
+            }
+
+            app.extraVizLayers.push_back(evl);
+        }
+
+        return mainShowGui();
+    }
+    catch (std::exception& e)
+    {
+        std::cerr << "Exit due to exception:\n" << mrpt::exception_to_str(e) << std::endl;
         return 1;
-      }
     }
-
-    if (!arg_tumTrajectory.empty())
-    {
-      ASSERT_FILE_EXISTS_(arg_tumTrajectory);
-      const bool trajectoryReadOk = app.trajectory.loadFromTextFile_TUM(arg_tumTrajectory);
-      ASSERT_(trajectoryReadOk);
-      std::cout << "Read trajectory with " << app.trajectory.size() << " keyframes.\n";
-    }
-
-    for (const auto& path : arg_add3dScenes)
-    {
-      ASSERT_FILE_EXISTS_(path);
-      auto scene  = mrpt::opengl::Scene::Create();
-      bool readOk = scene->loadFromFile(path);
-      ASSERT_(readOk);
-
-      ExtraVizLayer evl;
-      evl.fileName  = mrpt::system::extractFileName(path);
-      evl.glObjects = mrpt::opengl::CSetOfObjects::Create();
-      evl.glObjects->setName(evl.fileName);
-
-      for (const auto& obj : *scene->getViewport())
-      {
-        evl.glObjects->insert(obj);
-      }
-
-      app.extraVizLayers.push_back(evl);
-    }
-
-    return mainShowGui();
-  }
-  catch (std::exception& e)
-  {
-    std::cerr << "Exit due to exception:\n" << mrpt::exception_to_str(e) << std::endl;
-    return 1;
-  }
 }

--- a/mp2p_icp_viz/apps/mm-viewer/main.cpp
+++ b/mp2p_icp_viz/apps/mm-viewer/main.cpp
@@ -61,6 +61,15 @@ constexpr const char* APP_NAME = "mm-viewer";
 
 constexpr float TRAVELING_ZOOM2ROLL = 1e-4f;
 
+// Small axis-corner gizmo viewports ("Map frame" / "ENU frame"), kept for parity with the old
+// nanogui app. NOTE: with MRPT 2.x, `mrpt::imgui::CImGuiSceneView::render()` only renders the
+// scene's "main" viewport, so these two extra viewports are created and kept up to date but are
+// not currently visible on screen. MRPT 3.x is expected to support rendering arbitrary named
+// viewports through the same mechanism, so this code is intentionally NOT removed -- it should
+// start working again, unmodified, once this project moves to MRPT 3.x.
+constexpr const char* FIRST_MINI_VIEW_NAME  = "small-view-1";
+constexpr const char* SECOND_MINI_VIEW_NAME = "small-view-2";
+
 const char* const kColorIntensityNames[]  = {"cmNONE", "cmHOT", "cmJET", "cmGRAYSCALE"};
 const char* const kColorIntensityLabels[] = {"None", "Hot", "Jet", "Grayscale"};
 constexpr int      kNumColorIntensity     = 4;
@@ -504,6 +513,124 @@ void renderSceneOverlay()
   }
 }
 
+/** Creates the "Map frame"/"ENU frame" axis-corner gizmo viewports once. See the comment next to
+ * FIRST_MINI_VIEW_NAME/SECOND_MINI_VIEW_NAME above: not currently rendered under MRPT 2.x. */
+void ensureMiniCornerViewports()
+{
+  if (!app.scene->getViewport(FIRST_MINI_VIEW_NAME))
+  {
+    auto gl_view = app.scene->createViewport(FIRST_MINI_VIEW_NAME);
+
+    gl_view->setViewportPosition(0, 0, 0.1, 0.1 * 16.0 / 9.0);
+    gl_view->setTransparent(true);
+    {
+      mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("X");
+      obj->setLocation(1.1, 0, 0);
+      gl_view->insert(obj);
+    }
+    {
+      mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Y");
+      obj->setLocation(0, 1.1, 0);
+      gl_view->insert(obj);
+    }
+    {
+      mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Z");
+      obj->setLocation(0, 0, 1.1);
+      gl_view->insert(obj);
+    }
+    gl_view->insert(mrpt::opengl::stock_objects::CornerXYZ());
+  }
+
+  if (!app.scene->getViewport(SECOND_MINI_VIEW_NAME))
+  {
+    auto gl_view = app.scene->createViewport(SECOND_MINI_VIEW_NAME);
+
+    gl_view->setViewportPosition(0.1, 0, 0.1, 0.1 * 16.0 / 9.0);
+    gl_view->setTransparent(true);
+
+    auto glRoot = mrpt::opengl::CSetOfObjects::Create();
+    gl_view->insert(glRoot);
+
+    {
+      mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("X");
+      obj->setLocation(1.1, 0, 0);
+      glRoot->insert(obj);
+    }
+    {
+      mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Y");
+      obj->setLocation(0, 1.1, 0);
+      glRoot->insert(obj);
+    }
+    {
+      mrpt::opengl::CText::Ptr obj = mrpt::opengl::CText::Create("Z");
+      obj->setLocation(0, 0, 1.1);
+      glRoot->insert(obj);
+    }
+    glRoot->insert(mrpt::opengl::stock_objects::CornerXYZ());
+  }
+}
+
+/** Keeps the mini-corner viewport cameras/labels in sync with the main camera each frame.
+ * See the comment next to FIRST_MINI_VIEW_NAME/SECOND_MINI_VIEW_NAME above: not currently
+ * rendered under MRPT 2.x. */
+void updateMiniCornerView()
+{
+  auto gl_view1 = app.scene->getViewport(FIRST_MINI_VIEW_NAME);
+  if (!gl_view1)
+  {
+    return;
+  }
+
+  mrpt::opengl::TFontParams fp;
+  fp.draw_shadow = true;
+  fp.vfont_scale = 9.0f;
+
+  {
+    mrpt::opengl::CCamera& view_cam = gl_view1->getCamera();
+    view_cam.setAzimuthDegrees(app.sceneView.camera().getAzimuthDegrees());
+    view_cam.setElevationDegrees(app.sceneView.camera().getElevationDegrees());
+    view_cam.setZoomDistance(5);
+  }
+
+  const bool show_two_corners = app.applyGeoRef && app.theMap.georeferencing.has_value();
+
+  gl_view1->clearTextMessages();
+  gl_view1->addTextMessage(5, 5, show_two_corners ? "ENU frame" : "Map frame", 0, fp);
+
+  auto gl_view2 = app.scene->getViewport(SECOND_MINI_VIEW_NAME);
+  if (!gl_view2 || gl_view2->empty())
+  {
+    return;
+  }
+
+  auto glRoot = *gl_view2->begin();
+  if (!glRoot)
+  {
+    return;
+  }
+  glRoot->setVisibility(show_two_corners);
+
+  if (!show_two_corners)
+  {
+    gl_view2->clearTextMessages();
+    return;
+  }
+
+  glRoot->setPose(mrpt::poses::CPose3D::FromRotationAndTranslation(
+      app.theMap.georeferencing->T_enu_to_map.mean.getRotationMatrix(),
+      mrpt::math::TVector3D(0, 0, 0)));
+
+  {
+    mrpt::opengl::CCamera& view_cam = gl_view2->getCamera();
+    view_cam.setAzimuthDegrees(app.sceneView.camera().getAzimuthDegrees());
+    view_cam.setElevationDegrees(app.sceneView.camera().getElevationDegrees());
+    view_cam.setZoomDistance(5);
+  }
+
+  gl_view2->clearTextMessages();
+  gl_view2->addTextMessage(5, 5, "Map frame", 0, fp);
+}
+
 void updateGuiAfterLoadingNewMap()
 {
   app.layerVisible.clear();
@@ -893,6 +1020,8 @@ void rebuild_3d_view()
     app.sceneView.camera().setElevationDegrees(90.0f);
   }
 
+  ensureMiniCornerViewports();
+
   // Clip planes/FOV are refreshed every frame in updateCameraClipDistances(),
   // since the "linear" clip mode needs the up-to-date camera pose.
 }
@@ -1216,6 +1345,7 @@ void renderFrame()
   processCameraTravelling();
   rebuild_3d_view();
   updateCameraClipDistances();
+  updateMiniCornerView();
 
   renderMapViewerPanel();
   renderViewPanel();
@@ -1280,10 +1410,14 @@ int mainShowGui()
     ImGuiID leftTopId =
         ImGui::DockBuilderSplitNode(leftId, ImGuiDir_Up, 0.32f, nullptr, &leftBottomId);
 
+    // "Maps" gets its own independent docked panel, separate from the View/Travelling tab group.
+    ImGuiID leftMapsId =
+        ImGui::DockBuilderSplitNode(leftBottomId, ImGuiDir_Down, 0.45f, nullptr, &leftBottomId);
+
     ImGui::DockBuilderDockWindow("Map viewer", leftTopId);
     ImGui::DockBuilderDockWindow("View", leftBottomId);
-    ImGui::DockBuilderDockWindow("Maps", leftBottomId);
     ImGui::DockBuilderDockWindow("Travelling", leftBottomId);
+    ImGui::DockBuilderDockWindow("Maps", leftMapsId);
     ImGui::DockBuilderDockWindow("3D View", rightId);
   };
 

--- a/mp2p_icp_viz/package.xml
+++ b/mp2p_icp_viz/package.xml
@@ -23,6 +23,7 @@
   <depend>mrpt_libgui</depend>
   <depend>cli11</depend>
   <depend>libglfw3-dev</depend>
+  <depend>glut</depend>  <!-- Temporary dep: remove once ported to MRPT3 -->
 
   <test_depend condition="$ROS_VERSION == 1">catkin</test_depend>
 

--- a/mp2p_icp_viz/package.xml
+++ b/mp2p_icp_viz/package.xml
@@ -22,6 +22,7 @@
   <depend>mp2p_icp_core</depend>
   <depend>mrpt_libgui</depend>
   <depend>cli11</depend>
+  <depend>libglfw3-dev</depend>
 
   <test_depend condition="$ROS_VERSION == 1">catkin</test_depend>
 


### PR DESCRIPTION
## Summary

Migrates both GUI apps in `mp2p_icp_viz` (`mm-viewer`, `icp-log-viewer`) from `mrpt::gui::CDisplayWindowGUI` + nanogui to Dear ImGui (docking branch), on top of `mrpt::imgui::CImGuiSceneView` (ships with `mrpt::gui` >= 2.15.19).

- Dear ImGui vendored **once** as a git submodule (`mp2p_icp_viz/3rdparty/imgui`, docking branch), built as a private static lib that is never installed/exported.
- Shared infrastructure in `mp2p_icp_viz/apps/imgui_app_common/`: `ImGuiAppShell` (GLFW/GL/docking boilerplate + a `setupDefaultLayout` hook so each app defines its own default panel layout) and `SimpleFileDialog` (self-contained ImGui file browser, no native/system dialog dependency).
- Both apps split into independent dockable panels (Map viewer/View/Maps/Travelling for mm-viewer; Control/Summary/Variables/Maps/Pairings/View/Manual for icp-log-viewer), with a default docking layout applied only on first run.
- Feature parity kept with the old nanogui apps: layer visibility/recolorization, clip/FOV/ortho/2D view options, camera travelling keyframe animation, mouse/camera coordinate readout, keyboard navigation, pairing visualization, prior/uncertainty ellipsoids, and persisted UI/camera state (now under `~/.config/<app>/`).
- The small axis-corner gizmo mini-viewports are restored (kept in sync every frame) but currently inert under MRPT 2.x (`CImGuiSceneView` only renders the `"main"` viewport) — documented in `agents.md` since MRPT 3.x is expected to support this and the code should start working again unmodified.
- Fixed an ImGui duplicate-ID bug found during testing (icp-log-viewer's global/local layer checkboxes collided when both maps share a layer name).

See `~/plans/mp2p_icp_imgui_port.md` (not part of this repo) for the full phased plan/status.

## Test plan

- [x] `colcon build --packages-select mp2p_icp_viz` builds clean
- [x] `find install -iname '*imgui*'` returns nothing (imgui never installed/exported)
- [x] `mm-viewer` manually run against `mp2p_icp_core/demos/global_001.mm`: load, layer toggles, recolorization, camera, default docking layout all verified visually
- [x] `icp-log-viewer` manually run against a real `.icplog` generated via `icp-run -d`: record load, stats, dynamic variables, pairings, default docking layout all verified visually
- [x] `clang-format-14 --dry-run --Werror` clean via `mp2p_icp_core/scripts/formatter.sh --check`
- [ ] CI (colcon build/tests) — pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the legacy map viewer and ICP log viewer UIs with dockable Dear ImGui-based interfaces (mm-viewer and icp-log-viewer).
  * Added persistent layouts/settings, richer dockable panels, interactive 3D viewing, and in-app export.
  * Introduced an ImGui-based open/save file dialog, plus georeferenced overlay support and optional extra 3D scene loading.
* **Documentation**
  * Documented the ongoing ImGui migration and a known MRPT 2.x mini-viewport rendering limitation.
* **Build**
  * Vendored Dear ImGui (docking) via a shared app-shell/common components and updated build/manifest to pull required graphics headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->