### PR TITLE
fix: spurious -Wmaybe-uninitialized in FilterDecimateVoxels::initialize_filter

### DIFF
--- a/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateVoxels.cpp
+++ b/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateVoxels.cpp
@@ -87,15 +87,14 @@ void FilterDecimateVoxels::initialize_filter(const mrpt::containers::yaml& c)
     MRPT_LOG_DEBUG_STREAM("Loading these params:\n" << c);
     params.load_from_yaml(c, *this);
 
-    filter_grid_single_.reset();
-    filter_grid_.reset();
-
     if (useSingleGrid())
     {  // Create:
+        filter_grid_.reset();
         filter_grid_single_.emplace();
     }
     else
     {  // Create:
+        filter_grid_single_.reset();
         filter_grid_.emplace();
     }
 


### PR DESCRIPTION
## Summary
- A clean rebuild under GCC 15 surfaces a `-Wmaybe-uninitialized` warning in `FilterDecimateVoxels::initialize_filter()`, pointing at the `filter_grid_.emplace()` call, through an inlined chain into `unique_ptr`'s destructor for the pimpl's function-pointer deleter.
- Root cause: both `std::optional` grid members (`filter_grid_`, `filter_grid_single_`) were unconditionally `.reset()` before `.emplace()`-ing only one of them, so the one about to be (re)constructed was torn down twice in quick succession (once explicitly, once implicitly inside `emplace()`). GCC's flow analysis loses track of the deleter's initialization across that redundant double-teardown.
- Fix: only reset the *other* optional — the explicit reset was never needed for the one being emplaced.
- Confirmed this is not new: built `FilterDecimateVoxels.cpp` in isolation, with identical flags, from both the pre-#83 and post-#83 commits — the warning is present in both, so it predates and is unrelated to #83's changes.

## Test plan
- [x] Compiled the function in isolation before/after the fix with the project's exact flags: warning count 1 → 0, no new warnings introduced.
- [x] Full `mp2p_icp_core` test suite (112/112) passes.
- [x] Downstream `mola_lidar_odometry` still builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FEK5SL1AFntJXWgKsaHzoL