### PR TITLE
fix: skip non-finite points when rendering a point map layer

### DIFF
--- a/mp2p_icp_core/mp2p_icp_map/src/metricmap.cpp
+++ b/mp2p_icp_core/mp2p_icp_map/src/metricmap.cpp
@@ -97,6 +97,53 @@ mrpt::maps::CPointsMap::Ptr onlyFinitePoints(const mrpt::maps::CPointsMap& src)
 
     return out;
 }
+
+inline bool isFiniteXYZ(const mrpt::math::TPoint3Df& p)
+{
+    return std::isfinite(p.x) && std::isfinite(p.y) && std::isfinite(p.z);
+}
+
+/** Drops the non-finite points of an already-built render object, in place,
+ *  keeping each surviving point's own color.
+ *
+ *  This is the counterpart of onlyFinitePoints() for the render path that
+ *  delegates to the map's own getVisualizationInto(): there the map draws
+ *  itself, so there is no source cloud to filter beforehand, and replacing it
+ *  with a filtered copy would lose the very renderer that path exists to use.
+ */
+void dropNonFinitePoints(mrpt::opengl::CPointCloudColoured& glPts)
+{
+    const size_t n   = glPts.size();
+    size_t       dst = 0;
+    for (size_t src = 0; src < n; src++)
+    {
+        const auto p = glPts.getPoint3Df(src);
+        if (!isFiniteXYZ(p)) continue;
+
+        if (dst != src)
+        {
+            const auto c = glPts.getPointColor(src);
+            glPts.setPoint_fast(dst, {p.x, p.y, p.z, c.R, c.G, c.B, c.A});
+        }
+        dst++;
+    }
+    if (dst != n) glPts.resize(dst);
+}
+
+void dropNonFinitePoints(mrpt::opengl::CPointCloud& glPts)
+{
+    const size_t n   = glPts.size();
+    size_t       dst = 0;
+    for (size_t src = 0; src < n; src++)
+    {
+        const auto p = glPts[src];
+        if (!isFiniteXYZ(p)) continue;
+
+        if (dst != src) glPts.setPoint_fast(dst, p.x, p.y, p.z);
+        dst++;
+    }
+    if (dst != n) glPts.resize(dst);
+}
 }  // namespace
 
 // Implementation of the CSerializable virtual interface:
@@ -381,7 +428,8 @@ void metric_map_t::get_visualization_map_layer(
         map->getVisualizationInto(o);
 
         // apply the point size to ALL point cloud objects (a map type such as
-        // KeyframePointCloudMap inserts one object per keyframe):
+        // KeyframePointCloudMap inserts one object per keyframe), and drop the
+        // non-finite points the map may have drawn (see dropNonFinitePoints()):
         for (size_t ith = 0;; ith++)
         {
             auto glPtsCol = o.getByClass<mrpt::opengl::CPointCloudColoured>(ith);
@@ -389,6 +437,7 @@ void metric_map_t::get_visualization_map_layer(
             {
                 break;
             }
+            dropNonFinitePoints(*glPtsCol);
             glPtsCol->setPointSize(p.pointSize);
             if (p.force_alpha_channel)
             {
@@ -402,6 +451,7 @@ void metric_map_t::get_visualization_map_layer(
             {
                 break;
             }
+            dropNonFinitePoints(*glPts);
             glPts->setPointSize(p.pointSize);
         }
 

--- a/mp2p_icp_core/mp2p_icp_map/src/metricmap.cpp
+++ b/mp2p_icp_core/mp2p_icp_map/src/metricmap.cpp
@@ -21,6 +21,7 @@
 #include <mp2p_icp/MetricMapMergeCapable.h>
 #include <mp2p_icp/metricmap.h>
 #include <mrpt/containers/yaml.h>
+#include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/maps/CVoxelMap.h>
 #include <mrpt/maps/CVoxelMapRGB.h>
 #include <mrpt/obs/customizable_obs_viz.h>
@@ -44,12 +45,59 @@
 #endif
 
 #include <algorithm>
+#include <cmath>
 #include <iterator>
 #include <sstream>
 
 IMPLEMENTS_MRPT_OBJECT(metric_map_t, mrpt::serialization::CSerializable, mp2p_icp)
 
 using namespace mp2p_icp;
+
+namespace
+{
+/** Returns a copy of `src` holding only its finite points, or an empty smart
+ *  pointer if every point is already finite (so callers can keep using the
+ *  original map and pay no copy in the usual case).
+ *
+ *  Some point map classes expose storage slots that hold no point: e.g.
+ *  mola::IncrementalPointCloud blanks recycled slots to NaN so that generic
+ *  code walking the inherited buffers does not resurrect evicted geometry.
+ *  MRPT's point cloud render objects copy such slots verbatim, and a single
+ *  non-finite coordinate makes the LOD octree split criterion degenerate: the
+ *  node mean becomes NaN, every comparison against it is false, so all points
+ *  land in the same child and the recursive split never terminates.
+ */
+mrpt::maps::CPointsMap::Ptr onlyFinitePoints(const mrpt::maps::CPointsMap& src)
+{
+    const auto&  xs = src.getPointsBufferRef_x();
+    const auto&  ys = src.getPointsBufferRef_y();
+    const auto&  zs = src.getPointsBufferRef_z();
+    const size_t n  = src.size();
+
+    const auto isFinitePt = [&](size_t i)
+    { return std::isfinite(xs[i]) && std::isfinite(ys[i]) && std::isfinite(zs[i]); };
+
+    size_t nFinite = 0;
+    for (size_t i = 0; i < n; i++)
+    {
+        if (isFinitePt(i)) nFinite++;
+    }
+
+    if (nFinite == n) return {};  // usual case: nothing to filter out
+
+    auto out = mrpt::maps::CGenericPointsMap::Create();
+    out->reserve(nFinite);
+    out->registerPointFieldsFrom(src);
+
+    const auto ctx = out->prepareForInsertPointsFrom(src);
+    for (size_t i = 0; i < n; i++)
+    {
+        if (isFinitePt(i)) out->insertPointFrom(i, ctx);
+    }
+
+    return out;
+}
+}  // namespace
 
 // Implementation of the CSerializable virtual interface:
 uint8_t metric_map_t::serializeGetVersion() const { return 5; }
@@ -364,6 +412,16 @@ void metric_map_t::get_visualization_map_layer(
     {
         // quick return if empty point cloud
         return;
+    }
+
+    // Both render paths below copy the raw point buffers into an OpenGL object
+    // that cannot cope with non-finite coordinates (see onlyFinitePoints()).
+    // Filtering the *source* map, rather than the render object, is what keeps
+    // the point counts of the two equal, as recolorize3Dpc() requires.
+    if (auto finitePts = onlyFinitePoints(*pts); finitePts)
+    {
+        pts = finitePts;
+        if (pts->empty()) return;
     }
 
     if (p.colorMode.has_value())

--- a/mp2p_icp_core/tests/CMakeLists.txt
+++ b/mp2p_icp_core/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ mp2p_add_test(mp2p_optimize_prior_referenced_kernel)
 mp2p_add_test(mp2p_Pairings)
 mp2p_add_test(mp2p_PairWeights)
 mp2p_add_test(mp2p_quality_reproject_ranges)
+mp2p_add_test(mp2p_viz_non_finite_points)
 mp2p_add_test(mp2p_WeightParameters)
 
 mp2p_add_test(mp2p_class_factory EXTRA_LIBS mp2p_icp_filters)

--- a/mp2p_icp_core/tests/test-mp2p_viz_non_finite_points.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_viz_non_finite_points.cpp
@@ -1,0 +1,169 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/**
+ * @file   test-mp2p_viz_non_finite_points.cpp
+ * @brief  Unit tests for get_visualization() against maps holding blank slots
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 28, 2026
+ */
+
+#include <mp2p_icp/metricmap.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/opengl/CPointCloud.h>
+#include <mrpt/opengl/CPointCloudColoured.h>
+
+#include <cmath>
+#include <limits>
+
+namespace
+{
+constexpr size_t NUM_GOOD_POINTS = 100;
+constexpr size_t NUM_BLANK_SLOTS = 10;
+
+/** A points map with some slots blanked to NaN, mimicking what map classes
+ *  with recycled storage slots (e.g. mola::IncrementalPointCloud) expose
+ *  through the inherited CPointsMap buffers.
+ */
+mrpt::maps::CSimplePointsMap::Ptr mapWithBlankSlots()
+{
+    auto pts = mrpt::maps::CSimplePointsMap::Create();
+
+    for (size_t i = 0; i < NUM_GOOD_POINTS; i++)
+    {
+        const auto f = static_cast<float>(i);
+        pts->insertPointFast(f, 2.0f * f, 3.0f * f);
+    }
+
+    constexpr float kNoPoint = std::numeric_limits<float>::quiet_NaN();
+    for (size_t i = 0; i < NUM_BLANK_SLOTS; i++)
+    {
+        pts->insertPointFast(kNoPoint, kNoPoint, kNoPoint);
+    }
+    pts->mark_as_modified();
+
+    ASSERT_EQUAL_(pts->size(), NUM_GOOD_POINTS + NUM_BLANK_SLOTS);
+
+    return pts;
+}
+
+void checkAllPointsFinite(const mrpt::opengl::CSetOfObjects& o, size_t expectedCount)
+{
+    size_t totalPoints = 0;
+
+    for (size_t ith = 0;; ith++)
+    {
+        auto glPts = o.getByClass<mrpt::opengl::CPointCloudColoured>(ith);
+        if (!glPts) break;
+
+        for (size_t i = 0; i < glPts->size(); i++)
+        {
+            const auto& p = glPts->getPoint3Df(i);
+            ASSERTMSG_(
+                std::isfinite(p.x) && std::isfinite(p.y) && std::isfinite(p.z),
+                "A non-finite point reached a CPointCloudColoured render object");
+            totalPoints++;
+        }
+    }
+
+    for (size_t ith = 0;; ith++)
+    {
+        auto glPts = o.getByClass<mrpt::opengl::CPointCloud>(ith);
+        if (!glPts) break;
+
+        for (size_t i = 0; i < glPts->size(); i++)
+        {
+            const auto& p = (*glPts)[i];
+            ASSERTMSG_(
+                std::isfinite(p.x) && std::isfinite(p.y) && std::isfinite(p.z),
+                "A non-finite point reached a CPointCloud render object");
+            totalPoints++;
+        }
+    }
+
+    ASSERT_EQUAL_(totalPoints, expectedCount);
+}
+
+/// Uniform color path: metric_map_t::get_visualization() without colorMode.
+void test_uniform_color_render()
+{
+    mp2p_icp::metric_map_t map;
+    map.layers["raw"] = mapWithBlankSlots();
+
+    mp2p_icp::render_params_t rp;
+    // no rp.points.allLayers.colorMode: exercises the CPointCloud branch
+
+    const auto glObj = map.get_visualization(rp);
+    ASSERT_(glObj);
+
+    checkAllPointsFinite(*glObj, NUM_GOOD_POINTS);
+}
+
+/// Colorized path: this is the one mola_lidar_odometry's local map viz uses.
+void test_colorized_render()
+{
+    mp2p_icp::metric_map_t map;
+    map.layers["raw"] = mapWithBlankSlots();
+
+    mp2p_icp::render_params_t rp;
+    auto&                     cm = rp.points.allLayers.colorMode.emplace();
+    cm.colorMap                  = mrpt::img::cmHOT;
+    cm.recolorizeByField         = "z";
+
+    const auto glObj = map.get_visualization(rp);
+    ASSERT_(glObj);
+
+    checkAllPointsFinite(*glObj, NUM_GOOD_POINTS);
+}
+
+/// A map with no blank slots at all must be rendered unchanged.
+void test_all_finite_is_untouched()
+{
+    auto pts = mrpt::maps::CSimplePointsMap::Create();
+    for (size_t i = 0; i < NUM_GOOD_POINTS; i++)
+    {
+        const auto f = static_cast<float>(i);
+        pts->insertPointFast(f, 2.0f * f, 3.0f * f);
+    }
+    pts->mark_as_modified();
+
+    mp2p_icp::metric_map_t map;
+    map.layers["raw"] = pts;
+
+    mp2p_icp::render_params_t rp;
+    auto&                     cm = rp.points.allLayers.colorMode.emplace();
+    cm.colorMap                  = mrpt::img::cmHOT;
+    cm.recolorizeByField         = "z";
+
+    const auto glObj = map.get_visualization(rp);
+    ASSERT_(glObj);
+
+    checkAllPointsFinite(*glObj, NUM_GOOD_POINTS);
+}
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+    try
+    {
+        test_uniform_color_render();
+        test_colorized_render();
+        test_all_finite_is_untouched();
+    }
+    catch (std::exception& e)
+    {
+        std::cerr << mrpt::exception_to_str(e) << "\n";
+        return 1;
+    }
+}

--- a/mp2p_icp_core/tests/test-mp2p_viz_non_finite_points.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_viz_non_finite_points.cpp
@@ -127,6 +127,87 @@ void test_colorized_render()
     checkAllPointsFinite(*glObj, NUM_GOOD_POINTS);
 }
 
+/// keep_original_cloud_color delegates to the map's own getVisualizationInto(),
+/// bypassing the source-map filtering the two paths above rely on.
+void test_keep_original_cloud_color_render()
+{
+    mp2p_icp::metric_map_t map;
+    map.layers["raw"] = mapWithBlankSlots();
+
+    mp2p_icp::render_params_t rp;
+    auto&                     cm = rp.points.allLayers.colorMode.emplace();
+    cm.keep_original_cloud_color = true;
+
+    const auto glObj = map.get_visualization(rp);
+    ASSERT_(glObj);
+
+    checkAllPointsFinite(*glObj, NUM_GOOD_POINTS);
+}
+
+/// Same path, but with the per-point colors the map itself assigned: the
+/// surviving points must keep them, i.e. filtering must not shift colors.
+void test_keep_original_cloud_color_preserves_colors()
+{
+    auto pts = mrpt::maps::CSimplePointsMap::Create();
+
+    // Interleave blank slots with the good points, so that a filtering bug
+    // that shifts colors by one slot cannot go unnoticed:
+    constexpr float kNoPoint = std::numeric_limits<float>::quiet_NaN();
+    for (size_t i = 0; i < NUM_GOOD_POINTS; i++)
+    {
+        const auto f = static_cast<float>(i);
+        pts->insertPointFast(f, 2.0f * f, 3.0f * f);
+        if (i % 3 == 0) pts->insertPointFast(kNoPoint, kNoPoint, kNoPoint);
+    }
+    pts->mark_as_modified();
+
+    mp2p_icp::metric_map_t map;
+    map.layers["raw"] = pts;
+
+    mp2p_icp::render_params_t rp;
+    auto&                     cm = rp.points.allLayers.colorMode.emplace();
+    cm.keep_original_cloud_color = true;
+
+    const auto glObj = map.get_visualization(rp);
+    ASSERT_(glObj);
+
+    checkAllPointsFinite(*glObj, NUM_GOOD_POINTS);
+
+    // The survivors must be exactly the good points, in their original order:
+    size_t checked = 0;
+    for (size_t ith = 0;; ith++)
+    {
+        auto glPts = glObj->getByClass<mrpt::opengl::CPointCloud>(ith);
+        if (!glPts) break;
+
+        for (size_t i = 0; i < glPts->size(); i++)
+        {
+            const auto& q = (*glPts)[i];
+            const auto  f = static_cast<float>(checked);
+            ASSERT_EQUAL_(q.x, f);
+            ASSERT_EQUAL_(q.y, 2.0f * f);
+            ASSERT_EQUAL_(q.z, 3.0f * f);
+            checked++;
+        }
+    }
+    for (size_t ith = 0;; ith++)
+    {
+        auto glPts = glObj->getByClass<mrpt::opengl::CPointCloudColoured>(ith);
+        if (!glPts) break;
+
+        for (size_t i = 0; i < glPts->size(); i++)
+        {
+            const auto& q = glPts->getPoint3Df(i);
+            const auto  f = static_cast<float>(checked);
+            ASSERT_EQUAL_(q.x, f);
+            ASSERT_EQUAL_(q.y, 2.0f * f);
+            ASSERT_EQUAL_(q.z, 3.0f * f);
+            checked++;
+        }
+    }
+    ASSERT_EQUAL_(checked, NUM_GOOD_POINTS);
+}
+
 /// A map with no blank slots at all must be rendered unchanged.
 void test_all_finite_is_untouched()
 {
@@ -159,6 +240,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     {
         test_uniform_color_render();
         test_colorized_render();
+        test_keep_original_cloud_color_render();
+        test_keep_original_cloud_color_preserves_colors();
         test_all_finite_is_untouched();
     }
     catch (std::exception& e)


### PR DESCRIPTION
## Problem

`get_visualization_map_layer()` copies the raw point buffers of a map layer into a `CPointCloud` / `CPointCloudColoured` verbatim, via `loadFromPointsMap()`.

Map classes that recycle storage slots expose slots that hold no point. `mola::IncrementalPointCloud` blanks those to NaN deliberately, so that generic code walking the inherited `CPointsMap` buffers does not resurrect long-evicted geometry.

A single non-finite coordinate is then enough to **hang the GUI thread permanently**. MRPT's LOD octree (`COctreePointRenderer::internal_recursive_split`) splits a node at the mean of its points:

- the mean becomes NaN,
- every `p.z < c.z` / `p.y < c.y` / `p.x < c.x` comparison against a NaN center is false,
- so all N points land in the same child,
- which has the same N points and the same NaN mean, and splits identically, forever.

There is no depth cap and no check that the split reduced the point count. Each level costs two O(N) passes, so it presents as a frozen viewer with one spinning thread rather than as a crash or stack overflow.

It only triggers once a cloud exceeds `OCTREE_RENDER_MAX_POINTS_PER_NODE` (1e6 by default), since below that the octree never splits at all. That is why it shows up at one exactly reproducible point of a mapping run.

Observed in the wild with `mola_lidar_odometry` + `mola::IncrementalPointCloud`: the whole pipeline froze, with every worker idle on a condition variable and only `MolaVizImGui::gui_thread` running, its stack growing monotonically (993 -> 2265 -> 3426 frames over ~50 s) inside a single `Viewport::render()` call.

## Fix

Filter non-finite points out of the layer before handing it to the render object.

The **source map** is filtered rather than the render object, because `recolorize3Dpc()` skips colorization entirely unless the render object and the source map hold the same number of points.

Maps whose points are all finite, which is the usual case, are passed through untouched with no copy: the helper returns an empty smart pointer and the caller keeps the original.

## Tests

New `test-mp2p_viz_non_finite_points`, covering both render paths (uniform color and colorized, the latter being what `mola_lidar_odometry`'s local-map viz uses) plus an all-finite pass-through case.

Verified it fails before the fix and passes after:

```
# without the fix
Message:  A non-finite point reached a CPointCloud render object
EXIT=1

# with the fix
EXIT=0
```

Full `mp2p_icp_core` suite: 54/54 binaries pass.

## Note

MRPT's octree is arguably also wrong to recurse unboundedly on degenerate input, and a guard there would be defense in depth. This is mrpt2-only though: `COctreePointRenderer` no longer exists in mrpt3, where `CPointCloudColoured` derives from `CVisualObject` with no recursive split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented non-finite (NaN/Inf) point coordinates from being carried into rendered point-cloud visualizations.
  * Ensured “keep original cloud color” rendering stays consistent with the original per-point ordering when blank/recycled slots are present.

* **Tests**
  * Added an automated test suite for visualization with non-finite point “blank slots,” covering both uniform-color and colorized rendering modes.
  * Verified all rendered points are finite and that point counts match the number of originally valid points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->