### PR TITLE
Make the point-matchers' pairing list order-stable (it depended on TBB scheduling)

### DIFF
--- a/mp2p_icp_core/mp2p_icp/src/Matcher_Points_Blend.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/Matcher_Points_Blend.cpp
@@ -323,9 +323,16 @@ void Matcher_Points_Blend::implMatchOneLayer(
     // rewritten as a serial loop.
     using Result = mrpt::tfest::TMatchingPairList;
 
-    auto newPairs = tbb::parallel_reduce(
+    // parallel_DETERMINISTIC_reduce with an explicit grainsize, for the same
+    // reason as Matcher_Points_DistanceThreshold: this join is a concatenation,
+    // so the pairing ORDER is the shape of the reduction tree, and the plain
+    // form shapes that from whichever workers were free. See the long comment
+    // there.
+    constexpr size_t kDeterministicGrainSize = 512;
+
+    auto newPairs = tbb::parallel_deterministic_reduce(
         // Range
-        tbb::blocked_range<size_t>{0, nLocalPts},
+        tbb::blocked_range<size_t>{0, nLocalPts, kDeterministicGrainSize},
         // Identity
         Result(),
         // 1st lambda: Parallel computation

--- a/mp2p_icp_core/mp2p_icp/src/Matcher_Points_DistanceThreshold.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/Matcher_Points_DistanceThreshold.cpp
@@ -134,9 +134,30 @@ void Matcher_Points_DistanceThreshold::implMatchOneLayer(
     // TBB call structure based on the beautiful implementation in KISS-ICP.
     using Result = mrpt::tfest::TMatchingPairList;
 
-    auto newPairs = tbb::parallel_reduce(
+    // parallel_DETERMINISTIC_reduce, not parallel_reduce, and the grainsize is
+    // part of that: this reduction JOINS BY CONCATENATION, so the order of the
+    // resulting correspondence list is the shape of the reduction tree. Plain
+    // parallel_reduce shapes that tree from whichever workers happen to be free,
+    // which makes the pairing order -- and therefore the ICP result, and every
+    // decision downstream of it -- vary from run to run on an otherwise
+    // identical input. The deterministic form splits a fixed way for a given
+    // range and grainsize, regardless of thread count, so the concatenation
+    // order is a function of the input alone.
+    //
+    // It needs an explicit grainsize: it partitions down to grainsize (unlike
+    // auto_partitioner, which the plain form uses and which ignores the
+    // blocked_range default of 1), so leaving the default would split to single
+    // elements and drown the work in task overhead.
+    //
+    // Only the two matchers that concatenate need this. Matcher_Cov2Cov and the
+    // rest do not reduce at all, which is why LiDAR odometry -- which matches
+    // cov2cov -- has been bit-reproducible on many cores while loop closure,
+    // which matches point-to-point, was not.
+    constexpr size_t kDeterministicGrainSize = 512;
+
+    auto newPairs = tbb::parallel_deterministic_reduce(
         // Range
-        tbb::blocked_range<size_t>{0, nLocalPts},
+        tbb::blocked_range<size_t>{0, nLocalPts, kDeterministicGrainSize},
         // Identity
         Result(),
         // 1st lambda: Parallel computation


### PR DESCRIPTION
## The defect

`Matcher_Points_DistanceThreshold` and `Matcher_Points_Blend` build their correspondence list with `tbb::parallel_reduce` and join the per-range results by **concatenation**:

```cpp
[](Result a, const Result& b) -> Result {
    a.insert(a.end(), std::make_move_iterator(b.begin()), ...);
    return a;
}
```

The order of the resulting list is therefore the *shape of the reduction tree*, and plain `parallel_reduce` shapes that from whichever workers happen to be free. The same input yields a differently-ordered pairing list from run to run, which changes the ICP result and every decision downstream of it.

## Why this went unnoticed for so long

**Only these two matchers concatenate.** `Matcher_Cov2Cov`, `Matcher_Points_KnnPlane` and `Matcher_Points_InlierRatio` don't reduce at all.

That lines up exactly with what MOLA sees in practice, and is how I found it:

| | matcher | reproducible on 88 cores? |
|---|---|---|
| `mola_lidar_odometry` | `Matcher_Cov2Cov` | **yes** — byte-identical, verified |
| `mola_mapper` loop closure | `Matcher_Points_DistanceThreshold` | **no** |

LO has been bit-reproducible for weeks; loop closure was not, and the pipelines differ in precisely this.

## The fix

`parallel_deterministic_reduce` with an explicit grainsize. That form splits a fixed way for a given range and grainsize regardless of thread count, so the concatenation order becomes a function of the input alone.

The grainsize is **not optional**: `parallel_deterministic_reduce` partitions down to grainsize (unlike the `auto_partitioner` the plain form uses, which ignores `blocked_range`'s default of 1), so leaving the default would split to single elements and drown the work in task overhead.

## Verified

End to end through `mola_mapper`'s offline CLI on KITTI-07. With this change, and with KISS-Matcher — which has its own, separate nondeterminism — disabled, a **fully parallel** loop-closure scan is **3/3 byte-identical** where it was **3/3 different** before. Timing unchanged within noise (8.5 s either way).

## Deliberately not touched

`optimal_tf_gauss_newton` has two `parallel_reduce` calls of its own that sum H and g. They reduce to a **fixed-size matrix** rather than a list, so only floating-point rounding varies — and LiDAR odometry, which uses that same solver, is byte-identical in practice. No evidence they matter; the list-order defect fixed here is a different thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHcudTYtCaP4UV6rPXbTgi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the consistency of ICP matching results across runs.
  * Ensured correspondence ordering remains stable regardless of available worker threads.
  * Preserved existing behavior for builds without parallel processing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->