### PR TITLE
ICP: optional freezePairingsAfterIteration

### DIFF
--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Parameters.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Parameters.h
@@ -54,6 +54,17 @@ struct Parameters : public mrpt::serialization::CSerializable
     double minAbsStep_rot{1e-4};
     /** @} */
 
+    /** Number of initial iterations during which the matchers are re-run; after
+     *  them the correspondence set is frozen and the remaining iterations reuse
+     *  it, refining the pose against fixed pairings. 0 (default) means the
+     *  pairings are re-decided at every iteration, i.e. the classic behavior.
+     *
+     *  Each re-association is an opportunity for the discrete correspondence
+     *  configuration to change, so freezing bounds how many such switches one
+     *  registration can go through. Filter-based LIO systems that iterate an
+     *  EKF update typically freeze after their first couple of iterations. */
+    uint32_t freezePairingsAfterIteration{0};
+
     /** @name Debugging and logging
         @{ */
 

--- a/mp2p_icp_core/mp2p_icp/src/ICP.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/ICP.cpp
@@ -199,8 +199,17 @@ void ICP::align(
 
         mrpt::system::CTimeLoggerEntry tle4(profiler_, "align.4.1_matchers");
 
-        state.currentPairings = run_matchers(
-            matchers_, state.pcGlobal, state.pcLocal, state.currentSolution.optimalPose, mc);
+        // Re-decide the correspondences, unless they were frozen after the first
+        // few iterations (then the remaining ones refine the pose against a
+        // fixed pairing set).
+        const bool pairingsFrozen = p.freezePairingsAfterIteration > 0 &&
+                                    state.currentIteration >= p.freezePairingsAfterIteration &&
+                                    !state.currentPairings.empty();
+        if (!pairingsFrozen)
+        {
+            state.currentPairings = run_matchers(
+                matchers_, state.pcGlobal, state.pcLocal, state.currentSolution.optimalPose, mc);
+        }
 
         tle4.stop();
 

--- a/mp2p_icp_core/mp2p_icp/src/Parameters.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/Parameters.cpp
@@ -84,6 +84,7 @@ void Parameters::load_from(const mrpt::containers::yaml& p)
     MCP_LOAD_REQ(p, maxIterations);
     MCP_LOAD_OPT(p, minAbsStep_trans);
     MCP_LOAD_OPT(p, minAbsStep_rot);
+    MCP_LOAD_OPT(p, freezePairingsAfterIteration);
     MCP_LOAD_OPT(p, generateDebugFiles);
     MCP_LOAD_OPT(p, debugFileNameFormat);
     MCP_LOAD_OPT(p, debugPrintIterationProgress);
@@ -125,6 +126,7 @@ void Parameters::save_to(mrpt::containers::yaml& p) const
     MCP_SAVE(p, maxIterations);
     MCP_SAVE(p, minAbsStep_trans);
     MCP_SAVE(p, minAbsStep_rot);
+    MCP_SAVE(p, freezePairingsAfterIteration);
     MCP_SAVE(p, generateDebugFiles);
     MCP_SAVE(p, debugFileNameFormat);
     MCP_SAVE(p, debugPrintIterationProgress);


### PR DESCRIPTION
Adds \`mp2p_icp::Parameters::freezePairingsAfterIteration\`: after this many
inner ICP iterations, the correspondence set stops being re-decided by the
matchers and the remaining iterations refine the pose against the frozen
pairing set instead.

Default is 0 (classic behavior: pairings re-decided every iteration), so
this is opt-in and inert unless configured.

This recovers a parameter that an earlier measurement round in the LIO
research used from an uncommitted working tree, which made that result
unreproducible from any pinned commit. Committing and landing it here makes
it a real, citable knob again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to freeze correspondence pairings after a configurable number of ICP iterations.
  * Pairings can be reused for subsequent iterations instead of being recalculated each time.
  * The setting is configurable through YAML, with the default preserving existing behavior.
  * The setting is also preserved in binary records, while older records remain loadable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->