### PR TITLE
Merge per-thread voxel grids in FilterDecimateAdaptive

### DIFF
--- a/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateAdaptive.h
+++ b/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateAdaptive.h
@@ -53,9 +53,9 @@ namespace mp2p_icp_filters
  *   DecimateMethod::VoxelAverage generates new points, so per-point fields
  *   (intensity, ring, timestamp, ...) are not propagated to the output.
  *
- * When built with TBB, voxels are accumulated per thread and not merged, so the
- * per-voxel averages above are computed over the subset of points that fell in
- * the same thread block.
+ * When built with TBB the input is binned in parallel, but the resulting
+ * per-thread grids are merged by voxel key before sampling, so the output does
+ * not depend on the number of threads or on how the work was split.
  *
  * Not compatible with calling from different threads simultaneously for
  * different input point clouds. Use independent instances for each thread if

--- a/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/PointCloudToVoxelGrid.h
+++ b/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/PointCloudToVoxelGrid.h
@@ -44,6 +44,24 @@ class PointCloudToVoxelGrid
         const mrpt::maps::CPointsMap& p, const std::size_t first_pt_idx = 0,
         const std::size_t points_to_process = 0);
 
+    /** Appends the contents of another grid into this one, joining the point
+     *  indices of voxels sharing the same key.
+     *
+     *  Intended to reassemble the partial grids built by each thread when the
+     *  input cloud is binned in parallel: without it, one spatial voxel remains
+     *  split into one fragment per thread.
+     *
+     *  Both grids must have the same resolution. Point indices are left in
+     *  arbitrary order; call sortVoxelPointIndices() afterwards to restore the
+     *  ascending order that sequential binning would have produced.
+     */
+    void mergeFrom(const PointCloudToVoxelGrid& other);
+
+    /** Sorts the point indices of every voxel in ascending order, so that the
+     *  contents no longer depend on the order in which points were binned.
+     */
+    void sortVoxelPointIndices();
+
     /** Remove all points and internal data.
      */
     void clear();

--- a/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/PointCloudToVoxelGrid.h
+++ b/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/PointCloudToVoxelGrid.h
@@ -51,7 +51,7 @@ class PointCloudToVoxelGrid
      *  input cloud is binned in parallel: without it, one spatial voxel remains
      *  split into one fragment per thread.
      *
-     *  Both grids must have the same resolution. Point indices are left in
+     *  Both grids must have the same resolution and map type. Point indices are left in
      *  arbitrary order; call sortVoxelPointIndices() afterwards to restore the
      *  ascending order that sequential binning would have produced.
      */

--- a/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
@@ -27,6 +27,8 @@
 #include <mrpt/random/RandomGenerators.h>
 #include <mrpt/version.h>
 
+#include <algorithm>
+
 #if defined(MP2P_HAS_TBB)
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/parallel_for.h>
@@ -79,6 +81,10 @@ struct FilterDecimateAdaptive::Impl
 {
 #if defined(MP2P_HAS_TBB)
     tbb::enumerable_thread_specific<PointCloudToVoxelGrid> tls;
+
+    /// Where the per-thread grids of `tls` are reassembled. Owning the merged
+    /// voxels here is what keeps voxel_t a plain non-owning span.
+    PointCloudToVoxelGrid merged_grid;
 #else
     PointCloudToVoxelGrid filter_grid;
 #endif
@@ -200,10 +206,22 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
             grid.processPointCloud(pc, start, length);
         });
 
-    for (auto& grid : impl_->tls)
+    // Reassemble the per-thread grids: a voxel key is global, so the same
+    // spatial voxel is present in every grid whose block saw points in it.
+    // Visiting the grids separately would treat each fragment as an
+    // independent voxel, which both breaks the one-representative-per-voxel
+    // contract and makes the result depend on how work was split.
+    impl_->merged_grid.setConfiguration(params.voxel_size, true);
+
+    for (const auto& grid : impl_->tls)
     {
-        grid.visit_voxels(lambdaVisitVoxel);
+        impl_->merged_grid.mergeFrom(grid);
     }
+    impl_->merged_grid.sortVoxelPointIndices();
+
+    voxels.reserve(impl_->merged_grid.size());
+
+    impl_->merged_grid.visit_voxels(lambdaVisitVoxel);
 
 #else
     impl_->filter_grid.clear();
@@ -215,6 +233,15 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
     impl_->filter_grid.visit_voxels(lambdaVisitVoxel);
 
 #endif
+
+    // Canonical voxel order. Hash map traversal order is an implementation
+    // detail, and the resampling below walks this list with a stride, so which
+    // voxels make it to the output would otherwise depend on it. Ordering by
+    // the first input point of each voxel gives the same list for any map type
+    // and any number of threads.
+    std::sort(
+        voxels.begin(), voxels.end(),
+        [](const DataPerVoxel& a, const DataPerVoxel& b) { return a.voxel[0] < b.voxel[0]; });
 
     const size_t nVoxels = voxels.size();
 

--- a/mp2p_icp_core/mp2p_icp_filters/src/PointCloudToVoxelGrid.cpp
+++ b/mp2p_icp_core/mp2p_icp_filters/src/PointCloudToVoxelGrid.cpp
@@ -23,6 +23,7 @@
 // Used in the PIMP:
 #include <tsl/robin_map.h>
 
+#include <algorithm>
 #include <map>
 
 using namespace mp2p_icp_filters;
@@ -79,6 +80,76 @@ void PointCloudToVoxelGrid::processPointCloud(
     else
     {
         pass(impl_->pts_voxels_std_map);
+    }
+}
+
+void PointCloudToVoxelGrid::mergeFrom(const PointCloudToVoxelGrid& other)
+{
+    MRPT_START
+
+    ASSERT_EQUAL_(resolution_, other.resolution_);
+
+    auto append = [](auto& dest, const auto& src)
+    {
+        for (const auto& [key, entry] : src)
+        {
+            auto& destIndices = dest[key].indices;
+            destIndices.insert(destIndices.end(), entry.indices.begin(), entry.indices.end());
+        }
+    };
+
+    // The source may use a different map type than this grid, so all four
+    // combinations must be handled:
+    const auto& o = *other.impl_;
+
+    if (use_tsl_robin_map_)
+    {
+        if (other.use_tsl_robin_map_)
+        {
+            append(impl_->pts_voxels, o.pts_voxels);
+        }
+        else
+        {
+            append(impl_->pts_voxels, o.pts_voxels_std_map);
+        }
+    }
+    else
+    {
+        if (other.use_tsl_robin_map_)
+        {
+            append(impl_->pts_voxels_std_map, o.pts_voxels);
+        }
+        else
+        {
+            append(impl_->pts_voxels_std_map, o.pts_voxels_std_map);
+        }
+    }
+
+    MRPT_END
+}
+
+void PointCloudToVoxelGrid::sortVoxelPointIndices()
+{
+    auto sortAll = [](auto& voxels)
+    {
+        for (auto it = voxels.begin(); it != voxels.end(); ++it)
+        {
+            // tsl::robin_map only exposes mutable values via value():
+            auto& indices = it.value().indices;
+            std::sort(indices.begin(), indices.end());
+        }
+    };
+
+    if (use_tsl_robin_map_)
+    {
+        sortAll(impl_->pts_voxels);
+    }
+    else
+    {
+        for (auto& [key, entry] : impl_->pts_voxels_std_map)
+        {
+            std::sort(entry.indices.begin(), entry.indices.end());
+        }
     }
 }
 

--- a/mp2p_icp_core/mp2p_icp_filters/src/PointCloudToVoxelGrid.cpp
+++ b/mp2p_icp_core/mp2p_icp_filters/src/PointCloudToVoxelGrid.cpp
@@ -88,6 +88,7 @@ void PointCloudToVoxelGrid::mergeFrom(const PointCloudToVoxelGrid& other)
     MRPT_START
 
     ASSERT_EQUAL_(resolution_, other.resolution_);
+    ASSERT_EQUAL_(use_tsl_robin_map_, other.use_tsl_robin_map_);
 
     auto append = [](auto& dest, const auto& src)
     {
@@ -98,31 +99,13 @@ void PointCloudToVoxelGrid::mergeFrom(const PointCloudToVoxelGrid& other)
         }
     };
 
-    // The source may use a different map type than this grid, so all four
-    // combinations must be handled:
-    const auto& o = *other.impl_;
-
     if (use_tsl_robin_map_)
     {
-        if (other.use_tsl_robin_map_)
-        {
-            append(impl_->pts_voxels, o.pts_voxels);
-        }
-        else
-        {
-            append(impl_->pts_voxels, o.pts_voxels_std_map);
-        }
+        append(impl_->pts_voxels, other.impl_->pts_voxels);
     }
     else
     {
-        if (other.use_tsl_robin_map_)
-        {
-            append(impl_->pts_voxels_std_map, o.pts_voxels);
-        }
-        else
-        {
-            append(impl_->pts_voxels_std_map, o.pts_voxels_std_map);
-        }
+        append(impl_->pts_voxels_std_map, other.impl_->pts_voxels_std_map);
     }
 
     MRPT_END

--- a/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
@@ -205,6 +205,113 @@ int main()
             }
         }
 
+        // ---------------------------------------------------------
+        // Test: parallel binning must not fragment voxels
+        //
+        // A rotating lidar revisits the same voxel at input indices that are
+        // far apart, so a voxel's points end up in different parallel blocks.
+        // The cloud below reproduces that: kSweeps passes over the same
+        // kColumns positions, so voxel j holds exactly kSweeps points, at
+        // indices j, kColumns+j, 2*kColumns+j, ...
+        // ---------------------------------------------------------
+        {
+            constexpr int   kColumns   = 5000;
+            constexpr int   kSweeps    = 8;
+            constexpr float kVoxelSize = 0.5f;
+
+            const auto sweptCloud = mrpt::maps::CSimplePointsMap::Create();
+            for (int s = 0; s < kSweeps; ++s)
+            {
+                for (int j = 0; j < kColumns; ++j)
+                {
+                    // One voxel per column, plus a jitter well inside it so the
+                    // kSweeps points of a voxel are all distinct:
+                    sweptCloud->insertPoint(
+                        static_cast<float>(j) + 0.05f * static_cast<float>(s), 0.25f, 0.25f);
+                }
+            }
+
+            const auto runFilter = [&](unsigned int minPointsPerVoxel, unsigned int desiredCount)
+            {
+                mp2p_icp::metric_map_t m;
+                m.layers["raw"] = sweptCloud;
+
+                FilterDecimateAdaptive filter;
+                mrpt::containers::yaml p;
+                p["input_pointcloud_layer"]         = "raw";
+                p["output_pointcloud_layer"]        = "out";
+                p["desired_output_point_count"]     = desiredCount;
+                p["voxel_size"]                     = kVoxelSize;
+                p["minimum_input_points_per_voxel"] = minPointsPerVoxel;
+                // Force many blocks, so several threads see the same voxels:
+                p["parallelization_grain_size"] = 512;
+
+                filter.initialize(p);
+                filter.filter(m);
+
+                auto out = m.layer<mrpt::maps::CPointsMap>("out");
+                ASSERT_(out);
+                return out;
+            };
+
+            // (a) A voxel above the threshold must survive, no matter how its
+            //     points were distributed across threads:
+            {
+                auto out = runFilter(kSweeps, kColumns);
+                ASSERT_EQUAL_(out->size(), static_cast<size_t>(kColumns));
+                std::cout << "[Test Passed] minimum_input_points_per_voxel under parallel binning\n";
+            }
+
+            // (b) Asking for exactly one point per voxel must give one point
+            //     per voxel, not one per voxel fragment:
+            {
+                auto out = runFilter(1, kColumns);
+                ASSERT_EQUAL_(out->size(), static_cast<size_t>(kColumns));
+
+                std::vector<bool> seen(kColumns, false);
+                for (size_t i = 0; i < out->size(); i++)
+                {
+                    float x = 0;
+                    float y = 0;
+                    float z = 0;
+                    out->getPointFast(i, x, y, z);
+
+                    const int col = static_cast<int>(std::round(x - 0.05f * 0.5f * (kSweeps - 1)));
+                    ASSERT_GE_(col, 0);
+                    ASSERT_LT_(col, kColumns);
+                    ASSERTMSG_(!seen[col], "Two output points fell in the same voxel");
+                    seen[col] = true;
+                }
+                std::cout << "[Test Passed] one representative per voxel under parallel binning\n";
+            }
+
+            // (c) Two identical runs must give bit-identical output:
+            {
+                auto outA = runFilter(1, kColumns / 3);
+                auto outB = runFilter(1, kColumns / 3);
+
+                ASSERT_EQUAL_(outA->size(), outB->size());
+                ASSERT_(outA->size() > 0);
+
+                for (size_t i = 0; i < outA->size(); i++)
+                {
+                    float ax = 0;
+                    float ay = 0;
+                    float az = 0;
+                    float bx = 0;
+                    float by = 0;
+                    float bz = 0;
+                    outA->getPointFast(i, ax, ay, az);
+                    outB->getPointFast(i, bx, by, bz);
+                    ASSERT_EQUAL_(ax, bx);
+                    ASSERT_EQUAL_(ay, by);
+                    ASSERT_EQUAL_(az, bz);
+                }
+                std::cout << "[Test Passed] run-to-run determinism (" << outA->size()
+                          << " points)\n";
+            }
+        }
+
         std::cout << "\nFilterDecimateAdaptive Unit Tests Passed!\n";
     }
     catch (const std::exception& e)

--- a/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
@@ -259,7 +259,8 @@ int main()
             {
                 auto out = runFilter(kSweeps, kColumns);
                 ASSERT_EQUAL_(out->size(), static_cast<size_t>(kColumns));
-                std::cout << "[Test Passed] minimum_input_points_per_voxel under parallel binning\n";
+                std::cout
+                    << "[Test Passed] minimum_input_points_per_voxel under parallel binning\n";
             }
 
             // (b) Asking for exactly one point per voxel must give one point

--- a/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
@@ -333,32 +333,49 @@ int main()
 
                 const size_t nPts = sweptCloud->size();
 
-                PointCloudToVoxelGrid whole;
-                whole.setConfiguration(kVoxelSize, true);
-                whole.processPointCloud(*sweptCloud);
+                // Both backing map types, which must also agree with each
+                // other: the voxel contents are what the canonical ordering is
+                // built from, so they cannot depend on the container.
+                std::map<
+                    PointCloudToVoxelGrid::indices_t, std::vector<std::size_t>,
+                    PointCloudToVoxelGrid::IndicesHash>
+                    contentsPerMapType[2];
 
-                // Three arbitrary, unequal pieces, as parallel blocks would be:
-                PointCloudToVoxelGrid pieces[3];
-                const size_t          cuts[4] = {0, nPts / 7, nPts / 2, nPts};
-                for (int i = 0; i < 3; i++)
+                for (int useRobinMap = 0; useRobinMap < 2; useRobinMap++)
                 {
-                    pieces[i].setConfiguration(kVoxelSize, true);
-                    pieces[i].processPointCloud(*sweptCloud, cuts[i], cuts[i + 1] - cuts[i]);
+                    PointCloudToVoxelGrid whole;
+                    whole.setConfiguration(kVoxelSize, useRobinMap != 0);
+                    whole.processPointCloud(*sweptCloud);
+
+                    // Three arbitrary, unequal pieces, as parallel blocks would be:
+                    PointCloudToVoxelGrid pieces[3];
+                    const size_t          cuts[4] = {0, nPts / 7, nPts / 2, nPts};
+                    for (int i = 0; i < 3; i++)
+                    {
+                        pieces[i].setConfiguration(kVoxelSize, useRobinMap != 0);
+                        pieces[i].processPointCloud(*sweptCloud, cuts[i], cuts[i + 1] - cuts[i]);
+                    }
+
+                    PointCloudToVoxelGrid merged;
+                    merged.setConfiguration(kVoxelSize, useRobinMap != 0);
+                    for (const auto& p : pieces)
+                    {
+                        merged.mergeFrom(p);
+                    }
+                    merged.sortVoxelPointIndices();
+
+                    ASSERT_EQUAL_(merged.size(), whole.size());
+                    ASSERT_(voxelContents(merged) == voxelContents(whole));
+
+                    contentsPerMapType[useRobinMap] = voxelContents(merged);
+
+                    std::cout << "[Test Passed] mergeFrom() equals one-pass binning ("
+                              << merged.size() << " voxels, "
+                              << (useRobinMap ? "robin_map" : "std::map") << ")\n";
                 }
 
-                PointCloudToVoxelGrid merged;
-                merged.setConfiguration(kVoxelSize, true);
-                for (const auto& p : pieces)
-                {
-                    merged.mergeFrom(p);
-                }
-                merged.sortVoxelPointIndices();
-
-                ASSERT_EQUAL_(merged.size(), whole.size());
-                ASSERT_(voxelContents(merged) == voxelContents(whole));
-
-                std::cout << "[Test Passed] mergeFrom() equals one-pass binning (" << merged.size()
-                          << " voxels)\n";
+                ASSERT_(contentsPerMapType[0] == contentsPerMapType[1]);
+                std::cout << "[Test Passed] merged voxels do not depend on the map type\n";
             }
         }
 

--- a/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
@@ -26,6 +26,8 @@
 
 #include <cmath>
 #include <iostream>
+#include <map>
+#include <vector>
 
 using namespace mp2p_icp_filters;
 
@@ -310,6 +312,53 @@ int main()
                 }
                 std::cout << "[Test Passed] run-to-run determinism (" << outA->size()
                           << " points)\n";
+            }
+
+            // (d) The merge itself, independently of how many workers TBB
+            //     happens to give this machine: binning a cloud in pieces and
+            //     merging must equal binning it in one go. The checks above
+            //     only exercise the merge when the run really is concurrent.
+            {
+                const auto voxelContents = [](const PointCloudToVoxelGrid& g)
+                {
+                    std::map<
+                        PointCloudToVoxelGrid::indices_t, std::vector<std::size_t>,
+                        PointCloudToVoxelGrid::IndicesHash>
+                        out;
+                    g.visit_voxels([&](const PointCloudToVoxelGrid::indices_t idx,
+                                       const PointCloudToVoxelGrid::voxel_t&  vxl)
+                                   { out[idx].assign(vxl.begin(), vxl.end()); });
+                    return out;
+                };
+
+                const size_t nPts = sweptCloud->size();
+
+                PointCloudToVoxelGrid whole;
+                whole.setConfiguration(kVoxelSize, true);
+                whole.processPointCloud(*sweptCloud);
+
+                // Three arbitrary, unequal pieces, as parallel blocks would be:
+                PointCloudToVoxelGrid pieces[3];
+                const size_t          cuts[4] = {0, nPts / 7, nPts / 2, nPts};
+                for (int i = 0; i < 3; i++)
+                {
+                    pieces[i].setConfiguration(kVoxelSize, true);
+                    pieces[i].processPointCloud(*sweptCloud, cuts[i], cuts[i + 1] - cuts[i]);
+                }
+
+                PointCloudToVoxelGrid merged;
+                merged.setConfiguration(kVoxelSize, true);
+                for (const auto& p : pieces)
+                {
+                    merged.mergeFrom(p);
+                }
+                merged.sortVoxelPointIndices();
+
+                ASSERT_EQUAL_(merged.size(), whole.size());
+                ASSERT_(voxelContents(merged) == voxelContents(whole));
+
+                std::cout << "[Test Passed] mergeFrom() equals one-pass binning (" << merged.size()
+                          << " voxels)\n";
             }
         }
 


### PR DESCRIPTION
## The bug

Under TBB, `FilterDecimateAdaptive` bins the input cloud in parallel into one
`PointCloudToVoxelGrid` per thread, but the voxel key is global. The per-thread
grids were then visited independently:

```cpp
for (auto& grid : impl_->tls) { grid.visit_voxels(lambdaVisitVoxel); }
```

so a single spatial voxel was left split into one fragment per thread that saw
points in it, and each fragment was treated as an independent voxel.

Three consequences:

1. **Nondeterminism.** Which points land in which fragment depends on TBB's
   block splitting and work stealing, and `desired_output_point_count`
   truncates the voxel list, so two identical runs get different decimated
   clouds.
2. **Decimation emits up to one representative per thread per voxel**, not one
   per voxel, so the output is denser and less uniform than requested.
3. **`minimum_input_points_per_voxel` is applied per fragment**, so a voxel
   legitimately above the threshold is dropped when its points are split across
   threads.

This hits rotating lidars hard rather than marginally: consecutive point indices
sweep azimuth, so a voxel is revisited at input indices that are far apart and
therefore in different blocks. In the added regression test, which reproduces
that access pattern, **all 5000 voxels are dropped** by defect 3 on the current
code.

## The fix

Merge the per-thread grids by voxel key before sampling, into an owning
`PointCloudToVoxelGrid` (new `mergeFrom()`), so `voxel_t` stays a plain
non-owning span and its contract is unchanged. Voxel point indices are then
sorted, so a voxel's contents no longer depend on binning order.

The voxel list is also given a canonical order, by each voxel's first input
point, in **both** the parallel and the sequential paths. The resampling walks
that list with a stride, so which voxels reach the output would otherwise depend
on hash map traversal order — an implementation detail that differs between the
`tsl::robin_map` and `std::map` backends. Note this means **the sequential path's
output changes too**; it is no longer tied to bucket order.

## Tests

Three checks over a cloud that revisits voxels at distant input indices. All
three fail on `develop`:

| Check | On `develop` |
|---|---|
| `minimum_input_points_per_voxel` honored | 0 of 5000 voxels survive |
| one representative per voxel | two output points land in one voxel |
| two identical runs agree | — |

Full `mp2p_icp_core` suite: 110/110 pass.

## Measured downstream

Full `oxford-spires keble-college-03` via `mola-lidar-odometry-cli`, 2867 scans,
88 cores.

**Determinism.** With the IMU input removed (to exclude a separate,
unrelated IMU/lidar worker-pool race in `mola_lidar_odometry`), two full runs go
from *different* on `develop` to *byte-identical* with this change.

**Accuracy.** APE RMSE vs the sequence's GT: `develop` scores 0.644 and 0.432 on
two runs of its own; this branch scores 0.4488 twice. So this is **not** an
accuracy improvement — it lands inside the noise band `develop` already spans —
but the spread goes from 49% to zero.

**Cost.** `onLidar` mean 62.7 → 70.1 ms (**+12%**); the filter itself roughly
doubles (6.4 → 13.5 ms for the map instance). That is more than I hoped: the
merge copies every point index and sorts per voxel, so it is O(points), not one
pass over voxels. Pre-reserving the merged grid's buckets was tried and made no
difference, so it is not rehashing. The likely remaining cost is allocation
churn from one `std::vector` per voxel; replacing those with a flat arena inside
`PointCloudToVoxelGrid` would help the existing binning too, but that is a
larger change and I have left it out of this PR.

Happy to take direction on whether the +12% is acceptable as-is or should be
optimized before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adaptive point-cloud decimation so parallel processing produces deterministic results regardless of thread count or work partitioning.
  * Ensured voxel sampling consistently returns one representative point per spatial voxel.

* **New Features**
  * Added support for merging compatible voxel grids and sorting voxel point indices for reproducible processing.

* **Tests**
  * Added regression coverage for parallel voxel binning, minimum-point filtering, and repeatable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->