### PR TITLE
docs: repoint the demo includes and fix three dangling filter links

### DIFF
--- a/docs/source/mp2p_icp_filters.rst
+++ b/docs/source/mp2p_icp_filters.rst
@@ -398,6 +398,8 @@ If the output layer already exists, new points are accumulated on it; previous c
 ---
 
 
+.. _FilterDecimateAdaptive:
+
 Filter: `FilterDecimateAdaptive`
 --------------------------------
 
@@ -524,6 +526,8 @@ single YAML config work across heterogeneous LiDAR sensors without retuning.
 |
 
 ---
+
+.. _FilterDecimateVoxels:
 
 Filter: `FilterDecimateVoxels`
 ------------------------------
@@ -739,6 +743,8 @@ Filter: `FilterFartherPointSampling`
 |
 
 ---
+
+.. _FilterMerge:
 
 Filter: `FilterMerge`
 ---------------------

--- a/docs/source/sm2mm_pipelines.rst
+++ b/docs/source/sm2mm_pipelines.rst
@@ -80,7 +80,7 @@ and store the resulting map into a ``mola::KeyframePointCloudMap`` layer named `
 .. dropdown:: Pipeline YAML code
     :icon: list-unordered
 
-    .. literalinclude:: ../../../mp2p_icp/demos/sm2mm_no_decim_imu_mls_keyframe_map.yaml
+    .. literalinclude:: ../../../mp2p_icp/mp2p_icp_core/demos/sm2mm_no_decim_imu_mls_keyframe_map.yaml
        :language: yaml
 
 
@@ -126,7 +126,7 @@ creating a more memory-efficient representation.
 .. dropdown:: Pipeline YAML code
     :icon: list-unordered
 
-    .. literalinclude:: ../../../mp2p_icp/demos/sm2mm_pointcloud_voxelize.yaml
+    .. literalinclude:: ../../../mp2p_icp/mp2p_icp_core/demos/sm2mm_pointcloud_voxelize.yaml
        :language: yaml
 
 
@@ -189,5 +189,5 @@ enabling differentiation between stationary map features and moving objects for 
 .. dropdown:: Pipeline YAML code
     :icon: list-unordered
 
-    .. literalinclude:: ../../../mp2p_icp/demos/sm2mm_voxels_static_dynamic_points.yaml
+    .. literalinclude:: ../../../mp2p_icp/mp2p_icp_core/demos/sm2mm_voxels_static_dynamic_points.yaml
        :language: yaml


### PR DESCRIPTION
Two long-standing rendering bugs on the published filter/pipeline pages, both invisible in review because Sphinx only warns.

### 1. Three empty code blocks on the `sm2mm` pipelines page

The demo YAMLs are pulled in by relative path from the cross-repo docs build tree:

```rst
.. literalinclude:: ../../../mp2p_icp/demos/sm2mm_pointcloud_voxelize.yaml
```

There is no `mp2p_icp/demos/`; those files live in `mp2p_icp_core/demos/`. All three `literalinclude`s have been failing, so the page shows three empty code blocks where the example pipelines should be.

### 2. Three dropped cross-references on the filters page

`` `FilterDecimateVoxels`_ ``, `` `FilterMerge`_ `` and `` `FilterDecimateAdaptive`_ `` rely on the implicit hyperlink target that docutils derives from a section title. The titles are `` Filter: `FilterDecimateVoxels` ``, so the implicit target is the whole string and the short name never resolves. Each reference raised `ERROR: Unknown target name` and rendered as plain text instead of a link.

Fixed by giving those three sections explicit targets rather than renaming them, so the headings users already see are unchanged.

### Verification

Built with the real toolchain on the docs host (doxygen + doxyrest + Sphinx 7.2.6, the same path `build-docs.sh` runs), comparing against the current `develop`:

- `Include file ... not found` warnings: **3 -> 0**
- `Unknown target name` errors on this page: **3 -> 0**
- Total build errors: **24 -> 21**; no new warnings introduced

The one hand-written error left in the whole doc set is in `mola_state_estimation`, unrelated to this repo.

### Not fixed here

`mp2p_icp_filters.rst` also references 15 `*_example.png` images that were never committed anywhere in the repo, so they render as broken images. That is a missing-content problem rather than a path bug and needs someone to generate the figures; deliberately left alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reference anchors for adaptive decimation, voxel decimation, and merge filters.
  * Updated pipeline examples to use the correct demonstration file locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->