### PR TITLE
FilterDecimateAdaptive: several output layers from one voxelization pass, plus decimate_method

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -171,6 +171,22 @@ filters:
 
 Key filter categories: decimation (including range-adaptive EllipseLIO-style), outlier removal, range/ring/intensity gating, deskew, edge/plane extraction, layer management.
 
+`FilterDecimateAdaptive` accepts either the single-output keys (`output_pointcloud_layer` +
+`desired_output_point_count`) or an `outputs` sequence of several such pairs. In the latter case all
+output layers are sampled from ONE voxelization pass (the dominant cost), each with its own stride,
+which is what lets a consumer get a dense cloud for its local map and a sparse one for ICP without
+paying for two full passes. Measured on `test-mp2p_gicp_pipeline_benchmark`
+(`MP2P_BENCH_SINGLE_DECIMATION=1` selects the single-pass variant there), this saves ~2 ms per
+100k-point scan out of ~15 ms of 1st-pass filtering. Consumer side:
+`mola_lidar_odometry/pipelines/lidar3d-gicp-single-filter.yaml`.
+
+It also honors `decimate_method` (the `DecimateMethod` enum, now in its own header
+`mp2p_icp_filters/DecimateMethod.h`, shared with `FilterDecimateVoxels`). Because this filter
+revisits voxels in several rounds until the point count is met, `FirstPoint`/`RandomPoint` take
+successive points out of each voxel, while `ClosestToAverage`/`VoxelAverage` summarize the voxel and
+so emit at most one point per voxel (output capped at the voxel count); `VoxelAverage` synthesizes
+points, so per-point fields are not propagated.
+
 ### Standalone point cloud utilities (not `Filter` subclasses)
 
 - `mp2p_icp_filters::robust_max_range()` (`PointCloudRobustRange.h`) — a percentile (default 0.95) of the per-point range, instead of the raw maximum, so a small minority of far outlier returns (observed on Livox sensors: specular-reflection artifacts hundreds of meters away in an otherwise small scene) cannot dominate an observation-radius estimate the way `boundingBox().max.norm()` does. `O(n)` average via `std::nth_element`. Not yet wired into any consumer (`mola_lidar_odometry`'s `ESTIMATED_OBSERVATION_RADIUS`, `icp_benchmark`'s `Bench::processScan`) — both currently compute their own unfiltered bounding-box max, which is exactly the vulnerability this function exists to fix; see `test-mp2p_PointCloudRobustRange.cpp`.

--- a/docs/source/mp2p_icp_filters.rst
+++ b/docs/source/mp2p_icp_filters.rst
@@ -401,6 +401,8 @@ Filter: `FilterDecimateAdaptive`
 
 **Description**: Accepts an input point cloud, voxelizes it, and generates a new layer with an adaptive sampling to aim for a specific desired output point count.
 
+More than one output layer can be requested, each one with its own target point count (see `outputs` below). All of them are then sampled from one single voxelization pass, which is the dominant cost, instead of chaining several instances of this filter.
+
 **Parameters**:
 
 * **input\_pointcloud\_layer** (:cpp:type:`std::string`, default: `raw`): The input point cloud layer name.
@@ -409,9 +411,13 @@ Filter: `FilterDecimateAdaptive`
 
 * **desired\_output\_point\_count** (:cpp:type:`unsigned int`, default: `1000`): The target number of points in the output cloud.
 
+* **outputs** (sequence, optional): A list of output layers, each entry holding its own `output_pointcloud_layer` and `desired_output_point_count`. Mutually exclusive with the two single-output parameters above.
+
 * **minimum\_input\_points\_per\_voxel** (:cpp:type:`unsigned int`, default: `1`): Voxels with fewer points than this threshold will not generate any output point.
 
 * **voxel\_size** (:cpp:type:`float`, default: `0.10`): The size of the voxel grid used for downsampling (m).
+
+* **decimate\_method** (:cpp:enum:`mp2p_icp_filters::DecimateMethod`, default: `DecimateMethod::FirstPoint`): Which point represents each voxel, as in `FilterDecimateVoxels`_. Since this filter walks the voxels in as many rounds as needed to reach the desired point count, note that `DecimateMethod::FirstPoint` (the fastest) and `DecimateMethod::RandomPoint` take successive points out of each voxel, in insertion order or starting at a random offset, respectively; whereas `DecimateMethod::ClosestToAverage` and `DecimateMethod::VoxelAverage` summarize the whole voxel and hence yield **one point per voxel only**, so the output cannot be larger than the number of valid voxels. `DecimateMethod::VoxelAverage` generates new points, so per-point fields (intensity, ring, timestamp, ...) are not propagated to the output.
 
 * **parallelization\_grain\_size** (:cpp:type:`size\_t`, default: `16384`): Grain size for parallel processing of input clouds (used when TBB is enabled).
 
@@ -425,6 +431,22 @@ Filter: `FilterDecimateAdaptive`
           output_pointcloud_layer: 'adaptively_decimated'
           desired_output_point_count: 5000
           voxel_size: 0.2
+
+And the multiple-outputs form, e.g. to obtain a denser cloud to feed a local map and a sparser one to feed ICP:
+
+.. code-block:: yaml
+
+    filters:
+      #...
+      - class_name: mp2p_icp_filters::FilterDecimateAdaptive
+        params:
+          input_pointcloud_layer: 'raw'
+          voxel_size: 0.15
+          outputs:
+            - output_pointcloud_layer: 'decimated_for_map'
+              desired_output_point_count: 10000
+            - output_pointcloud_layer: 'decimated_for_icp'
+              desired_output_point_count: 3000
 
 .. rubric:: Before → After Screenshot
 

--- a/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/DecimateMethod.h
+++ b/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/DecimateMethod.h
@@ -1,0 +1,53 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file   DecimateMethod.h
+ * @brief  Method to pick the representative point of a voxel
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 31, 2026
+ */
+
+#pragma once
+
+#include <mrpt/typemeta/TEnumType.h>
+
+#include <cstdint>
+
+namespace mp2p_icp_filters
+{
+/** Enum to select what method to use to pick the downsampled point for each
+ *  voxel, in FilterDecimateVoxels and FilterDecimateAdaptive.
+ *
+ * \ingroup mp2p_icp_filters_grp
+ */
+enum class DecimateMethod : uint8_t
+{
+    /** Pick the first point that was put int the voxel */
+    FirstPoint = 0,
+    /** Closest to the average of all voxel points */
+    ClosestToAverage,
+    /** Average of all voxel points */
+    VoxelAverage,
+    /** Pick one of the voxel points at random */
+    RandomPoint
+};
+
+}  // namespace mp2p_icp_filters
+
+MRPT_ENUM_TYPE_BEGIN_NAMESPACE(mp2p_icp_filters, mp2p_icp_filters::DecimateMethod)
+MRPT_FILL_ENUM(DecimateMethod::FirstPoint);
+MRPT_FILL_ENUM(DecimateMethod::ClosestToAverage);
+MRPT_FILL_ENUM(DecimateMethod::VoxelAverage);
+MRPT_FILL_ENUM(DecimateMethod::RandomPoint);
+MRPT_ENUM_TYPE_END()

--- a/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateAdaptive.h
+++ b/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateAdaptive.h
@@ -21,15 +21,41 @@
 #pragma once
 
 #include <mp2p_icp/metricmap.h>
+#include <mp2p_icp_filters/DecimateMethod.h>
 #include <mp2p_icp_filters/FilterBase.h>
 #include <mp2p_icp_filters/PointCloudToVoxelGrid.h>
 #include <mrpt/core/pimpl.h>
 #include <mrpt/maps/CPointsMap.h>
 
+#include <string>
+#include <vector>
+
 namespace mp2p_icp_filters
 {
 /** Accepts as input a point cloud layer, voxelizes it, and generates a new
  * point cloud layer with an adaptive sampling.
+ *
+ * More than one output layer can be requested (see Parameters::outputs), each
+ * one with its own target point count. All of them are then generated from one
+ * single voxelization pass over the input, which is the dominant cost, instead
+ * of chaining several instances of this filter.
+ *
+ * Which point represents each voxel is selected with `decimate_method`, as in
+ * FilterDecimateVoxels. Note though that this filter walks the voxels in
+ * several rounds until the desired point count is reached, so:
+ * - DecimateMethod::FirstPoint (the default, and the fastest) and
+ *   DecimateMethod::RandomPoint take successive points out of each voxel, in
+ *   insertion order or starting at a random offset, respectively.
+ * - DecimateMethod::ClosestToAverage and DecimateMethod::VoxelAverage yield ONE
+ *   point per voxel only, so the output cannot be larger than the number of
+ *   valid voxels no matter the desired point count. They are also more
+ *   expensive, since all voxel points must be traversed to get the average.
+ *   DecimateMethod::VoxelAverage generates new points, so per-point fields
+ *   (intensity, ring, timestamp, ...) are not propagated to the output.
+ *
+ * When built with TBB, voxels are accumulated per thread and not merged, so the
+ * per-voxel averages above are computed over the subset of points that fell in
+ * the same thread block.
  *
  * Not compatible with calling from different threads simultaneously for
  * different input point clouds. Use independent instances for each thread if
@@ -46,21 +72,35 @@ class FilterDecimateAdaptive : public mp2p_icp_filters::FilterBase
     // See docs in FilterBase
     void filter(mp2p_icp::metric_map_t& inOut) const override;
 
+    /** One requested output layer, with its own target point count. */
+    struct OutputTarget
+    {
+        void load_from_yaml(const mrpt::containers::yaml& c);
+
+        std::string  output_pointcloud_layer;
+        unsigned int desired_output_point_count = 1000;
+    };
+
     struct Parameters
     {
         void load_from_yaml(const mrpt::containers::yaml& c);
 
         std::string input_pointcloud_layer = mp2p_icp::metric_map_t::PT_LAYER_RAW;
 
-        std::string output_pointcloud_layer;
-
-        unsigned int desired_output_point_count = 1000;
+        /** The requested output layers. Loaded either from the YAML sequence
+         * "outputs", or from the single-output keys "output_pointcloud_layer"
+         * and "desired_output_point_count". */
+        std::vector<OutputTarget> outputs;
 
         /** Voxels with less points will not generate anything at the output
          * layer */
         unsigned int minimum_input_points_per_voxel = 1;
 
         float voxel_size = 0.10;
+
+        /** The method to pick what point will be used as representative of each
+         * voxel. See notes on top of this class. */
+        DecimateMethod decimate_method = DecimateMethod::FirstPoint;
 
         /// When TBB is enabled, the grainsize for splitting the input clouds into threads
         size_t parallelization_grain_size = 16UL * 1024UL;

--- a/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateVoxels.h
+++ b/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateVoxels.h
@@ -21,31 +21,14 @@
 #pragma once
 
 #include <mp2p_icp/metricmap.h>
+#include <mp2p_icp_filters/DecimateMethod.h>
 #include <mp2p_icp_filters/FilterBase.h>
 #include <mp2p_icp_filters/PointCloudToVoxelGrid.h>
 #include <mp2p_icp_filters/PointCloudToVoxelGridSingle.h>
 #include <mrpt/maps/CPointsMap.h>
-#include <mrpt/typemeta/TEnumType.h>
 
 namespace mp2p_icp_filters
 {
-/** Enum to select what method to use to pick the downsampled point for each
- *  voxel in FilterDecimateVoxels.
- *
- * \ingroup mp2p_icp_filters_grp
- */
-enum class DecimateMethod : uint8_t
-{
-    /** Pick the first point that was put int the voxel */
-    FirstPoint = 0,
-    /** Closest to the average of all voxel points */
-    ClosestToAverage,
-    /** Average of all voxel points */
-    VoxelAverage,
-    /** Pick one of the voxel points at random */
-    RandomPoint
-};
-
 /** Builds a new layer with a decimated version of one or more input layers,
  * merging their contents.
  *
@@ -140,10 +123,3 @@ class FilterDecimateVoxels : public mp2p_icp_filters::FilterBase
 /** @} */
 
 }  // namespace mp2p_icp_filters
-
-MRPT_ENUM_TYPE_BEGIN_NAMESPACE(mp2p_icp_filters, mp2p_icp_filters::DecimateMethod)
-MRPT_FILL_ENUM(DecimateMethod::FirstPoint);
-MRPT_FILL_ENUM(DecimateMethod::ClosestToAverage);
-MRPT_FILL_ENUM(DecimateMethod::VoxelAverage);
-MRPT_FILL_ENUM(DecimateMethod::RandomPoint);
-MRPT_ENUM_TYPE_END()

--- a/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
@@ -23,6 +23,8 @@
 #include <mp2p_icp_filters/GetOrCreatePointLayer.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/round.h>
+#include <mrpt/math/TPoint3D.h>
+#include <mrpt/random/RandomGenerators.h>
 #include <mrpt/version.h>
 
 #if defined(MP2P_HAS_TBB)
@@ -34,16 +36,43 @@ IMPLEMENTS_MRPT_OBJECT(FilterDecimateAdaptive, mp2p_icp_filters::FilterBase, mp2
 
 using namespace mp2p_icp_filters;
 
+void FilterDecimateAdaptive::OutputTarget::load_from_yaml(const mrpt::containers::yaml& c)
+{
+    MCP_LOAD_REQ(c, output_pointcloud_layer);
+    MCP_LOAD_REQ(c, desired_output_point_count);
+}
+
 void FilterDecimateAdaptive::Parameters::load_from_yaml(const mrpt::containers::yaml& c)
 {
     MCP_LOAD_REQ(c, input_pointcloud_layer);
-    MCP_LOAD_REQ(c, output_pointcloud_layer);
 
-    MCP_LOAD_REQ(c, desired_output_point_count);
+    outputs.clear();
+
+    if (c.has("outputs"))
+    {
+        ASSERTMSG_(
+            !c.has("output_pointcloud_layer") && !c.has("desired_output_point_count"),
+            "Use either the 'outputs' sequence, or the single-output keys "
+            "'output_pointcloud_layer'/'desired_output_point_count', but not both.");
+
+        auto cfgOutputs = c["outputs"];
+        ASSERTMSG_(cfgOutputs.isSequence(), "'outputs' must be a YAML sequence.");
+
+        for (const auto& entry : cfgOutputs.asSequence())
+        {
+            outputs.emplace_back().load_from_yaml(entry);
+        }
+        ASSERTMSG_(!outputs.empty(), "'outputs' cannot be an empty sequence.");
+    }
+    else
+    {
+        outputs.emplace_back().load_from_yaml(c);
+    }
 
     MCP_LOAD_OPT(c, voxel_size);
     MCP_LOAD_OPT(c, minimum_input_points_per_voxel);
     MCP_LOAD_OPT(c, parallelization_grain_size);
+    MCP_LOAD_OPT(c, decimate_method);
 }
 
 struct FilterDecimateAdaptive::Impl
@@ -77,7 +106,11 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
     checkAllParametersAreRealized();
 
     // sanity checks:
-    ASSERT_GT_(params.desired_output_point_count, 0);
+    ASSERT_(!params.outputs.empty());
+    for (const auto& o : params.outputs)
+    {
+        ASSERT_GT_(o.desired_output_point_count, 0);
+    }
     ASSERT_GT_(params.voxel_size, 0);
 
     // In:
@@ -95,17 +128,7 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
 
     const auto& pc = *pcPtr;
 
-    // Create if new: Append to existing layer, if already existed.
-    mrpt::maps::CPointsMap::Ptr outPc = GetOrCreatePointLayer(
-        inOut, params.output_pointcloud_layer,
-        /*do not allow empty*/
-        false,
-        /* create cloud of the same type */
-        pcPtr->GetRuntimeClass()->className);
-
     const auto& _ = params;  // shortcut
-
-    outPc->reserve(outPc->size() + _.desired_output_point_count);
 
     struct DataPerVoxel
     {
@@ -114,6 +137,17 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
         PointCloudToVoxelGrid::voxel_t voxel;
         uint32_t                       nextIdx   = 0;
         bool                           exhausted = false;
+
+        /// Where to start taking points from within the voxel (!=0 only for
+        /// DecimateMethod::RandomPoint).
+        uint32_t startOffset = 0;
+
+        /// Representative of the whole voxel, precomputed once since it does
+        /// not depend on the output target. Only for the two average-based
+        /// decimation methods: an index into the input cloud for
+        /// ClosestToAverage, the average point itself for VoxelAverage.
+        uint32_t              representativeIdx = 0;
+        mrpt::math::TPoint3Df average           = {0, 0, 0};
     };
 
     // A list of all "valid" voxels:
@@ -182,70 +216,174 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
 
 #endif
 
-    outPc->registerPointFieldsFrom(pc);
-    mrpt::maps::CPointsMap::InsertCtx ctx = outPc->prepareForInsertPointsFrom(pc);
-    mp2p_icp::warn_on_field_padding_mismatch(pc, *outPc, *this);
+    const size_t nVoxels = voxels.size();
+
+    // Precompute, once for all output targets, whatever the selected
+    // decimation method needs per voxel:
+    // ----------------------------------------------------------------
+    const bool usesAverage = _.decimate_method == DecimateMethod::ClosestToAverage ||
+                             _.decimate_method == DecimateMethod::VoxelAverage;
+
+    if (_.decimate_method == DecimateMethod::RandomPoint)
+    {
+        auto rng = mrpt::random::CRandomGenerator();
+
+        for (auto& v : voxels)
+        {
+            v.startOffset = static_cast<uint32_t>(rng.drawUniform64bit() % v.voxel.size());
+        }
+    }
+    else if (usesAverage)
+    {
+        const auto& xs = pc.getPointsBufferRef_x();
+        const auto& ys = pc.getPointsBufferRef_y();
+        const auto& zs = pc.getPointsBufferRef_z();
+
+        for (auto& v : voxels)
+        {
+            const float inv_n = 1.0f / static_cast<float>(v.voxel.size());
+
+            auto mean = mrpt::math::TPoint3Df(0, 0, 0);
+            for (size_t i = 0; i < v.voxel.size(); i++)
+            {
+                const auto ptIdx = v.voxel[i];
+                mean.x += xs[ptIdx];
+                mean.y += ys[ptIdx];
+                mean.z += zs[ptIdx];
+            }
+            mean *= inv_n;
+            v.average = mean;
+
+            if (_.decimate_method != DecimateMethod::ClosestToAverage)
+            {
+                continue;
+            }
+
+            std::optional<float> minSqrErr;
+            for (size_t i = 0; i < v.voxel.size(); i++)
+            {
+                const auto  ptIdx  = v.voxel[i];
+                const float sqrErr = mrpt::square(xs[ptIdx] - mean.x) +
+                                     mrpt::square(ys[ptIdx] - mean.y) +
+                                     mrpt::square(zs[ptIdx] - mean.z);
+
+                if (!minSqrErr.has_value() || sqrErr < *minSqrErr)
+                {
+                    minSqrErr           = sqrErr;
+                    v.representativeIdx = ptIdx;
+                }
+            }
+        }
+    }
 
     // Perform resampling:
     // -------------------
+    // Note that all requested output layers are sampled from this same, single
+    // voxelization pass above (the dominant cost), each one walking the voxel
+    // list independently with its own stride.
     constexpr int FRACTIONARY_BIT_COUNT = 12;
-
-    const size_t nVoxels = voxels.size();
 
     if (nVoxels == 0)
     {
-        MRPT_LOG_WARN("FilterDecimateAdaptive: No occupied voxels. Output will be empty.");
-        return;  // Exit early to avoid division by zero
+        MRPT_LOG_WARN("FilterDecimateAdaptive: No occupied voxels. Outputs will be empty.");
     }
 
-    float voxelIdxIncrement = 1.0f;
-    if (nVoxels > params.desired_output_point_count)
+    for (const auto& target : _.outputs)
     {
-        voxelIdxIncrement =
-            static_cast<float>(nVoxels) / static_cast<float>(params.desired_output_point_count);
-    }
+        // Create if new: Append to existing layer, if already existed.
+        mrpt::maps::CPointsMap::Ptr outPc = GetOrCreatePointLayer(
+            inOut, target.output_pointcloud_layer,
+            /*do not allow empty*/
+            false,
+            /* create cloud of the same type */
+            pcPtr->GetRuntimeClass()->className);
 
-    const auto voxelIdxIncrement_frac =
-        static_cast<std::size_t>(voxelIdxIncrement * (1 << FRACTIONARY_BIT_COUNT));
+        outPc->reserve(outPc->size() + target.desired_output_point_count);
+        outPc->registerPointFieldsFrom(pc);
 
-    bool anyInsertInTheRound = false;
-
-    std::size_t i_frac = 0;
-    while (outPc->size() < params.desired_output_point_count)
-    {
-        std::size_t i = i_frac >> FRACTIONARY_BIT_COUNT;
-
-        if (i >= nVoxels)
+        if (nVoxels == 0)
         {
-            i_frac = i_frac % (nVoxels << FRACTIONARY_BIT_COUNT);
-            i      = i_frac >> FRACTIONARY_BIT_COUNT;
-
-            if (!anyInsertInTheRound)
-            {
-                // This means there is no more points and we must end
-                // despite we didn't reached the user's desired number of
-                // points:
-                break;
-            }
-
-            anyInsertInTheRound = false;
+            continue;  // Avoid division by zero below; layer is left as created.
         }
 
-        auto& ith = voxels[i];
-        if (!ith.exhausted)
+        mrpt::maps::CPointsMap::InsertCtx ctx = outPc->prepareForInsertPointsFrom(pc);
+        mp2p_icp::warn_on_field_padding_mismatch(pc, *outPc, *this);
+
+        // Each output starts its own walk over the shared voxel list:
+        for (auto& v : voxels)
         {
-            auto ptIdx = ith.voxel[ith.nextIdx++];
-
-            outPc->insertPointFrom(ptIdx, ctx);
-            anyInsertInTheRound = true;
-
-            if (ith.nextIdx >= ith.voxel.size())
-            {
-                ith.exhausted = true;
-            }
+            v.nextIdx   = 0;
+            v.exhausted = false;
         }
 
-        i_frac += voxelIdxIncrement_frac;
+        float voxelIdxIncrement = 1.0f;
+        if (nVoxels > target.desired_output_point_count)
+        {
+            voxelIdxIncrement =
+                static_cast<float>(nVoxels) / static_cast<float>(target.desired_output_point_count);
+        }
+
+        const auto voxelIdxIncrement_frac =
+            static_cast<std::size_t>(voxelIdxIncrement * (1 << FRACTIONARY_BIT_COUNT));
+
+        bool anyInsertInTheRound = false;
+
+        std::size_t i_frac = 0;
+        while (outPc->size() < target.desired_output_point_count)
+        {
+            std::size_t i = i_frac >> FRACTIONARY_BIT_COUNT;
+
+            if (i >= nVoxels)
+            {
+                i_frac = i_frac % (nVoxels << FRACTIONARY_BIT_COUNT);
+                i      = i_frac >> FRACTIONARY_BIT_COUNT;
+
+                if (!anyInsertInTheRound)
+                {
+                    // This means there is no more points and we must end
+                    // despite we didn't reached the user's desired number of
+                    // points:
+                    break;
+                }
+
+                anyInsertInTheRound = false;
+            }
+
+            auto& ith = voxels[i];
+            if (!ith.exhausted)
+            {
+                if (usesAverage)
+                {
+                    // These two methods summarize the whole voxel, so each one
+                    // can only ever emit one point:
+                    if (_.decimate_method == DecimateMethod::VoxelAverage)
+                    {
+                        outPc->insertPointFast(ith.average.x, ith.average.y, ith.average.z);
+                    }
+                    else
+                    {
+                        outPc->insertPointFrom(ith.representativeIdx, ctx);
+                    }
+                    ith.exhausted = true;
+                }
+                else
+                {
+                    // Take successive points out of the voxel, starting at
+                    // startOffset (0 unless picking at random):
+                    const auto k = (ith.startOffset + ith.nextIdx++) % ith.voxel.size();
+
+                    outPc->insertPointFrom(ith.voxel[k], ctx);
+
+                    if (ith.nextIdx >= ith.voxel.size())
+                    {
+                        ith.exhausted = true;
+                    }
+                }
+                anyInsertInTheRound = true;
+            }
+
+            i_frac += voxelIdxIncrement_frac;
+        }
     }
 
     MRPT_LOG_DEBUG_STREAM("used voxels=" << nTotalVoxels);

--- a/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
@@ -24,6 +24,7 @@
 #include <mrpt/core/exceptions.h>
 #include <mrpt/maps/CSimplePointsMap.h>
 
+#include <cmath>
 #include <iostream>
 
 using namespace mp2p_icp_filters;
@@ -75,6 +76,133 @@ int main()
             ASSERT_NEAR_(outSize, 500, 20);  // Allow small tolerance
 
             std::cout << "[Test Passed] Adaptive decimation count check\n";
+        }
+
+        // ---------------------------------------------------------
+        // Test: two output layers from one single voxelization pass
+        // ---------------------------------------------------------
+        {
+            FilterDecimateAdaptive filter;
+            mrpt::containers::yaml p;
+            p["input_pointcloud_layer"]         = "raw";
+            p["voxel_size"]                     = 0.5f;
+            p["minimum_input_points_per_voxel"] = 1;
+
+            p["outputs"] = mrpt::containers::yaml::Sequence();
+            p["outputs"].push_back(mrpt::containers::yaml::Map(
+                {{"output_pointcloud_layer", "multi_out_map"},
+                 {"desired_output_point_count", 500}}));
+            p["outputs"].push_back(mrpt::containers::yaml::Map(
+                {{"output_pointcloud_layer", "multi_out_icp"},
+                 {"desired_output_point_count", 150}}));
+
+            filter.initialize(p);
+            filter.filter(map);
+
+            auto outMap = map.layer<mrpt::maps::CPointsMap>("multi_out_map");
+            auto outIcp = map.layer<mrpt::maps::CPointsMap>("multi_out_icp");
+            ASSERT_(outMap);
+            ASSERT_(outIcp);
+
+            std::cout << "Multi-output decimation: map=" << outMap->size()
+                      << " (desired 500), icp=" << outIcp->size() << " (desired 150)\n";
+
+            ASSERT_NEAR_(outMap->size(), 500, 20);
+            ASSERT_NEAR_(outIcp->size(), 150, 20);
+
+            std::cout << "[Test Passed] Multi-output decimation count check\n";
+        }
+
+        // ---------------------------------------------------------
+        // Test: 'outputs' and the single-output keys are exclusive
+        // ---------------------------------------------------------
+        {
+            FilterDecimateAdaptive filter;
+            mrpt::containers::yaml p;
+            p["input_pointcloud_layer"]     = "raw";
+            p["output_pointcloud_layer"]    = "some_layer";
+            p["desired_output_point_count"] = 100;
+            p["outputs"]                    = mrpt::containers::yaml::Sequence();
+            p["outputs"].push_back(mrpt::containers::yaml::Map(
+                {{"output_pointcloud_layer", "other_layer"}, {"desired_output_point_count", 100}}));
+
+            bool didThrow = false;
+            try
+            {
+                filter.initialize(p);
+            }
+            catch (const std::exception&)
+            {
+                didThrow = true;
+            }
+            ASSERT_(didThrow);
+
+            std::cout << "[Test Passed] Mutually-exclusive output parameters check\n";
+        }
+
+        // ---------------------------------------------------------
+        // Test: the decimate_method options
+        // ---------------------------------------------------------
+        {
+            // A cloud of tight clusters of 4 points each, each one well inside
+            // its own voxel, so the expected output of every method is known:
+            const auto      clustered      = mrpt::maps::CSimplePointsMap::Create();
+            constexpr int   kClusters      = 200;
+            constexpr float kVoxelSize     = 0.5f;
+            constexpr float kSpread        = 0.1f;
+            const auto      clusterCenterX = [](int i) { return static_cast<float>(i) + 0.25f; };
+
+            for (int i = 0; i < kClusters; ++i)
+            {
+                const float cx = clusterCenterX(i);  // one cluster per voxel
+                const float cy = 0.25f;
+                clustered->insertPoint(cx - kSpread, cy, 0.25f);
+                clustered->insertPoint(cx + kSpread, cy, 0.25f);
+                clustered->insertPoint(cx, cy - kSpread, 0.25f);
+                clustered->insertPoint(cx, cy + kSpread, 0.25f);
+            }
+
+            for (const auto& method :
+                 {"DecimateMethod::FirstPoint", "DecimateMethod::ClosestToAverage",
+                  "DecimateMethod::VoxelAverage", "DecimateMethod::RandomPoint"})
+            {
+                mp2p_icp::metric_map_t m;
+                m.layers["raw"] = clustered;
+
+                FilterDecimateAdaptive filter;
+                mrpt::containers::yaml p;
+                p["input_pointcloud_layer"]         = "raw";
+                p["output_pointcloud_layer"]        = "out";
+                p["desired_output_point_count"]     = kClusters;
+                p["voxel_size"]                     = kVoxelSize;
+                p["minimum_input_points_per_voxel"] = 1;
+                p["decimate_method"]                = method;
+
+                filter.initialize(p);
+                filter.filter(m);
+
+                auto out = m.layer<mrpt::maps::CPointsMap>("out");
+                ASSERT_(out);
+
+                // One point per cluster, whatever the method:
+                ASSERT_EQUAL_(out->size(), static_cast<size_t>(kClusters));
+
+                // Every output point must lie within its own cluster's extent:
+                for (size_t i = 0; i < out->size(); i++)
+                {
+                    float x = 0;
+                    float y = 0;
+                    float z = 0;
+                    out->getPointFast(i, x, y, z);
+
+                    const float nearestCenter = std::round(x - 0.25f) + 0.25f;
+                    ASSERT_LT_(std::abs(x - nearestCenter), kSpread + 1e-3f);
+                    ASSERT_LT_(std::abs(y - 0.25f), kSpread + 1e-3f);
+                }
+
+                std::cout << "[Test Passed] decimate_method=" << method << " (" << out->size()
+                          << " points)\n";
+            }
         }
 
         std::cout << "\nFilterDecimateAdaptive Unit Tests Passed!\n";

--- a/mp2p_icp_core/tests/test-mp2p_gicp_pipeline_benchmark.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_gicp_pipeline_benchmark.cpp
@@ -27,6 +27,10 @@
  *  Internal CTimeLogger of mp2p_icp::ICP and the filter pipeline is enabled
  *  and dumped to stdout to serve as a profiling reference.
  *
+ *  Set MP2P_BENCH_SINGLE_DECIMATION=1 to replace the two chained decimation
+ *  stages by a single FilterDecimateAdaptive producing both output clouds from
+ *  one voxelization pass, to compare both variants.
+ *
  *  This test requires the mola_metric_maps package; if not available at build
  *  time it is silently skipped via CMake.
  */
@@ -38,6 +42,7 @@
 #include <mp2p_icp_filters/Generator.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/exceptions.h>
+#include <mrpt/core/get_env.h>
 #include <mrpt/maps/CGenericPointsMap.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/poses/CPose3D.h>
@@ -205,6 +210,28 @@ constexpr const char* kYamlFilters1stPass = R"yaml(
     desired_output_point_count: 3000
 )yaml";
 
+// Same two output clouds, but sampled from one single voxelization pass.
+constexpr const char* kYamlFilters1stPassSingleDecimation = R"yaml(
+- class_name: mp2p_icp_filters::FilterByRange
+  params:
+    input_pointcloud_layer: "raw"
+    output_layer_between: "raw_range_filtered"
+    range_min: 0.5
+    range_max: 30.0
+    metric_l_infinity: true
+
+- class_name: mp2p_icp_filters::FilterDecimateAdaptive
+  params:
+    name: "FilterDecimateAdaptive (map+icp)"
+    input_pointcloud_layer: "raw_range_filtered"
+    voxel_size: 0.15
+    outputs:
+      - output_pointcloud_layer: "decimated_for_map"
+        desired_output_point_count: 10000
+      - output_pointcloud_layer: "decimated_for_icp"
+        desired_output_point_count: 3000
+)yaml";
+
 constexpr const char* kYamlFilters2ndPass = R"yaml(
 - class_name: mp2p_icp_filters::FilterMerge
   params:
@@ -275,9 +302,17 @@ int main(int /*argc*/, char** /*argv*/)
         auto obs1 = makeSyntheticScan(pose1, 0.10, 5678);
 
         // --- Parse YAML blocks ---
-        const auto yObsGen   = parseSeq(kYamlObservationsGenerator);
-        const auto yLmGen    = parseSeq(kYamlLocalmapGenerator);
-        const auto yF1       = parseSeq(kYamlFilters1stPass);
+        const auto yObsGen = parseSeq(kYamlObservationsGenerator);
+        const auto yLmGen  = parseSeq(kYamlLocalmapGenerator);
+        // Set MP2P_BENCH_SINGLE_DECIMATION=1 to sample both decimated clouds
+        // from one single voxelization pass instead of chaining two filters.
+        const bool singleDecimation = mrpt::get_env<bool>("MP2P_BENCH_SINGLE_DECIMATION", false);
+        std::cout << "Decimation variant: "
+                  << (singleDecimation ? "single filter, two outputs" : "two chained filters")
+                  << "\n";
+
+        const auto yF1 =
+            parseSeq(singleDecimation ? kYamlFilters1stPassSingleDecimation : kYamlFilters1stPass);
         const auto yF2       = parseSeq(kYamlFilters2ndPass);
         const auto yInsertLm = parseSeq(kYamlInsertIntoLocalMap);
         const auto yIcp      = mrpt::containers::yaml::FromText(kYamlIcp);


### PR DESCRIPTION
Two independent additions to `FilterDecimateAdaptive`.

## 1. Several output layers from a single voxelization pass

New optional `outputs` YAML sequence, each entry with its own `output_pointcloud_layer` and `desired_output_point_count`:

```yaml
- class_name: mp2p_icp_filters::FilterDecimateAdaptive
  params:
    input_pointcloud_layer: "deskewed"
    voxel_size: 0.15
    outputs:
      - output_pointcloud_layer: "decimated_for_map"
        desired_output_point_count: 10000
      - output_pointcloud_layer: "decimated_for_icp"
        desired_output_point_count: 3000
```

All outputs are sampled from **one** voxelization pass (the dominant cost), each walking the shared voxel list with its own stride. The single-output keys keep working exactly as before, and are mutually exclusive with `outputs`.

This is what lets a consumer get a dense cloud for its local map and a sparse one for ICP without paying for two full passes. Chaining two filters also computed the second cloud from already-decimated voxel statistics rather than from the full scan.

### Measurements

`test-mp2p_gicp_pipeline_benchmark` gains an env var, `MP2P_BENCH_SINGLE_DECIMATION=1`, to select the single-pass variant, so both can be compared in-tree:

| 1st-pass filtering, per 100k-point scan | mean |
|---|---|
| two chained filters (current) | ~15.0 ms |
| single filter, two outputs | ~13.0 ms |

The combined filter costs the same as the old "map" stage alone, so the "icp" stage (~2 ms) disappears. ICP quality and recovered pose are unchanged.

End-to-end through MOLA-LO on the Mulran KAIST01 test fragment: 6.4 ms/scan versus 6.5 + 1.8 ms.

## 2. `decimate_method`

Support for the same `decimate_method` parameter as `FilterDecimateVoxels`. The `DecimateMethod` enum moves to its own header, `mp2p_icp_filters/DecimateMethod.h`, now shared by both filters (`FilterDecimateVoxels.h` includes it, so its users are unaffected).

Since this filter revisits voxels in as many rounds as needed to reach the requested point count, the methods behave differently here, and this is documented in the class and in the docs:

- `FirstPoint` (default, previous behavior) and `RandomPoint` take successive points out of each voxel, in insertion order or from a random per-voxel offset.
- `ClosestToAverage` and `VoxelAverage` summarize the whole voxel and hence emit **one point per voxel only**, so the output cannot exceed the number of valid voxels. `VoxelAverage` synthesizes points, so per-point fields are not propagated. Their per-voxel results are precomputed once and reused by all output targets.

Note that under TBB the per-thread voxel grids are not merged, so those per-voxel averages are computed over the points that fell in the same thread block.

## Testing

`test-mp2p_FilterDecimateAdaptive` gains coverage for the multiple outputs, the mutually-exclusive parameters, and the four decimation methods. All 112 `mp2p_icp_core` tests pass.

## Consumer

`mola_lidar_odometry` PR: MOLAorg/mola_lidar_odometry#121


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adaptive voxel decimation can now generate multiple output point clouds with independent target sizes from one configuration.
  * Added selectable representative-point methods, including first, random, voxel-average, and closest-to-average sampling.
  * Empty inputs now create configured output layers consistently.
  * Existing single-output configuration remains supported for compatibility.

* **Documentation**
  * Added configuration guidance, YAML examples, performance details, output limits, and field-propagation notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->