### PR TITLE
Store voxel point indices in one flat array (recovers the FilterDecimateAdaptive regression)

### DIFF
--- a/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/PointCloudToVoxelGrid.h
+++ b/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/PointCloudToVoxelGrid.h
@@ -57,6 +57,14 @@ class PointCloudToVoxelGrid
      */
     void mergeFrom(const PointCloudToVoxelGrid& other);
 
+    /** Like mergeFrom(), for several grids at once.
+     *
+     *  Preferred over calling mergeFrom() in a loop: the point indices of all
+     *  voxels live in one contiguous array, which is laid out just once here
+     *  instead of once per merged grid.
+     */
+    void mergeFrom(const std::vector<const PointCloudToVoxelGrid*>& others);
+
     /** Sorts the point indices of every voxel in ascending order, so that the
      *  contents no longer depend on the order in which points were binned.
      */
@@ -76,18 +84,18 @@ class PointCloudToVoxelGrid
     /** Non-owning view of the point indices in a voxel.
      *  Backed by the flat index array inside PointCloudToVoxelGrid; valid
      *  only while the owning PointCloudToVoxelGrid is alive and unmodified.
-     *  Trivially copyable (pointer + count, 16 bytes — no heap allocation).
+     *  Trivially copyable (pointer + count, no heap allocation).
      */
     struct voxel_t
     {
-        const std::size_t* begin_ptr = nullptr;
-        std::uint32_t      count     = 0;
+        const std::uint32_t* begin_ptr = nullptr;
+        std::uint32_t        count     = 0;
 
-        std::size_t        size() const { return count; }
-        bool               empty() const { return count == 0; }
-        const std::size_t* begin() const { return begin_ptr; }
-        const std::size_t* end() const { return begin_ptr + count; }
-        std::size_t        operator[](std::size_t i) const { return begin_ptr[i]; }
+        std::size_t          size() const { return count; }
+        bool                 empty() const { return count == 0; }
+        const std::uint32_t* begin() const { return begin_ptr; }
+        const std::uint32_t* end() const { return begin_ptr + count; }
+        std::size_t          operator[](std::size_t i) const { return begin_ptr[i]; }
     };
 
     struct indices_t

--- a/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
@@ -85,6 +85,9 @@ struct FilterDecimateAdaptive::Impl
     /// Where the per-thread grids of `tls` are reassembled. Owning the merged
     /// voxels here is what keeps voxel_t a plain non-owning span.
     PointCloudToVoxelGrid merged_grid;
+
+    /// Reusable list of the `tls` grids to merge, to avoid reallocating it.
+    std::vector<const PointCloudToVoxelGrid*> parts;
 #else
     PointCloudToVoxelGrid filter_grid;
 #endif
@@ -138,8 +141,8 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
 
     struct DataPerVoxel
     {
-        // voxel_t is a non-owning span (16 bytes); copy by value so we don't
-        // hold a dangling pointer to the temporary built inside visit_voxels.
+        // voxel_t is a non-owning span; copy by value so we don't hold a
+        // dangling pointer to the temporary built inside visit_voxels.
         PointCloudToVoxelGrid::voxel_t voxel;
         uint32_t                       nextIdx   = 0;
         bool                           exhausted = false;
@@ -213,10 +216,12 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
     // contract and makes the result depend on how work was split.
     impl_->merged_grid.setConfiguration(params.voxel_size, true);
 
+    impl_->parts.clear();
     for (const auto& grid : impl_->tls)
     {
-        impl_->merged_grid.mergeFrom(grid);
+        impl_->parts.push_back(&grid);
     }
+    impl_->merged_grid.mergeFrom(impl_->parts);
     impl_->merged_grid.sortVoxelPointIndices();
 
     voxels.reserve(impl_->merged_grid.size());

--- a/mp2p_icp_core/mp2p_icp_filters/src/PointCloudToVoxelGrid.cpp
+++ b/mp2p_icp_core/mp2p_icp_filters/src/PointCloudToVoxelGrid.cpp
@@ -19,26 +19,85 @@
  */
 
 #include <mp2p_icp_filters/PointCloudToVoxelGrid.h>
+#include <mrpt/core/exceptions.h>
 
 // Used in the PIMP:
 #include <tsl/robin_map.h>
 
 #include <algorithm>
+#include <limits>
 #include <map>
 
 using namespace mp2p_icp_filters;
 
-// Internal per-voxel bookkeeping: stores point indices for each voxel.
+/** Internal per-voxel bookkeeping. The point indices themselves live in one
+ *  contiguous array shared by all voxels (see Impl::indices), so that adding a
+ *  voxel does not require a heap allocation of its own.
+ */
 struct VoxelEntry
 {
-    std::vector<std::size_t> indices;
+    /// Where this voxel's run starts within the flat index array.
+    std::uint32_t offset = 0;
+
+    /// How many indices of the run are already written.
+    std::uint32_t filled = 0;
+
+    /// Final length of the run, once the ongoing pass finishes.
+    std::uint32_t count = 0;
 };
 
 struct PointCloudToVoxelGrid::Impl
 {
     tsl::robin_map<indices_t, VoxelEntry, IndicesHash> pts_voxels;
     std::map<indices_t, VoxelEntry, IndicesHash>       pts_voxels_std_map;
+
+    /// Flat storage for the point indices of every voxel, one contiguous run
+    /// per voxel. Kept across calls (only its size is reset in clear()) to
+    /// avoid reallocating it for each processed cloud.
+    std::vector<std::uint32_t> indices;
+
+    /// Scratch buffer used to rebuild `indices` when runs move around.
+    std::vector<std::uint32_t> indices_aux;
+
+    /// Sum of the `count` of all voxels, i.e. the size `indices` must have.
+    std::uint32_t total_indices = 0;
 };
+
+namespace
+{
+using RobinMap = tsl::robin_map<
+    PointCloudToVoxelGrid::indices_t, VoxelEntry, PointCloudToVoxelGrid::IndicesHash>;
+using StdMap =
+    std::map<PointCloudToVoxelGrid::indices_t, VoxelEntry, PointCloudToVoxelGrid::IndicesHash>;
+
+// tsl::robin_map only exposes mutable values via value(), std::map via second:
+VoxelEntry& valueRef(RobinMap::iterator& it) { return it.value(); }
+VoxelEntry& valueRef(StdMap::iterator& it) { return it->second; }
+
+/** Assigns every voxel a run of `count` entries in a freshly laid out index
+ *  array, carrying over the `filled` indices each voxel already had.
+ *  Needed whenever new points are added, since runs of existing voxels must
+ *  grow in place.
+ */
+template <class MAP>
+void relayoutVoxels(
+    MAP& voxels, std::vector<std::uint32_t>& arena, std::vector<std::uint32_t>& aux,
+    const std::uint32_t total)
+{
+    aux.resize(total);
+
+    std::uint32_t next = 0;
+    for (auto it = voxels.begin(); it != voxels.end(); ++it)
+    {
+        auto& e = valueRef(it);
+        std::copy(
+            arena.begin() + e.offset, arena.begin() + e.offset + e.filled, aux.begin() + next);
+        e.offset = next;
+        next += e.count;
+    }
+    arena.swap(aux);
+}
+}  // namespace
 
 PointCloudToVoxelGrid::PointCloudToVoxelGrid() : impl_(mrpt::make_impl<Impl>()) {}
 
@@ -64,12 +123,29 @@ void PointCloudToVoxelGrid::processPointCloud(
 
     const auto last_pt_idx = points_to_process ? (first_pt_idx + points_to_process) : xs.size();
 
+    // Point indices are stored as 32 bit to halve the memory traffic:
+    ASSERT_LT_(last_pt_idx, static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max()));
+
     auto pass = [&](auto& voxels)
     {
+        // 1st pass: how many points fall into each voxel.
         for (std::size_t i = first_pt_idx; i < last_pt_idx; i++)
         {
             const indices_t key = {coord2idx(xs[i]), coord2idx(ys[i]), coord2idx(zs[i])};
-            voxels[key].indices.push_back(i);
+            voxels[key].count++;
+        }
+
+        impl_->total_indices += static_cast<std::uint32_t>(last_pt_idx - first_pt_idx);
+
+        relayoutVoxels(voxels, impl_->indices, impl_->indices_aux, impl_->total_indices);
+
+        // 2nd pass: write each point index into the run of its voxel.
+        for (std::size_t i = first_pt_idx; i < last_pt_idx; i++)
+        {
+            const indices_t key = {coord2idx(xs[i]), coord2idx(ys[i]), coord2idx(zs[i])};
+            auto            it  = voxels.find(key);
+            auto&           e   = valueRef(it);
+            impl_->indices[e.offset + e.filled++] = static_cast<std::uint32_t>(i);
         }
     };
 
@@ -85,27 +161,62 @@ void PointCloudToVoxelGrid::processPointCloud(
 
 void PointCloudToVoxelGrid::mergeFrom(const PointCloudToVoxelGrid& other)
 {
+    mergeFrom(std::vector<const PointCloudToVoxelGrid*>{&other});
+}
+
+void PointCloudToVoxelGrid::mergeFrom(const std::vector<const PointCloudToVoxelGrid*>& others)
+{
     MRPT_START
 
-    ASSERT_EQUAL_(resolution_, other.resolution_);
-    ASSERT_EQUAL_(use_tsl_robin_map_, other.use_tsl_robin_map_);
-
-    auto append = [](auto& dest, const auto& src)
+    for (const auto* o : others)
     {
-        for (const auto& [key, entry] : src)
+        ASSERT_EQUAL_(resolution_, o->resolution_);
+        ASSERT_EQUAL_(use_tsl_robin_map_, o->use_tsl_robin_map_);
+    }
+
+    auto append = [&](auto& dest, auto srcOf)
+    {
+        for (const auto* o : others)
         {
-            auto& destIndices = dest[key].indices;
-            destIndices.insert(destIndices.end(), entry.indices.begin(), entry.indices.end());
+            impl_->total_indices += o->impl_->total_indices;
+
+            for (const auto& [key, entry] : srcOf(*o))
+            {
+                dest[key].count += entry.count;
+            }
+        }
+
+        // One single layout pass for all the merged grids:
+        relayoutVoxels(dest, impl_->indices, impl_->indices_aux, impl_->total_indices);
+
+        for (const auto* o : others)
+        {
+            const auto& srcIndices = o->impl_->indices;
+            for (const auto& [key, entry] : srcOf(*o))
+            {
+                auto  it = dest.find(key);
+                auto& e  = valueRef(it);
+                std::copy(
+                    srcIndices.begin() + entry.offset,
+                    srcIndices.begin() + entry.offset + entry.count,
+                    impl_->indices.begin() + e.offset + e.filled);
+                e.filled += entry.count;
+            }
         }
     };
 
     if (use_tsl_robin_map_)
     {
-        append(impl_->pts_voxels, other.impl_->pts_voxels);
+        append(
+            impl_->pts_voxels,
+            [](const PointCloudToVoxelGrid& g) -> const RobinMap& { return g.impl_->pts_voxels; });
     }
     else
     {
-        append(impl_->pts_voxels_std_map, other.impl_->pts_voxels_std_map);
+        append(
+            impl_->pts_voxels_std_map,
+            [](const PointCloudToVoxelGrid& g) -> const StdMap&
+            { return g.impl_->pts_voxels_std_map; });
     }
 
     MRPT_END
@@ -113,13 +224,12 @@ void PointCloudToVoxelGrid::mergeFrom(const PointCloudToVoxelGrid& other)
 
 void PointCloudToVoxelGrid::sortVoxelPointIndices()
 {
-    auto sortAll = [](auto& voxels)
+    auto sortAll = [&](const auto& voxels)
     {
-        for (auto it = voxels.begin(); it != voxels.end(); ++it)
+        for (const auto& [key, entry] : voxels)
         {
-            // tsl::robin_map only exposes mutable values via value():
-            auto& indices = it.value().indices;
-            std::sort(indices.begin(), indices.end());
+            const auto runBegin = impl_->indices.begin() + entry.offset;
+            std::sort(runBegin, runBegin + entry.count);
         }
     };
 
@@ -129,10 +239,7 @@ void PointCloudToVoxelGrid::sortVoxelPointIndices()
     }
     else
     {
-        for (auto& [key, entry] : impl_->pts_voxels_std_map)
-        {
-            std::sort(entry.indices.begin(), entry.indices.end());
-        }
+        sortAll(impl_->pts_voxels_std_map);
     }
 }
 
@@ -149,6 +256,11 @@ void PointCloudToVoxelGrid::clear()
     {
         impl_->pts_voxels_std_map.clear();
     }
+
+    // Keep the capacity of the flat index array: it is refilled on every run
+    // with a similar number of points.
+    impl_->indices.clear();
+    impl_->total_indices = 0;
 }
 
 void PointCloudToVoxelGrid::visit_voxels(
@@ -159,8 +271,8 @@ void PointCloudToVoxelGrid::visit_voxels(
         for (const auto& [idx, entry] : voxels)
         {
             voxel_t view;
-            view.begin_ptr = entry.indices.data();
-            view.count     = static_cast<uint32_t>(entry.indices.size());
+            view.begin_ptr = impl_->indices.data() + entry.offset;
+            view.count     = entry.count;
             userCode(idx, view);
         }
     };

--- a/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
@@ -367,6 +367,16 @@ int main()
                     ASSERT_EQUAL_(merged.size(), whole.size());
                     ASSERT_(voxelContents(merged) == voxelContents(whole));
 
+                    // Merging all the pieces in one single call, as the filter
+                    // does, must give exactly the same result:
+                    PointCloudToVoxelGrid mergedAtOnce;
+                    mergedAtOnce.setConfiguration(kVoxelSize, useRobinMap != 0);
+                    mergedAtOnce.mergeFrom({&pieces[0], &pieces[1], &pieces[2]});
+                    mergedAtOnce.sortVoxelPointIndices();
+
+                    ASSERT_EQUAL_(mergedAtOnce.size(), whole.size());
+                    ASSERT_(voxelContents(mergedAtOnce) == voxelContents(whole));
+
                     contentsPerMapType[useRobinMap] = voxelContents(merged);
 
                     std::cout << "[Test Passed] mergeFrom() equals one-pass binning ("


### PR DESCRIPTION
Follow-up to #86 (already merged into `develop`): pure optimization, **no output change**.

## The problem

#86 fixed the voxel fragmentation bug, but cost about +12% on `onLidar` mean, mostly
inside the two `FilterDecimateAdaptive` instances of the MOLA-LO default pipeline.

## What changed

**1. `PointCloudToVoxelGrid` stores point indices in one flat array.**
Each voxel used to own a `std::vector<std::size_t>`, i.e. one heap allocation per voxel,
destroyed and rebuilt from scratch for every processed cloud (tens of thousands of voxels
per scan). Now all indices live in a single contiguous `std::vector<uint32_t>`, and the
hash map entry only holds an offset and a count into it. `clear()` keeps that array's
capacity, so in steady state the binning allocates nothing at all. Indices are `uint32_t`
instead of `std::size_t`, halving the memory traffic (`voxel_t::count` was already 32 bit;
`processPointCloud()` asserts the point count fits).

`voxel_t` stays a plain non-owning span, as intended, and it is now genuinely backed by the
flat index array that its own doc comment already described.

**2. `FilterDecimateAdaptive` merges all its per-thread grids in one call.**
New `mergeFrom(const std::vector<const PointCloudToVoxelGrid*>&)` overload. This turned out
to matter a lot: `tbb::enumerable_thread_specific` accumulates one grid per worker thread
that has *ever* run the filter (observed growing to 63+ over a few hundred scans on this
88-thread box), and the filter merges all of them, most of them empty. With a flat array,
each `mergeFrom()` has to lay the array out again, so merging in a loop was O(grids x voxels).
Merging in one call lays it out exactly once and makes empty grids free again.

## Mechanism of the speedup

Allocator churn was indeed the dominant cost, but only once the repeated re-layout was
removed. A sequential phase breakdown on a real scan (55518 points, 7 blocks) shows where
it goes:

| phase | before | after |
|---|---|---|
| binning (7 blocks) | 6.94 ms | 2.75 ms |
| merge | 4.05 ms | (see note) |
| per-voxel index sort | 0.50 ms | 0.37 ms |
| visit_voxels | 0.29 ms | 0.20 ms |

Note: the merge is no longer comparable phase-by-phase, since it went from one call per
grid to a single call.

## Measurements

**End-to-end**, oxford-spires keble-college-03, IMU input removed so the run is
deterministic (`mola-lidar-odometry-cli`, `lidar3d-default.yaml`, 2867 poses). All three
variants were run consecutively in the same session, swapping only `libmp2p_icp_filters.so`.
MRPT time logger means:

| | pre-#86 | #86 (`develop`) | this PR |
|---|---|---|---|
| `FilterDecimateAdaptive (map)` | 6.4 ms | 11.6 ms | **6.3 ms** |
| `FilterDecimateAdaptive (icp)` | 4.5 ms | 7.0 ms | **4.3 ms** |
| `onLidar` mean | 62.6 ms | 62.5 ms | **53.3 ms** |
| `onLidar` worst case | 150.0 ms | 283.2 ms | **173.4 ms** |

The two filters are back to their pre-#86 cost, and slightly below it.

**Output is unchanged.** #86 and this PR produce the byte-identical trajectory,
`md5 a42c29b537c737a1089ba9dfc5b23e44`, 2867 poses. (Pre-#86 gives a different md5, as it
must: that is the bug #86 fixed.)

Two caveats on the numbers, in the interest of honesty:

- This machine was running unrelated heavy jobs throughout (load average 20-120), so these
  are not quiet-machine numbers. The `#86` vs `this PR` pair is the trustworthy comparison:
  the two ran back to back under comparable load and produce identical output, so their
  `onLidar` figures are directly comparable. The pre-#86 column ran later, under the
  heaviest load of the three.
- The pre-#86 `onLidar` mean is *not* a clean comparison against the other two: pre-#86
  emits a different (buggy) decimated cloud, so the downstream ICP does different work.
  Only its two `FilterDecimateAdaptive` rows are meaningful here, and those match the
  independently measured baseline for this sequence (6.4 / 4.5 ms) exactly.

**Micro-benchmark**, used to iterate: the two filters chained exactly as the pipeline
chains them, over a real 55518-point keble scan, 150 iterations, three variants interleaved
A/B/C and pinned to a fixed 16-core set with `taskset` to cut the variance from external
load. Medians over 3 interleaved repetitions, `(map)` / `(icp)` in ms:

| | pre-#86 | #86 | this PR |
|---|---|---|---|
| moderate external load | 4.4 / 3.1 | 7.3-10.0 / 4.9-6.4 | 5.5-5.7 / 3.6 |
| heavy external load | 5.3-5.9 / 3.8-4.0 | 10.1-12.0 / 6.4-7.0 | 6.4-6.7 / 3.8-4.4 |

## Ruled out / considered

- **Pre-reserving the merged map's bucket array**: already tried in #86, no measurable
  effect, not repeated here.
- **Sorting a compact key array instead of the full per-voxel structs** for the canonical
  voxel ordering: this does make that phase cheaper in isolation (1.6 -> 0.95 ms), but a
  dedicated pinned A/B of exactly that change showed no difference at filter level, so it
  was dropped rather than landed.
- **Counting sort for the canonical voxel order**: would be O(#points) with a #points-sized
  scratch buffer. Rejected: it pessimizes configurations where the cloud is large but the
  voxel count is small.
- **Stealing the largest per-thread grid** instead of merging into an empty one: would save
  roughly one grid's worth of hash inserts out of ~7, judged not worth the extra public
  `swap()` and the "pick the largest" logic. Not measured, so not claimed.
- **Tuning `parallelization_grain_size`**: this is a pipeline config change rather than a
  code change, and it is a separate decision. Not touched here.

## Tests

- Full `mp2p_icp_core` suite: **112/112 passing**.
- `test-mp2p_FilterDecimateAdaptive` already covers the fragmentation properties,
  run-to-run determinism, and `mergeFrom()` equivalence against one-pass binning over both
  backing map types. Extended it to also cover the new multi-grid `mergeFrom()` overload,
  which must equal both the one-by-one merge and one-pass binning.