### PR TITLE
Add robust_max_range(): percentile-based, outlier-robust point cloud extent

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -171,6 +171,10 @@ filters:
 
 Key filter categories: decimation (including range-adaptive EllipseLIO-style), outlier removal, range/ring/intensity gating, deskew, edge/plane extraction, layer management.
 
+### Standalone point cloud utilities (not `Filter` subclasses)
+
+- `mp2p_icp_filters::robust_max_range()` (`PointCloudRobustRange.h`) — a percentile (default 0.95) of the per-point range, instead of the raw maximum, so a small minority of far outlier returns (observed on Livox sensors: specular-reflection artifacts hundreds of meters away in an otherwise small scene) cannot dominate an observation-radius estimate the way `boundingBox().max.norm()` does. `O(n)` average via `std::nth_element`. Not yet wired into any consumer (`mola_lidar_odometry`'s `ESTIMATED_OBSERVATION_RADIUS`, `icp_benchmark`'s `Bench::processScan`) — both currently compute their own unfiltered bounding-box max, which is exactly the vulnerability this function exists to fix; see `test-mp2p_PointCloudRobustRange.cpp`.
+
 ---
 
 ## Build system

--- a/mp2p_icp_core/mp2p_icp_filters/CMakeLists.txt
+++ b/mp2p_icp_core/mp2p_icp_filters/CMakeLists.txt
@@ -50,6 +50,7 @@ set(LIB_SRCS
   src/GeneratorEdgesFromCurvature.cpp
   src/GeneratorEdgesFromRangeImage.cpp
   src/GetOrCreatePointLayer.cpp
+  src/PointCloudRobustRange.cpp
   src/PointCloudToVoxelGrid.cpp
   src/PointCloudToVoxelGridSingle.cpp
   src/sm2mm.cpp
@@ -91,6 +92,7 @@ set(LIB_PUBLIC_HDRS
   include/mp2p_icp_filters/GeneratorEdgesFromCurvature.h
   include/mp2p_icp_filters/GeneratorEdgesFromRangeImage.h
   include/mp2p_icp_filters/GetOrCreatePointLayer.h
+  include/mp2p_icp_filters/PointCloudRobustRange.h
   include/mp2p_icp_filters/PointCloudToVoxelGrid.h
   include/mp2p_icp_filters/PointCloudToVoxelGridSingle.h
   include/mp2p_icp_filters/sm2mm.h

--- a/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/PointCloudRobustRange.h
+++ b/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/PointCloudRobustRange.h
@@ -1,0 +1,53 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file   PointCloudRobustRange.h
+ * @brief  Outlier-robust estimate of a point cloud's maximum range.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 30, 2026
+ */
+
+#pragma once
+
+#include <mrpt/maps/CPointsMap.h>
+#include <mrpt/math/TPoint3D.h>
+
+namespace mp2p_icp_filters
+{
+/** Outlier-robust estimate of a point cloud's maximum range (distance from
+ * a `center` point, default the origin).
+ *
+ * Plain `boundingBox().max.norm()` is dominated by even a single spurious
+ * far return (e.g. specular-reflection artifacts observed on Livox sensors,
+ * hundreds of meters away in an otherwise <20 m scene): consumers that use
+ * such an estimate to size a downstream voxel grid or range filter can end
+ * up starving the real, near-field points. This function instead returns
+ * the given `percentile` of the per-point range distribution, so a small
+ * minority of extreme points cannot dominate it.
+ *
+ * Implemented with `std::nth_element` (average O(n)), not a full sort.
+ *
+ * \param pc The point cloud. May be empty, in which case 0 is returned.
+ * \param percentile In (0,1]. Ranges are sorted and the value at this
+ *        fraction is returned; e.g. 0.95 (the default) discards the top 5%
+ *        of ranges as potential outliers. 1.0 reproduces the plain maximum.
+ * \param center Ranges are measured from this point.
+ *
+ * \ingroup mp2p_icp_filters_grp
+ */
+double robust_max_range(
+    const mrpt::maps::CPointsMap& pc, double percentile = 0.95,
+    const mrpt::math::TPoint3Df& center = {0, 0, 0});
+
+}  // namespace mp2p_icp_filters

--- a/mp2p_icp_core/mp2p_icp_filters/src/PointCloudRobustRange.cpp
+++ b/mp2p_icp_core/mp2p_icp_filters/src/PointCloudRobustRange.cpp
@@ -1,0 +1,61 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file   PointCloudRobustRange.cpp
+ * @brief  Outlier-robust estimate of a point cloud's maximum range.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 30, 2026
+ */
+
+#include <mp2p_icp_filters/PointCloudRobustRange.h>
+#include <mrpt/core/exceptions.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+using namespace mp2p_icp_filters;
+
+double mp2p_icp_filters::robust_max_range(
+    const mrpt::maps::CPointsMap& pc, double percentile, const mrpt::math::TPoint3Df& center)
+{
+    ASSERT_GT_(percentile, 0.0);
+    ASSERT_LE_(percentile, 1.0);
+
+    const size_t n = pc.size();
+    if (n == 0)
+    {
+        return 0.0;
+    }
+
+    const auto& xs = pc.getPointsBufferRef_x();
+    const auto& ys = pc.getPointsBufferRef_y();
+    const auto& zs = pc.getPointsBufferRef_z();
+
+    std::vector<float> ranges(n);
+    for (size_t i = 0; i < n; i++)
+    {
+        const float dx = xs[i] - center.x;
+        const float dy = ys[i] - center.y;
+        const float dz = zs[i] - center.z;
+        ranges[i]       = std::sqrt(dx * dx + dy * dy + dz * dz);
+    }
+
+    // percentile==1.0 must still map to the last (largest) element, not one
+    // past the end.
+    const size_t rank = std::min(n - 1, static_cast<size_t>(percentile * static_cast<double>(n)));
+
+    std::nth_element(ranges.begin(), ranges.begin() + rank, ranges.end());
+    return static_cast<double>(ranges[rank]);
+}

--- a/mp2p_icp_core/tests/CMakeLists.txt
+++ b/mp2p_icp_core/tests/CMakeLists.txt
@@ -97,6 +97,7 @@ mp2p_add_test(mp2p_Filters EXTRA_LIBS mp2p_icp_filters)
 mp2p_add_test(mp2p_FilterSOR EXTRA_LIBS mp2p_icp_filters)
 mp2p_add_test(mp2p_FilterVoxelSOR EXTRA_LIBS mp2p_icp_filters)
 mp2p_add_test(mp2p_generator EXTRA_LIBS mp2p_icp_filters)
+mp2p_add_test(mp2p_PointCloudRobustRange EXTRA_LIBS mp2p_icp_filters)
 mp2p_add_test(mp2p_generator_view_vector EXTRA_LIBS mp2p_icp_filters)
 mp2p_add_test(sm2mm_georef EXTRA_LIBS mp2p_icp_filters)
 

--- a/mp2p_icp_core/tests/test-mp2p_PointCloudRobustRange.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_PointCloudRobustRange.cpp
@@ -1,0 +1,145 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file   test-mp2p_PointCloudRobustRange.cpp
+ * @brief  Unit test for robust_max_range()
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 30, 2026
+ */
+
+#include <mp2p_icp_filters/PointCloudRobustRange.h>
+#include <mrpt/maps/CSimplePointsMap.h>
+
+using namespace mp2p_icp_filters;
+
+namespace
+{
+
+// 97 "real" points spread between 1.0 and 5.0 m, plus 3 far outliers at
+// 400/401/402 m (3%): a stand-in for the Livox specular-reflection artifacts
+// that motivated this function -- a tiny minority of returns hundreds of
+// meters away in an otherwise small scene.
+mrpt::maps::CSimplePointsMap::Ptr createOutlierPointCloud()
+{
+    auto pc = mrpt::maps::CSimplePointsMap::Create();
+
+    for (int i = 0; i < 97; i++)
+    {
+        const float range = 1.0f + i * (4.0f / 96.0f);  // 1.0 ... 5.0
+        pc->insertPoint(range, 0.0f, 0.0f);
+    }
+    pc->insertPoint(400.0f, 0.0f, 0.0f);
+    pc->insertPoint(401.0f, 0.0f, 0.0f);
+    pc->insertPoint(402.0f, 0.0f, 0.0f);
+
+    return pc;
+}
+
+void test_empty_cloud()
+{
+    mrpt::maps::CSimplePointsMap pc;
+    ASSERT_EQUAL_(robust_max_range(pc), 0.0);
+}
+
+void test_outliers_are_ignored_at_p95()
+{
+    auto pc = createOutlierPointCloud();
+
+    const double r = robust_max_range(*pc, 0.95);
+
+    // rank = floor(0.95 * 100) = 95, which falls within the 97 "real"
+    // points (indices 0..96 once sorted), well clear of the 3 outliers.
+    ASSERT_GE_(r, 4.5);
+    ASSERT_LE_(r, 5.01);
+}
+
+void test_percentile_one_reproduces_plain_max()
+{
+    auto pc = createOutlierPointCloud();
+
+    const double r = robust_max_range(*pc, 1.0);
+
+    // Must include the worst outlier, exactly what a bounding-box-derived
+    // estimate would also give -- the behavior this function is meant to
+    // improve on when a lower percentile is used instead.
+    ASSERT_(r > 401.9 && r < 402.1);
+}
+
+void test_custom_center()
+{
+    auto pc = mrpt::maps::CSimplePointsMap::Create();
+    pc->insertPoint(10.0f, 0.0f, 0.0f);
+    pc->insertPoint(10.0f, 0.0f, 0.0f);
+
+    // Measuring from (10,0,0) itself: range should collapse to ~0.
+    const double r = robust_max_range(*pc, 1.0, {10.0f, 0.0f, 0.0f});
+    ASSERT_LE_(r, 1e-4);
+}
+
+void test_invalid_percentile_throws()
+{
+    auto pc = createOutlierPointCloud();
+
+    bool have_thrown = false;
+    try
+    {
+        robust_max_range(*pc, 0.0);
+    }
+    catch (const std::exception&)
+    {
+        have_thrown = true;
+    }
+    ASSERT_(have_thrown);
+
+    have_thrown = false;
+    try
+    {
+        robust_max_range(*pc, 1.5);
+    }
+    catch (const std::exception&)
+    {
+        have_thrown = true;
+    }
+    ASSERT_(have_thrown);
+}
+
+}  // namespace
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
+{
+    try
+    {
+        test_empty_cloud();
+        std::cout << "test_empty_cloud: Success ✅" << std::endl;
+
+        test_outliers_are_ignored_at_p95();
+        std::cout << "test_outliers_are_ignored_at_p95: Success ✅" << std::endl;
+
+        test_percentile_one_reproduces_plain_max();
+        std::cout << "test_percentile_one_reproduces_plain_max: Success ✅" << std::endl;
+
+        test_custom_center();
+        std::cout << "test_custom_center: Success ✅" << std::endl;
+
+        test_invalid_percentile_throws();
+        std::cout << "test_invalid_percentile_throws: Success ✅" << std::endl;
+
+        return 0;
+    }
+    catch (const std::exception& e)
+    {
+        std::cerr << "Error: ❌\n" << e.what() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `mp2p_icp_filters::robust_max_range()`: a percentile (default 0.95) of the per-point range from a center point, instead of the raw `boundingBox().max.norm()`, so a small minority of far outlier returns cannot dominate the estimate.
- Motivated by a real failure on the TIERS multi-lidar dataset: Livox sensors occasionally report specular-reflection returns hundreds of meters away in an otherwise <20 m scene. Both `mola_lidar_odometry`'s `ESTIMATED_OBSERVATION_RADIUS` (`LidarOdometry_AdaptiveVariables.cpp`) and `icp_benchmark`'s `Bench::processScan` currently compute this the unfiltered way, and in production that inflated radius feeds `lidar3d-gicp.yaml`'s `FilterByRange` thresholds for the *same* frame (`range_min = max(1.0, 0.03*ESTIMATED_OBSERVATION_RADIUS)`), which strips the real near-field points while still admitting the outlier that caused the inflation.
- `O(n)` average via `std::nth_element`, no full sort.
- This PR is scoped to the utility itself, with unit tests. Wiring it into `mola_lidar_odometry` and `icp_benchmark` is intentionally left for a separate follow-up.

## Test plan
- [x] New unit test `test-mp2p_PointCloudRobustRange.cpp`: empty cloud, outlier rejection at p=0.95, p=1.0 reproduces plain max, custom center, invalid percentile throws.
- [x] `colcon build --packages-select mp2p_icp_core` succeeds.
- [x] `ctest --test-dir build/mp2p_icp_core -R "Filter|PointCloud"` — 42/42 pass, including the new test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a robust point-cloud range estimate that reduces the impact of distant outliers.
  * Supports configurable percentiles and measurement centers, with the default using the 95th percentile.
  * Handles empty point clouds and provides the plain maximum when using the 100th percentile.

* **Tests**
  * Added coverage for outliers, empty inputs, custom centers, maximum-range behavior, and invalid percentile values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->