### PR TITLE
feat: decimate_method support in FilterDecimateAdaptive

### DIFF
--- a/mp2p_icp_core/mp2p_icp_filters/CMakeLists.txt
+++ b/mp2p_icp_core/mp2p_icp_filters/CMakeLists.txt
@@ -55,6 +55,7 @@ set(LIB_SRCS
   src/PointCloudToVoxelGrid.cpp
   src/PointCloudToVoxelGridSingle.cpp
   src/sm2mm.cpp
+  src/VoxelRepresentativePoint.cpp
   #
   src/register.cpp # This must be last
 )
@@ -98,6 +99,7 @@ set(LIB_PUBLIC_HDRS
   include/mp2p_icp_filters/PointCloudToVoxelGrid.h
   include/mp2p_icp_filters/PointCloudToVoxelGridSingle.h
   include/mp2p_icp_filters/sm2mm.h
+  include/mp2p_icp_filters/VoxelRepresentativePoint.h
 )
 
 

--- a/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateAdaptive.h
+++ b/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateAdaptive.h
@@ -23,6 +23,7 @@
 #include <mp2p_icp/metricmap.h>
 #include <mp2p_icp_filters/FilterBase.h>
 #include <mp2p_icp_filters/PointCloudToVoxelGrid.h>
+#include <mp2p_icp_filters/VoxelRepresentativePoint.h>  // DecimateMethod
 #include <mrpt/core/pimpl.h>
 #include <mrpt/maps/CPointsMap.h>
 
@@ -61,6 +62,13 @@ class FilterDecimateAdaptive : public mp2p_icp_filters::FilterBase
         unsigned int minimum_input_points_per_voxel = 1;
 
         float voxel_size = 0.10;
+
+        /** How to pick the representative point of each occupied voxel.
+         * Only DecimateMethod::FirstPoint preserves the adaptive point-budget
+         * round-robin over several points per voxel; the other methods emit
+         * exactly one (synthesized, for VoxelAverage) or one real point per
+         * occupied voxel. */
+        DecimateMethod decimate_method = DecimateMethod::FirstPoint;
 
         /// When TBB is enabled, the grainsize for splitting the input clouds into threads
         size_t parallelization_grain_size = 16UL * 1024UL;

--- a/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateVoxels.h
+++ b/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateVoxels.h
@@ -24,28 +24,11 @@
 #include <mp2p_icp_filters/FilterBase.h>
 #include <mp2p_icp_filters/PointCloudToVoxelGrid.h>
 #include <mp2p_icp_filters/PointCloudToVoxelGridSingle.h>
+#include <mp2p_icp_filters/VoxelRepresentativePoint.h>  // DecimateMethod
 #include <mrpt/maps/CPointsMap.h>
-#include <mrpt/typemeta/TEnumType.h>
 
 namespace mp2p_icp_filters
 {
-/** Enum to select what method to use to pick the downsampled point for each
- *  voxel in FilterDecimateVoxels.
- *
- * \ingroup mp2p_icp_filters_grp
- */
-enum class DecimateMethod : uint8_t
-{
-    /** Pick the first point that was put int the voxel */
-    FirstPoint = 0,
-    /** Closest to the average of all voxel points */
-    ClosestToAverage,
-    /** Average of all voxel points */
-    VoxelAverage,
-    /** Pick one of the voxel points at random */
-    RandomPoint
-};
-
 /** Builds a new layer with a decimated version of one or more input layers,
  * merging their contents.
  *
@@ -140,10 +123,3 @@ class FilterDecimateVoxels : public mp2p_icp_filters::FilterBase
 /** @} */
 
 }  // namespace mp2p_icp_filters
-
-MRPT_ENUM_TYPE_BEGIN_NAMESPACE(mp2p_icp_filters, mp2p_icp_filters::DecimateMethod)
-MRPT_FILL_ENUM(DecimateMethod::FirstPoint);
-MRPT_FILL_ENUM(DecimateMethod::ClosestToAverage);
-MRPT_FILL_ENUM(DecimateMethod::VoxelAverage);
-MRPT_FILL_ENUM(DecimateMethod::RandomPoint);
-MRPT_ENUM_TYPE_END()

--- a/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/VoxelRepresentativePoint.h
+++ b/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/VoxelRepresentativePoint.h
@@ -1,0 +1,88 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file   VoxelRepresentativePoint.h
+ * @brief  DecimateMethod enum and the shared per-voxel point-picking logic,
+ *         used by both FilterDecimateVoxels and FilterDecimateAdaptive.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 31, 2026
+ */
+
+#pragma once
+
+#include <mp2p_icp_filters/PointCloudToVoxelGrid.h>
+#include <mrpt/core/aligned_std_vector.h>
+#include <mrpt/math/TPoint3D.h>
+#include <mrpt/typemeta/TEnumType.h>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace mrpt::random
+{
+class CRandomGenerator;
+}
+
+namespace mp2p_icp_filters
+{
+/** Enum to select what method to use to pick the downsampled point for each
+ *  voxel, shared by FilterDecimateVoxels and FilterDecimateAdaptive.
+ *
+ * \ingroup mp2p_icp_filters_grp
+ */
+enum class DecimateMethod : uint8_t
+{
+    /** Pick the first point that was put int the voxel */
+    FirstPoint = 0,
+    /** Closest to the average of all voxel points */
+    ClosestToAverage,
+    /** Average of all voxel points */
+    VoxelAverage,
+    /** Pick one of the voxel points at random */
+    RandomPoint
+};
+
+/** The outcome of picking one representative point for an occupied voxel,
+ *  for any DecimateMethod except FirstPoint (callers normally special-case
+ *  FirstPoint themselves, since it does not need to touch point coordinates
+ *  at all). Exactly one of the two optionals is set:
+ *  - `point`: a synthesized coordinate (DecimateMethod::VoxelAverage).
+ *  - `pointIndex`: the index, into the source cloud, of a real point
+ *    (DecimateMethod::ClosestToAverage, DecimateMethod::RandomPoint).
+ */
+struct VoxelRepresentativePoint
+{
+    std::optional<mrpt::math::TPoint3Df> point;
+    std::optional<std::size_t>           pointIndex;
+};
+
+/** Computes the representative point of an occupied voxel for `method`,
+ *  which must not be DecimateMethod::FirstPoint (that case is cheaper to
+ *  special-case at the call site: it never needs to look at coordinates).
+ *  `rng` is only touched for DecimateMethod::RandomPoint.
+ */
+VoxelRepresentativePoint pickVoxelRepresentativePoint(
+    DecimateMethod method, const PointCloudToVoxelGrid::voxel_t& voxel,
+    const mrpt::aligned_std_vector<float>& xs, const mrpt::aligned_std_vector<float>& ys,
+    const mrpt::aligned_std_vector<float>& zs, mrpt::random::CRandomGenerator& rng);
+
+}  // namespace mp2p_icp_filters
+
+MRPT_ENUM_TYPE_BEGIN_NAMESPACE(mp2p_icp_filters, mp2p_icp_filters::DecimateMethod)
+MRPT_FILL_ENUM(DecimateMethod::FirstPoint);
+MRPT_FILL_ENUM(DecimateMethod::ClosestToAverage);
+MRPT_FILL_ENUM(DecimateMethod::VoxelAverage);
+MRPT_FILL_ENUM(DecimateMethod::RandomPoint);
+MRPT_ENUM_TYPE_END()

--- a/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
@@ -23,6 +23,7 @@
 #include <mp2p_icp_filters/GetOrCreatePointLayer.h>
 #include <mrpt/containers/yaml.h>
 #include <mrpt/core/round.h>
+#include <mrpt/random/RandomGenerators.h>
 #include <mrpt/version.h>
 
 #if defined(MP2P_HAS_TBB)
@@ -44,6 +45,7 @@ void FilterDecimateAdaptive::Parameters::load_from_yaml(const mrpt::containers::
     MCP_LOAD_OPT(c, voxel_size);
     MCP_LOAD_OPT(c, minimum_input_points_per_voxel);
     MCP_LOAD_OPT(c, parallelization_grain_size);
+    MCP_LOAD_OPT(c, decimate_method);
 }
 
 struct FilterDecimateAdaptive::Impl
@@ -210,6 +212,29 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
 
     bool anyInsertInTheRound = false;
 
+    const auto& xs = pc.getPointsBufferRef_x();
+    const auto& ys = pc.getPointsBufferRef_y();
+    const auto& zs = pc.getPointsBufferRef_z();
+
+    auto rng = mrpt::random::CRandomGenerator();
+
+    // Picks the single representative point for a voxel under any of the
+    // non-default decimate_method's. Unlike FirstPoint, these always emit
+    // exactly one point per occupied voxel, regardless of how many times the
+    // point-budget round-robin below revisits it.
+    const auto insertVoxelRepresentative = [&](const PointCloudToVoxelGrid::voxel_t& voxel)
+    {
+        const auto rep = pickVoxelRepresentativePoint(_.decimate_method, voxel, xs, ys, zs, rng);
+        if (rep.point)
+        {
+            outPc->insertPointFast(rep.point->x, rep.point->y, rep.point->z);
+        }
+        else
+        {
+            outPc->insertPointFrom(*rep.pointIndex, ctx);
+        }
+    };
+
     std::size_t i_frac = 0;
     while (outPc->size() < params.desired_output_point_count)
     {
@@ -234,15 +259,23 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
         auto& ith = voxels[i];
         if (!ith.exhausted)
         {
-            auto ptIdx = ith.voxel[ith.nextIdx++];
-
-            outPc->insertPointFrom(ptIdx, ctx);
-            anyInsertInTheRound = true;
-
-            if (ith.nextIdx >= ith.voxel.size())
+            if (_.decimate_method == DecimateMethod::FirstPoint)
             {
+                auto ptIdx = ith.voxel[ith.nextIdx++];
+
+                outPc->insertPointFrom(ptIdx, ctx);
+
+                if (ith.nextIdx >= ith.voxel.size())
+                {
+                    ith.exhausted = true;
+                }
+            }
+            else
+            {
+                insertVoxelRepresentative(ith.voxel);
                 ith.exhausted = true;
             }
+            anyInsertInTheRound = true;
         }
 
         i_frac += voxelIdxIncrement_frac;

--- a/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateVoxels.cpp
+++ b/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateVoxels.cpp
@@ -319,74 +319,10 @@ void FilterDecimateVoxels::filter(mp2p_icp::metric_map_t& inOut) const
 
                 nonEmptyVoxels++;
 
-                std::optional<mrpt::math::TPoint3Df> insertPt;
-                size_t insertPtIdx;  // valid only if insertPt is empty
-
-                switch (params.decimate_method)
-                {
-                    case DecimateMethod::FirstPoint:
-                    default:
-                    {
-                        THROW_EXCEPTION("Should not reach here!");
-                    }
-
-                    case DecimateMethod::VoxelAverage:
-                    case DecimateMethod::ClosestToAverage:
-                    {
-                        // Analyze the voxel contents:
-                        auto        mean  = mrpt::math::TPoint3Df(0, 0, 0);
-                        const float inv_n = (1.0f / static_cast<float>(vxl.size()));
-                        for (size_t i = 0; i < vxl.size(); i++)
-                        {
-                            const auto pt_idx = vxl[i];
-                            mean.x += xs[pt_idx];
-                            mean.y += ys[pt_idx];
-                            mean.z += zs[pt_idx];
-                        }
-                        mean *= inv_n;
-
-                        if (params.decimate_method == DecimateMethod::ClosestToAverage)
-                        {
-                            std::optional<float>  minSqrErr;
-                            std::optional<size_t> bestIdx;
-
-                            for (size_t i = 0; i < vxl.size(); i++)
-                            {
-                                const auto  pt_idx = vxl[i];
-                                const float sqrErr = mrpt::square(xs[pt_idx] - mean.x) +
-                                                     mrpt::square(ys[pt_idx] - mean.y) +
-                                                     mrpt::square(zs[pt_idx] - mean.z);
-
-                                if (!minSqrErr.has_value() || sqrErr < *minSqrErr)
-                                {
-                                    minSqrErr = sqrErr;
-                                    bestIdx   = pt_idx;
-                                }
-                            }
-                            // Insert the closest to the mean:
-                            insertPtIdx = *bestIdx;
-                        }
-                        else
-                        {
-                            // Insert the mean:
-                            insertPt = {mean.x, mean.y, mean.z};
-                        }
-                    }
-                    break;
-
-                    case DecimateMethod::RandomPoint:
-                    {
-                        // Insert a randomly-picked point:
-                        const auto idxInVoxel =
-                            (params.decimate_method == DecimateMethod::RandomPoint)
-                                ? (rng.drawUniform64bit() % vxl.size())
-                                : 0UL;
-
-                        const auto pt_idx = vxl[idxInVoxel];
-                        insertPtIdx       = pt_idx;
-                    }
-                    break;
-                }  // end switch decimation method
+                const auto rep =
+                    pickVoxelRepresentativePoint(params.decimate_method, vxl, xs, ys, zs, rng);
+                std::optional<mrpt::math::TPoint3Df> insertPt = rep.point;
+                size_t insertPtIdx = rep.pointIndex.value_or(0);  // valid only if insertPt is empty
 
                 // insert it, if passed the flatten filter:
                 if (params.flatten_to.has_value())

--- a/mp2p_icp_core/mp2p_icp_filters/src/VoxelRepresentativePoint.cpp
+++ b/mp2p_icp_core/mp2p_icp_filters/src/VoxelRepresentativePoint.cpp
@@ -1,0 +1,88 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file   VoxelRepresentativePoint.cpp
+ * @brief  DecimateMethod enum and the shared per-voxel point-picking logic.
+ * @author Jose Luis Blanco Claraco
+ * @date   Jul 31, 2026
+ */
+
+#include <mp2p_icp_filters/VoxelRepresentativePoint.h>
+#include <mrpt/core/bits_math.h>
+#include <mrpt/core/exceptions.h>
+#include <mrpt/random/RandomGenerators.h>
+
+using namespace mp2p_icp_filters;
+
+VoxelRepresentativePoint mp2p_icp_filters::pickVoxelRepresentativePoint(
+    const DecimateMethod method, const PointCloudToVoxelGrid::voxel_t& voxel,
+    const mrpt::aligned_std_vector<float>& xs, const mrpt::aligned_std_vector<float>& ys,
+    const mrpt::aligned_std_vector<float>& zs, mrpt::random::CRandomGenerator& rng)
+{
+    VoxelRepresentativePoint out;
+
+    switch (method)
+    {
+        case DecimateMethod::VoxelAverage:
+        case DecimateMethod::ClosestToAverage:
+        {
+            mrpt::math::TPoint3Df mean(0, 0, 0);
+            const float           inv_n = 1.0f / static_cast<float>(voxel.size());
+            for (size_t i = 0; i < voxel.size(); i++)
+            {
+                const auto pt_idx = voxel[i];
+                mean.x += xs[pt_idx];
+                mean.y += ys[pt_idx];
+                mean.z += zs[pt_idx];
+            }
+            mean *= inv_n;
+
+            if (method == DecimateMethod::VoxelAverage)
+            {
+                out.point = mean;
+                break;
+            }
+
+            std::optional<float>  minSqrErr;
+            std::optional<size_t> bestIdx;
+            for (size_t i = 0; i < voxel.size(); i++)
+            {
+                const auto  pt_idx = voxel[i];
+                const float sqrErr = mrpt::square(xs[pt_idx] - mean.x) +
+                                     mrpt::square(ys[pt_idx] - mean.y) +
+                                     mrpt::square(zs[pt_idx] - mean.z);
+                if (!minSqrErr.has_value() || sqrErr < *minSqrErr)
+                {
+                    minSqrErr = sqrErr;
+                    bestIdx   = pt_idx;
+                }
+            }
+            out.pointIndex = *bestIdx;
+            break;
+        }
+        case DecimateMethod::RandomPoint:
+        {
+            const auto idxInVoxel = rng.drawUniform64bit() % voxel.size();
+            out.pointIndex        = voxel[idxInVoxel];
+            break;
+        }
+        case DecimateMethod::FirstPoint:
+        default:
+            THROW_EXCEPTION(
+                "pickVoxelRepresentativePoint() does not handle DecimateMethod::FirstPoint; "
+                "callers must special-case it.");
+    }
+
+    return out;
+}

--- a/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
@@ -23,10 +23,33 @@
 #include <mp2p_icp_filters/FilterDecimateAdaptive.h>
 #include <mrpt/core/exceptions.h>
 #include <mrpt/maps/CSimplePointsMap.h>
+#include <mrpt/typemeta/TEnumType.h>
 
 #include <iostream>
+#include <optional>
 
 using namespace mp2p_icp_filters;
+
+namespace
+{
+// Finds the output point whose x coordinate is nearest to `x`, and asserts it
+// is within `tol`. Used to check per-voxel representative points without
+// depending on output ordering.
+float closestX(const mrpt::maps::CPointsMap& pc, float x)
+{
+    const auto&          xs = pc.getPointsBufferRef_x();
+    std::optional<float> best;
+    for (const auto v : xs)
+    {
+        if (!best.has_value() || std::abs(v - x) < std::abs(*best - x))
+        {
+            best = v;
+        }
+    }
+    ASSERT_(best.has_value());
+    return *best;
+}
+}  // namespace
 
 int main()
 {
@@ -75,6 +98,67 @@ int main()
             ASSERT_NEAR_(outSize, 500, 20);  // Allow small tolerance
 
             std::cout << "[Test Passed] Adaptive decimation count check\n";
+        }
+
+        // ---------------------------------------------------------
+        // Test: decimate_method VoxelAverage and ClosestToAverage, one
+        // point per voxel by construction (4 voxels, exactly 4 desired
+        // output points), so each output point must correspond to a known
+        // per-voxel centroid (VoxelAverage) or a known real point
+        // (ClosestToAverage), independently of FirstPoint's behavior.
+        // ---------------------------------------------------------
+        {
+            auto pc2 = mrpt::maps::CSimplePointsMap::Create();
+            // 4 voxels along X ([0,1), [1,2), [2,3), [3,4)), 3 points each,
+            // asymmetric so the closest-to-mean point is unambiguous.
+            const float offsets[3]   = {0.1f, 0.2f, 0.6f};
+            const float voxelBase[4] = {0.0f, 1.0f, 2.0f, 3.0f};
+            for (const float base : voxelBase)
+            {
+                for (const float off : offsets)
+                {
+                    pc2->insertPoint(base + off, 0.0f, 0.0f);
+                }
+            }
+
+            const float expectedMean[4]    = {0.3f, 1.3f, 2.3f, 3.3f};
+            const float expectedClosest[4] = {0.2f, 1.2f, 2.2f, 3.2f};
+
+            for (const auto method :
+                 {DecimateMethod::VoxelAverage, DecimateMethod::ClosestToAverage})
+            {
+                mp2p_icp::metric_map_t map2;
+                map2.layers["raw"] = pc2;
+
+                FilterDecimateAdaptive filter;
+                mrpt::containers::yaml p;
+                p["input_pointcloud_layer"]         = "raw";
+                p["output_pointcloud_layer"]        = "out";
+                p["desired_output_point_count"]     = 4;
+                p["voxel_size"]                     = 1.0f;
+                p["minimum_input_points_per_voxel"] = 1;
+                p["decimate_method"]                = mrpt::typemeta::enum2str(method);
+
+                filter.initialize(p);
+                filter.filter(map2);
+
+                auto out = map2.layer<mrpt::maps::CPointsMap>("out");
+                ASSERT_(out);
+                ASSERT_EQUAL_(out->size(), 4U);
+
+                const float* expected =
+                    (method == DecimateMethod::VoxelAverage) ? expectedMean : expectedClosest;
+                const float tol = (method == DecimateMethod::VoxelAverage) ? 1e-4f : 1e-6f;
+
+                for (int i = 0; i < 4; i++)
+                {
+                    const float got = closestX(*out, expected[i]);
+                    ASSERT_NEAR_(got, expected[i], tol);
+                }
+
+                std::cout << "[Test Passed] FilterDecimateAdaptive decimate_method="
+                          << mrpt::typemeta::enum2str(method) << "\n";
+            }
         }
 
         std::cout << "\nFilterDecimateAdaptive Unit Tests Passed!\n";


### PR DESCRIPTION
## Summary
- `FilterDecimateAdaptive` always picked an arbitrary real point per occupied voxel ("first point", in whatever order points were processed), unlike PCL's `pcl::VoxelGrid` (used by DLIO), which always returns the true per-voxel centroid — so the two decimation strategies could not be compared like-for-like without a code change.
- Adds the same `decimate_method` enum `FilterDecimateVoxels` already exposes (`FirstPoint`, `VoxelAverage`, `ClosestToAverage`, `RandomPoint`) to `FilterDecimateAdaptive`. `FirstPoint` stays the default and keeps its existing adaptive point-budget round-robin unchanged; the other methods each emit exactly one point per occupied voxel, regardless of how many times the round-robin revisits it.
- Factors the per-voxel representative-point logic — previously duplicated between the two filters — into a shared `VoxelRepresentativePoint.h`/`.cpp` (also moves the `DecimateMethod` enum there, out of `FilterDecimateVoxels.h`, since it's no longer specific to that filter).

## Test plan
- [x] New unit test cases in `test-mp2p_FilterDecimateAdaptive.cpp`: `VoxelAverage` checked against a hand-computed centroid, `ClosestToAverage` checked against a known nearest real point (asymmetric voxel contents to avoid a tie).
- [x] Full `mp2p_icp_core` test suite (112/112) passes, including the pre-existing `FilterDecimateVoxels` suite, confirming the refactor didn't change that filter's behavior.
- [x] Downstream `mola_lidar_odometry` still builds against the updated headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEK5SL1AFntJXWgKsaHzoL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable representative-point selection for adaptive voxel decimation.
  * Choose the first, average, closest-to-average, or random point from each occupied voxel.
  * Adaptive decimation now supports YAML configuration of the selection method.
  * Voxel-based and adaptive filters use consistent representative-point behavior.
* **Tests**
  * Added coverage validating average and closest-to-average selection, output counts, and representative coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->