### PR TITLE
FilterDecimateAdaptive: dynamic point budgets, and a bound on the voxel stride

### DIFF
--- a/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateAdaptive.h
+++ b/mp2p_icp_core/mp2p_icp_filters/include/mp2p_icp_filters/FilterDecimateAdaptive.h
@@ -27,6 +27,7 @@
 #include <mrpt/core/pimpl.h>
 #include <mrpt/maps/CPointsMap.h>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -53,6 +54,15 @@ namespace mp2p_icp_filters
  *   DecimateMethod::VoxelAverage generates new points, so per-point fields
  *   (intensity, ring, timestamp, ...) are not propagated to the output.
  *
+ * The voxel walk uses a stride of `nVoxels/desired_output_point_count` and
+ * stops as soon as the requested count is reached, so a stride above 1 means
+ * that only one in every `stride` occupied cells is ever sampled: coverage is
+ * a fixed fraction of the scene, and which fraction depends on how many
+ * occupied cells the input happens to have. An absolute point count therefore
+ * expresses very different sampling densities on a small room and on an open
+ * road. Set OutputTarget::maximum_voxel_stride to bound that ratio instead,
+ * leaving the absolute count as a floor for sparse inputs.
+ *
  * When built with TBB the input is binned in parallel, but the resulting
  * per-thread grids are merged by voxel key before sampling, so the output does
  * not depend on the number of threads or on how the work was split.
@@ -75,15 +85,30 @@ class FilterDecimateAdaptive : public mp2p_icp_filters::FilterBase
     /** One requested output layer, with its own target point count. */
     struct OutputTarget
     {
-        void load_from_yaml(const mrpt::containers::yaml& c);
+        /** \param parent The filter the parameters belong to, so dynamic
+         *  (formula) parameters can be declared on it. */
+        void load_from_yaml(const mrpt::containers::yaml& c, FilterDecimateAdaptive& parent);
 
-        std::string  output_pointcloud_layer;
-        unsigned int desired_output_point_count = 1000;
+        std::string output_pointcloud_layer;
+
+        /** Dynamic parameter: may be given as a formula, e.g.
+         *  "500 + 15*ESTIMATED_OBSERVATION_RADIUS". */
+        uint32_t desired_output_point_count = 1000;
+
+        /** If non-zero, raises the effective point count for this output until
+         *  the voxel walk visits one in every `maximum_voxel_stride` occupied
+         *  cells at most, that is, until
+         *  `nVoxels/count <= maximum_voxel_stride`. See the class docs.
+         *
+         *  It only ever raises the count, never lowers it, so
+         *  desired_output_point_count keeps acting as a floor for sparse
+         *  inputs. Dynamic parameter: may be given as a formula. */
+        double maximum_voxel_stride = 0;
     };
 
     struct Parameters
     {
-        void load_from_yaml(const mrpt::containers::yaml& c);
+        void load_from_yaml(const mrpt::containers::yaml& c, FilterDecimateAdaptive& parent);
 
         std::string input_pointcloud_layer = mp2p_icp::metric_map_t::PT_LAYER_RAW;
 
@@ -96,6 +121,7 @@ class FilterDecimateAdaptive : public mp2p_icp_filters::FilterBase
          * layer */
         unsigned int minimum_input_points_per_voxel = 1;
 
+        /** Dynamic parameter: may be given as a formula. */
         float voxel_size = 0.10;
 
         /** The method to pick what point will be used as representative of each

--- a/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
@@ -28,6 +28,8 @@
 #include <mrpt/version.h>
 
 #include <algorithm>
+#include <cmath>
+#include <limits>
 
 #if defined(MP2P_HAS_TBB)
 #include <tbb/enumerable_thread_specific.h>
@@ -336,9 +338,18 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
         uint32_t pointCountTarget = target.desired_output_point_count;
         if (target.maximum_voxel_stride > 0)
         {
-            const auto fromStride = static_cast<uint32_t>(
-                std::ceil(static_cast<double>(nVoxels) / target.maximum_voxel_stride));
-            pointCountTarget = std::max(pointCountTarget, fromStride);
+            // The input is the hard ceiling: no method can emit more points
+            // than it was given. Clamping there also keeps an arbitrarily
+            // small stride from overflowing the conversion below. Strides
+            // under 1 are legitimate for the methods that can take several
+            // points out of one voxel, so they are not rejected.
+            const double cap = static_cast<double>(
+                std::min<std::size_t>(pc.size(), std::numeric_limits<uint32_t>::max()));
+            const double wanted =
+                std::ceil(static_cast<double>(nVoxels) / target.maximum_voxel_stride);
+
+            pointCountTarget =
+                std::max(pointCountTarget, static_cast<uint32_t>(std::min(wanted, cap)));
         }
 
         // Create if new: Append to existing layer, if already existed.

--- a/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/mp2p_icp_filters/src/FilterDecimateAdaptive.cpp
@@ -38,13 +38,16 @@ IMPLEMENTS_MRPT_OBJECT(FilterDecimateAdaptive, mp2p_icp_filters::FilterBase, mp2
 
 using namespace mp2p_icp_filters;
 
-void FilterDecimateAdaptive::OutputTarget::load_from_yaml(const mrpt::containers::yaml& c)
+void FilterDecimateAdaptive::OutputTarget::load_from_yaml(
+    const mrpt::containers::yaml& c, FilterDecimateAdaptive& parent)
 {
     MCP_LOAD_REQ(c, output_pointcloud_layer);
-    MCP_LOAD_REQ(c, desired_output_point_count);
+    DECLARE_PARAMETER_IN_REQ(c, desired_output_point_count, parent);
+    DECLARE_PARAMETER_IN_OPT(c, maximum_voxel_stride, parent);
 }
 
-void FilterDecimateAdaptive::Parameters::load_from_yaml(const mrpt::containers::yaml& c)
+void FilterDecimateAdaptive::Parameters::load_from_yaml(
+    const mrpt::containers::yaml& c, FilterDecimateAdaptive& parent)
 {
     MCP_LOAD_REQ(c, input_pointcloud_layer);
 
@@ -59,19 +62,25 @@ void FilterDecimateAdaptive::Parameters::load_from_yaml(const mrpt::containers::
 
         auto cfgOutputs = c["outputs"];
         ASSERTMSG_(cfgOutputs.isSequence(), "'outputs' must be a YAML sequence.");
+        ASSERTMSG_(!cfgOutputs.asSequence().empty(), "'outputs' cannot be an empty sequence.");
 
+        // Sized up front, never grown: declaring a dynamic parameter stores a
+        // pointer to the target field, which a reallocation would dangle.
+        outputs.resize(cfgOutputs.asSequence().size());
+
+        size_t idx = 0;
         for (const auto& entry : cfgOutputs.asSequence())
         {
-            outputs.emplace_back().load_from_yaml(entry);
+            outputs.at(idx++).load_from_yaml(entry, parent);
         }
-        ASSERTMSG_(!outputs.empty(), "'outputs' cannot be an empty sequence.");
     }
     else
     {
-        outputs.emplace_back().load_from_yaml(c);
+        outputs.resize(1);
+        outputs.front().load_from_yaml(c, parent);
     }
 
-    MCP_LOAD_OPT(c, voxel_size);
+    DECLARE_PARAMETER_IN_OPT(c, voxel_size, parent);
     MCP_LOAD_OPT(c, minimum_input_points_per_voxel);
     MCP_LOAD_OPT(c, parallelization_grain_size);
     MCP_LOAD_OPT(c, decimate_method);
@@ -103,7 +112,7 @@ void FilterDecimateAdaptive::initialize_filter(const mrpt::containers::yaml& c)
     MRPT_START
 
     MRPT_LOG_DEBUG_STREAM("Loading these params:\n" << c);
-    params.load_from_yaml(c);
+    params.load_from_yaml(c, *this);
 
     MRPT_END
 }
@@ -322,6 +331,16 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
 
     for (const auto& target : _.outputs)
     {
+        // Bound the sampling ratio, if asked to: the absolute count then acts
+        // as a floor, so this can only add coverage, never remove it.
+        uint32_t pointCountTarget = target.desired_output_point_count;
+        if (target.maximum_voxel_stride > 0)
+        {
+            const auto fromStride = static_cast<uint32_t>(
+                std::ceil(static_cast<double>(nVoxels) / target.maximum_voxel_stride));
+            pointCountTarget = std::max(pointCountTarget, fromStride);
+        }
+
         // Create if new: Append to existing layer, if already existed.
         mrpt::maps::CPointsMap::Ptr outPc = GetOrCreatePointLayer(
             inOut, target.output_pointcloud_layer,
@@ -330,7 +349,9 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
             /* create cloud of the same type */
             pcPtr->GetRuntimeClass()->className);
 
-        outPc->reserve(outPc->size() + target.desired_output_point_count);
+        const size_t sizeBefore = outPc->size();
+
+        outPc->reserve(sizeBefore + pointCountTarget);
         outPc->registerPointFieldsFrom(pc);
 
         if (nVoxels == 0)
@@ -349,10 +370,9 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
         }
 
         float voxelIdxIncrement = 1.0f;
-        if (nVoxels > target.desired_output_point_count)
+        if (nVoxels > pointCountTarget)
         {
-            voxelIdxIncrement =
-                static_cast<float>(nVoxels) / static_cast<float>(target.desired_output_point_count);
+            voxelIdxIncrement = static_cast<float>(nVoxels) / static_cast<float>(pointCountTarget);
         }
 
         const auto voxelIdxIncrement_frac =
@@ -361,7 +381,7 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
         bool anyInsertInTheRound = false;
 
         std::size_t i_frac = 0;
-        while (outPc->size() < target.desired_output_point_count)
+        while (outPc->size() < pointCountTarget)
         {
             std::size_t i = i_frac >> FRACTIONARY_BIT_COUNT;
 
@@ -416,6 +436,16 @@ void FilterDecimateAdaptive::filter(mp2p_icp::metric_map_t& inOut) const
 
             i_frac += voxelIdxIncrement_frac;
         }
+
+        // A stride above 1 means the budget is binding: only one in
+        // `voxelIdxIncrement` occupied cells is ever visited, so coverage is a
+        // stride-shaped subsample of the scene rather than the whole of it.
+        // Reported so a configuration can be checked against its input instead
+        // of assumed.
+        MRPT_LOG_DEBUG_FMT(
+            "output '%s': nVoxels=%zu budget=%u stride=%.2f emitted=%zu",
+            target.output_pointcloud_layer.c_str(), nVoxels, pointCountTarget, voxelIdxIncrement,
+            outPc->size() - sizeBefore);
     }
 
     MRPT_LOG_DEBUG_STREAM("used voxels=" << nTotalVoxels);

--- a/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
@@ -19,6 +19,7 @@
  * @date   Jan 27, 2026
  */
 
+#include <mp2p_icp/Parameterizable.h>
 #include <mp2p_icp/metricmap.h>
 #include <mp2p_icp_filters/FilterDecimateAdaptive.h>
 #include <mrpt/core/exceptions.h>
@@ -140,6 +141,134 @@ int main()
             ASSERT_(didThrow);
 
             std::cout << "[Test Passed] Mutually-exclusive output parameters check\n";
+        }
+
+        // ---------------------------------------------------------
+        // Test: the point budget and the voxel size accept formulas
+        //
+        // Loading these through the plain YAML-to-number path parses up to the
+        // first non-numeric character and silently keeps the truncated value,
+        // so a budget written as an expression would quietly become something
+        // else entirely. Both the single-output and the 'outputs' forms are
+        // covered, since they take different code paths.
+        // ---------------------------------------------------------
+        {
+            mp2p_icp::ParameterSource ps;
+            ps.updateVariable("SCENE_RADIUS", 20.0);
+
+            FilterDecimateAdaptive filter;
+            mrpt::containers::yaml p;
+            p["input_pointcloud_layer"]         = "raw";
+            p["minimum_input_points_per_voxel"] = 1;
+            p["voxel_size"]                     = "0.25*2";  // -> 0.5
+            p["outputs"]                        = mrpt::containers::yaml::Sequence();
+            p["outputs"].push_back(mrpt::containers::yaml::Map(
+                {{"output_pointcloud_layer", "expr_out_map"},
+                 {"desired_output_point_count", "25*SCENE_RADIUS"}}));  // -> 500
+            p["outputs"].push_back(mrpt::containers::yaml::Map(
+                {{"output_pointcloud_layer", "expr_out_icp"},
+                 {"desired_output_point_count", "150"}}));
+
+            filter.initialize(p);
+            filter.attachToParameterSource(ps);
+            ps.realize();
+            filter.filter(map);
+
+            ASSERT_EQUAL_(filter.params.voxel_size, 0.5f);
+            ASSERT_EQUAL_(filter.params.outputs.at(0).desired_output_point_count, 500U);
+            ASSERT_EQUAL_(filter.params.outputs.at(1).desired_output_point_count, 150U);
+
+            auto outMap = map.layer<mrpt::maps::CPointsMap>("expr_out_map");
+            auto outIcp = map.layer<mrpt::maps::CPointsMap>("expr_out_icp");
+            ASSERT_(outMap);
+            ASSERT_(outIcp);
+            ASSERT_NEAR_(outMap->size(), 500, 20);
+            ASSERT_NEAR_(outIcp->size(), 150, 20);
+
+            // The same variable, changed, must move the budget:
+            ps.updateVariable("SCENE_RADIUS", 8.0);
+            ps.realize();
+            ASSERT_EQUAL_(filter.params.outputs.at(0).desired_output_point_count, 200U);
+
+            std::cout << "[Test Passed] Formula-valued budget and voxel size\n";
+        }
+
+        // ---------------------------------------------------------
+        // Test: single-output form, formula budget
+        // ---------------------------------------------------------
+        {
+            mp2p_icp::ParameterSource ps;
+            ps.updateVariable("SCENE_RADIUS", 12.0);
+
+            FilterDecimateAdaptive filter;
+            mrpt::containers::yaml p;
+            p["input_pointcloud_layer"]         = "raw";
+            p["output_pointcloud_layer"]        = "expr_single_out";
+            p["desired_output_point_count"]     = "10*SCENE_RADIUS";  // -> 120
+            p["voxel_size"]                     = 0.5f;
+            p["minimum_input_points_per_voxel"] = 1;
+
+            filter.initialize(p);
+            filter.attachToParameterSource(ps);
+            ps.realize();
+            filter.filter(map);
+
+            ASSERT_EQUAL_(filter.params.outputs.at(0).desired_output_point_count, 120U);
+
+            auto out = map.layer<mrpt::maps::CPointsMap>("expr_single_out");
+            ASSERT_(out);
+            ASSERT_NEAR_(out->size(), 120, 20);
+
+            std::cout << "[Test Passed] Formula-valued budget, single-output form\n";
+        }
+
+        // ---------------------------------------------------------
+        // Test: maximum_voxel_stride bounds the sampling ratio
+        //
+        // The 10k-point raw cloud fills a 10x10 m plane; at 0.5 m voxels that
+        // is 20x20 = 400 occupied cells. An absolute budget of 100 samples one
+        // cell in four; asking for a stride of 1 must instead visit all 400,
+        // and asking for 2 must visit half of them.
+        // ---------------------------------------------------------
+        {
+            const auto countFor = [&](double maxStride, unsigned int budget, const char* layer)
+            {
+                mp2p_icp::metric_map_t m;
+                m.layers["raw"] = pc;
+
+                FilterDecimateAdaptive filter;
+                mrpt::containers::yaml p;
+                p["input_pointcloud_layer"]         = "raw";
+                p["output_pointcloud_layer"]        = layer;
+                p["desired_output_point_count"]     = budget;
+                p["voxel_size"]                     = 0.5f;
+                p["minimum_input_points_per_voxel"] = 1;
+                if (maxStride > 0)
+                {
+                    p["maximum_voxel_stride"] = maxStride;
+                }
+
+                filter.initialize(p);
+                filter.filter(m);
+                return m.layer<mrpt::maps::CPointsMap>(layer)->size();
+            };
+
+            const size_t nCells = countFor(1.0, 1, "stride_all");
+            ASSERT_EQUAL_(nCells, 400U);
+
+            // Off (the default) leaves the absolute budget alone:
+            ASSERT_EQUAL_(countFor(0.0, 100, "stride_off"), 100U);
+
+            // On, and binding: the floor is raised to full coverage.
+            ASSERT_EQUAL_(countFor(1.0, 100, "stride_1"), nCells);
+
+            // On, one cell in two:
+            ASSERT_EQUAL_(countFor(2.0, 100, "stride_2"), nCells / 2);
+
+            // On, but not binding: it only ever raises the count.
+            ASSERT_EQUAL_(countFor(2.0, 350, "stride_floor"), 350U);
+
+            std::cout << "[Test Passed] maximum_voxel_stride (" << nCells << " occupied cells)\n";
         }
 
         // ---------------------------------------------------------

--- a/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
+++ b/mp2p_icp_core/tests/test-mp2p_FilterDecimateAdaptive.cpp
@@ -268,7 +268,14 @@ int main()
             // On, but not binding: it only ever raises the count.
             ASSERT_EQUAL_(countFor(2.0, 350, "stride_floor"), 350U);
 
-            std::cout << "[Test Passed] maximum_voxel_stride (" << nCells << " occupied cells)\n";
+            // A stride small enough to ask for more points than exist must
+            // clamp at the input size rather than overflow the conversion:
+            const size_t clamped = countFor(1e-12, 100, "stride_tiny");
+            ASSERT_LE_(clamped, pc->size());
+            ASSERT_GT_(clamped, nCells);
+
+            std::cout << "[Test Passed] maximum_voxel_stride (" << nCells << " occupied cells, "
+                      << clamped << " when clamped at the input size)\n";
         }
 
         // ---------------------------------------------------------


### PR DESCRIPTION
## Why

Two problems in `FilterDecimateAdaptive`, one silent and one conceptual.

**1. The point budget and the voxel size could not take a formula, and failed silently when given one.** Both were loaded with `MCP_LOAD_*`, which parses a YAML scalar up to its first non-numeric character and keeps the truncated value without a warning. So `desired_output_point_count: "300*SCENE_SCALE"` quietly became `300`. Other parameters in the same pipelines (`range_min`, `range_max`, map sizes) already use `DECLARE_PARAMETER_*` and do accept expressions; these two now do too.

**2. An absolute point count is the wrong knob.** The sampling walk uses

```
stride = nVoxels / desired_output_point_count      (when nVoxels > count)
```

and stops as soon as the count is reached, so with `stride > 1` the first round already hits the target and **only one in every `stride` occupied cells is ever visited**. The remaining cells are never sampled. Which fraction of the scene that is depends on `nVoxels` -- a property of the scene, the sensor and the voxel size, not of the configuration.

Measured with the shipped `lidar3d-gicp.yaml` (new DEBUG probe, median over a few hundred scans):

| dataset | map stage nVoxels | stride | icp stage nVoxels | stride |
|---|---|---|---|---|
| KITTI 10 | 50064 | **5.01** | 9980 | **3.33** |
| KITTI 04 | 47276 | **4.73** | 9984 | **3.33** |
| KITTI 00 | 35122 | **3.51** | 9972 | **3.32** |
| TIERS forest01 (OS1) | 40986 | **4.10** | 9984 | **3.33** |
| Oxford observatory-quarter-01 | 13840 | 1.38 | 9800 | **3.27** |
| BotanicGarden 1018-00 (VLP16) | 10803 | 1.08 | 9555 | **3.18** |
| Oxford keble-college-02 | 9431 | 1.00 | 9196 | **3.07** |
| TIERS indoor01 (OS1) | 7570 | 1.00 | 7169 | **2.39** |
| TIERS indoor01 (VLP16) | 3611 | 1.00 | 4740 | **1.58** |

The same fixed budget means "sample 7% of the occupied cells" on a road and "sample 63%" in a room.

## What changed

- `desired_output_point_count` and `voxel_size` are now declared parameters and accept formulas.
- New optional `maximum_voxel_stride`. When non-zero it raises the effective point count until `nVoxels/count <= maximum_voxel_stride`. It **only ever raises** the count, so `desired_output_point_count` keeps acting as a floor for sparse inputs, and **leaving it unset preserves today's behavior exactly**.
- The `outputs` vector is sized up front. Declaring a dynamic parameter stores a pointer to its target field, so growing the vector afterwards would have dangled the pointers already declared. Latent today, live as soon as a multi-output filter declares one.
- A DEBUG line reports `nVoxels`, the effective budget, the stride and the emitted count per output, so a configuration can be checked against its actual input rather than assumed. That is where the table above comes from.

## Testing

`test-mp2p_FilterDecimateAdaptive` gains three cases: formula-valued budget in both the `outputs` and single-output forms (including that changing the variable moves the budget), and `maximum_voxel_stride` on a cloud with a known 400 occupied cells -- off leaves the absolute budget alone, `1` visits all 400, `2` visits 200, and a budget above the stride-implied one wins.

All 55 `mp2p_icp_core` test binaries pass.

Note `colcon test` on this package reports failures from a missing `DartConfiguration.tcl` regardless of this branch; the binaries themselves pass when run directly.

## Not in this PR

No shipped pipeline sets `maximum_voxel_stride` yet, so this changes no default. The `mola_lidar_odometry` side, with the KITTI numbers behind a chosen default, is a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added adaptive point-cloud sampling controls with configurable maximum voxel stride.
  * Added support for dynamically evaluated voxel sizes and output point budgets.
  * Improved sampling behavior across single- and multi-output configurations.

* **Bug Fixes**
  * Ensured requested point counts remain minimum targets when stride limits are applied.
  * Improved validation for empty output configurations.

* **Tests**
  * Added coverage for dynamic parameters, point budgets, voxel stride limits, and multi-output sampling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->