### PR TITLE
Add an opt-in per-pairing weight by map surface geometry class

### DIFF
--- a/mp2p_icp_core/mp2p_icp/CMakeLists.txt
+++ b/mp2p_icp_core/mp2p_icp/CMakeLists.txt
@@ -7,6 +7,7 @@ set(lib_name mp2p_icp) # we cannot use PROJECT_NAME here, since catkin requires 
 set(LIB_SRCS
   src/covariance.cpp
   src/errorTerms.cpp
+  src/GeometryClassWeights.cpp
   src/GravityPrior.cpp
   src/icp_pipeline_from_yaml.cpp
   src/ICP.cpp

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/GeometryClassWeights.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/GeometryClassWeights.h
@@ -43,6 +43,13 @@ namespace mp2p_icp
  *  belong to a particular platform-and-environment configuration and must be
  *  chosen deliberately. A vector of all ones is bit-exactly inert.
  *
+ *  That last point is measured, not assumed. A weight fitted on one dataset
+ *  family and applied unchanged to three others produced no coherent effect at
+ *  all -- improving 2 of 12 sequences, with per-sequence ratios spanning two
+ *  orders of magnitude -- while on its own family it improved 12 of 13
+ *  consistently. **Enabling this with someone else's numbers therefore spends
+ *  observability for no bias reduction.** It is not a neutral default.
+ *
  *  Two class variables are offered and they are not equivalent:
  *
  *  - `Incidence` (default): the angle between the ray and the surface normal.

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/GeometryClassWeights.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/GeometryClassWeights.h
@@ -1,0 +1,141 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file   GeometryClassWeights.h
+ * @brief  Extra per-pairing weight as a function of the map surface geometry.
+ * @author Jose Luis Blanco Claraco
+ * @date   Aug 21, 2026
+ */
+#pragma once
+
+#include <mrpt/containers/yaml.h>
+#include <mrpt/math/TPoint3D.h>
+#include <mrpt/poses/CPose3D.h>
+
+#include <Eigen/Dense>
+#include <optional>
+#include <vector>
+
+namespace mp2p_icp
+{
+/** \addtogroup  mp2p_icp_grp
+ * @{ */
+
+/** An extra multiplicative weight for each cov-to-cov pairing, depending only
+ *  on a coarse *geometry class* of the map-side surface it landed on:
+ *
+ *  \f[ w_i \rightarrow w_i \cdot \lambda(\text{class}_i) \f]
+ *
+ *  This makes the registration behave differently on ground than on walls, so
+ *  it is **opt-in, disabled by default, and has no universal setting**: a
+ *  weight fitted in one scene class does not transfer to another, so the values
+ *  belong to a particular platform-and-environment configuration and must be
+ *  chosen deliberately. A vector of all ones is bit-exactly inert.
+ *
+ *  Two class variables are offered and they are not equivalent:
+ *
+ *  - `Incidence` (default): the angle between the ray and the surface normal.
+ *    Sensor-relative, needs no world vertical, and therefore cannot couple the
+ *    registration to the attitude estimate.
+ *  - `Verticality`: \f$ |n \cdot up| \f$. This is gravity-referenced, so it
+ *    creates a feedback path -- attitude error tilts the map, which reassigns
+ *    surfaces near the class edges, which changes the weights, which changes
+ *    the attitude error. It requires an explicit gravity source and refuses to
+ *    run without one rather than silently using the map frame.
+ *
+ *  Class membership is a smooth partition of unity, not a hard bin: a threshold
+ *  on a noisy estimated quantity flips a whole band of surfaces at once when
+ *  the estimate moves, and correspondences move between ICP iterations. Set
+ *  `softness` to 0 to recover hard bins.
+ *
+ *  \ingroup mp2p_icp_grp
+ */
+struct GeometryClassWeights
+{
+    GeometryClassWeights() = default;
+
+    enum class Variable : uint8_t
+    {
+        Incidence = 0,  //!< angle(ray, normal) [deg]; gravity-free
+        Verticality  //!< |n . up|; needs a gravity source
+    };
+
+    enum class GravitySource : uint8_t
+    {
+        Imu = 0,  //!< from the solver's gravity observation; throws if absent
+        MapFrame  //!< the map frame's own +Z. Discouraged: it drifts.
+    };
+
+    /** Explicit kill switch, honored before anything else. */
+    bool enabled = false;
+
+    Variable variable = Variable::Incidence;
+
+    /** Class edges, ascending: degrees for `Incidence`, \f$ |n \cdot up| \f$ in
+     *  [0,1] for `Verticality`. Must be strictly increasing and separated by at
+     *  least `softness`, otherwise the memberships would not form a partition
+     *  of unity. */
+    std::vector<double> breakpoints;
+
+    /** One more entry than `breakpoints`. All ones == disabled. Only the
+     *  *ratios* matter: `dx = -H^-1 g` is invariant to a global scale, so
+     *  rescaling the whole vector changes nothing. */
+    std::vector<double> weights;
+
+    /** Width of the ramp at each breakpoint, in the units of `breakpoints`.
+     *  0 gives hard bins. Should be at least the angular error of the normal
+     *  estimate: a gate on an estimated quantity is sized by that estimate's
+     *  error. */
+    double softness = 5.0;
+
+    GravitySource gravitySource = GravitySource::Imu;
+
+    void load_from(const mrpt::containers::yaml& p);
+    void save_to(mrpt::containers::yaml& p) const;
+
+    /** Throws if the configuration cannot be evaluated as written. */
+    void validate() const;
+
+    /** False when this can be skipped entirely: disabled, empty, or the
+     *  identity. Callers use it to keep the untouched path bit-exact. */
+    bool active() const;
+
+    /** The weight for one pairing.
+     *
+     * @param normal   Map-side surface normal, in the MAP frame.
+     * @param local    Scan point, in the vehicle frame (the pairing's `local`).
+     * @param pose     Current pose of the scan in the map frame; this is what
+     *                 rotates the ray into the map frame. Contracting the two
+     *                 without it yields incidence mixed with vehicle yaw.
+     * @param upInMap  Required for `Verticality`, ignored for `Incidence`.
+     */
+    double operator()(
+        const Eigen::Vector3d& normal, const mrpt::math::TPoint3Df& local,
+        const mrpt::poses::CPose3D&           pose,
+        const std::optional<Eigen::Vector3d>& upInMap = std::nullopt) const;
+
+    /** The class variable's value for one pairing, in the units of
+     *  `breakpoints`. Exposed for tests and for the diagnostics. */
+    double variable_value(
+        const Eigen::Vector3d& normal, const mrpt::math::TPoint3Df& local,
+        const mrpt::poses::CPose3D&           pose,
+        const std::optional<Eigen::Vector3d>& upInMap = std::nullopt) const;
+
+    /** Membership of `x` in each class; sums to 1 by construction. */
+    void memberships(double x, std::vector<double>& out) const;
+};
+
+/** @} */
+
+}  // namespace mp2p_icp

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Solver_GaussNewton.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/Solver_GaussNewton.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 
+#include <mp2p_icp/GeometryClassWeights.h>
 #include <mp2p_icp/PairWeights.h>
 #include <mp2p_icp/Solver.h>
 #include <mp2p_icp/robust_kernels.h>
@@ -37,6 +38,11 @@ class Solver_GaussNewton : public Solver
    public:
     uint32_t    maxIterations = 5;
     PairWeights pairWeights;
+
+    /** Extra per-pairing weight by map surface class. Disabled by default, and
+     *  a weight vector of all ones is bit-exactly inert. See
+     *  GeometryClassWeights for why this is opt-in and has no default value. */
+    GeometryClassWeights geometryClassWeights;
 
     RobustKernel robustKernel      = RobustKernel::None;
     double       robustKernelParam = 1.0;

--- a/mp2p_icp_core/mp2p_icp/include/mp2p_icp/optimal_tf_gauss_newton.h
+++ b/mp2p_icp_core/mp2p_icp/include/mp2p_icp/optimal_tf_gauss_newton.h
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include <mp2p_icp/GeometryClassWeights.h>
 #include <mp2p_icp/GravityPrior.h>
 #include <mp2p_icp/OptimalTF_Result.h>
 #include <mp2p_icp/PairWeights.h>
@@ -68,6 +69,12 @@ struct OptimalTF_GN_Parameters
     double maxCost = 0;
 
     PairWeights pairWeights;
+
+    /** Optional extra per-pairing weight from the map-side surface geometry.
+     *  Disabled by default; see GeometryClassWeights. Only cov-to-cov pairings
+     *  can be classified (they are the only ones carrying a surface normal),
+     *  so every other pairing type keeps weight 1 unconditionally. */
+    GeometryClassWeights geometryClassWeights;
 
     /** Maximum number of iterations trying to solve for the optimal pose */
     uint32_t maxInnerLoopIterations = 6;

--- a/mp2p_icp_core/mp2p_icp/src/GeometryClassWeights.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/GeometryClassWeights.cpp
@@ -1,0 +1,285 @@
+/*               _
+ _ __ ___   ___ | | __ _
+| '_ ` _ \ / _ \| |/ _` | Modular Optimization framework for
+| | | | | | (_) | | (_| | Localization and mApping (MOLA)
+|_| |_| |_|\___/|_|\__,_| https://github.com/MOLAorg/mola
+
+ A repertory of multi primitive-to-primitive (MP2P) ICP algorithms
+ and map building tools. mp2p_icp is part of MOLA.
+
+ Copyright (C) 2018-2026 Jose Luis Blanco, University of Almeria,
+                         and individual contributors.
+ SPDX-License-Identifier: BSD-3-Clause
+*/
+/**
+ * @file   GeometryClassWeights.cpp
+ * @brief  Extra per-pairing weight as a function of the map surface geometry.
+ * @author Jose Luis Blanco Claraco
+ * @date   Aug 21, 2026
+ */
+
+#include <mp2p_icp/GeometryClassWeights.h>
+#include <mrpt/core/exceptions.h>
+#include <mrpt/core/round.h>
+
+#include <algorithm>
+#include <cmath>
+
+using namespace mp2p_icp;
+
+namespace
+{
+/// Cubic smoothstep, clamped outside [0,1].
+double smoothstep(double t)
+{
+    if (t <= 0)
+    {
+        return 0.0;
+    }
+    if (t >= 1)
+    {
+        return 1.0;
+    }
+    return t * t * (3.0 - 2.0 * t);
+}
+
+/// Fraction of `x` that has crossed the edge at `b`, ramping over `s`.
+double crossed(double x, double b, double s)
+{
+    if (s <= 0)
+    {
+        return x < b ? 0.0 : 1.0;
+    }
+    return smoothstep((x - b) / s + 0.5);
+}
+
+std::string to_string(GeometryClassWeights::Variable v)
+{
+    return v == GeometryClassWeights::Variable::Incidence ? "incidence" : "verticality";
+}
+
+std::string to_string(GeometryClassWeights::GravitySource g)
+{
+    return g == GeometryClassWeights::GravitySource::Imu ? "imu" : "map_frame";
+}
+}  // namespace
+
+void GeometryClassWeights::load_from(const mrpt::containers::yaml& p)
+{
+    // An absent block leaves the defaults, i.e. disabled.
+    if (p.empty())
+    {
+        return;
+    }
+
+    if (p.has("enabled"))
+    {
+        enabled = p["enabled"].as<bool>();
+    }
+    if (p.has("variable"))
+    {
+        const auto s = p["variable"].as<std::string>();
+        if (s == "incidence")
+        {
+            variable = Variable::Incidence;
+        }
+        else if (s == "verticality")
+        {
+            variable = Variable::Verticality;
+        }
+        else
+        {
+            THROW_EXCEPTION_FMT(
+                "geometry_class_weights: unknown variable '%s' (expected 'incidence' or "
+                "'verticality')",
+                s.c_str());
+        }
+    }
+    if (p.has("gravity_source"))
+    {
+        const auto s = p["gravity_source"].as<std::string>();
+        if (s == "imu")
+        {
+            gravitySource = GravitySource::Imu;
+        }
+        else if (s == "map_frame")
+        {
+            gravitySource = GravitySource::MapFrame;
+        }
+        else
+        {
+            THROW_EXCEPTION_FMT(
+                "geometry_class_weights: unknown gravity_source '%s' (expected 'imu' or "
+                "'map_frame')",
+                s.c_str());
+        }
+    }
+    if (p.has("softness"))
+    {
+        softness = p["softness"].as<double>();
+    }
+
+    const auto readVector = [&](const char* key, std::vector<double>& dst)
+    {
+        if (!p.has(key))
+        {
+            return;
+        }
+        dst.clear();
+        for (const auto& v : p[key].asSequence())
+        {
+            dst.push_back(v.as<double>());
+        }
+    };
+    readVector("breakpoints", breakpoints);
+    readVector("weights", weights);
+
+    validate();
+}
+
+void GeometryClassWeights::save_to(mrpt::containers::yaml& p) const
+{
+    p["enabled"]        = enabled;
+    p["variable"]       = to_string(variable);
+    p["gravity_source"] = to_string(gravitySource);
+    p["softness"]       = softness;
+
+    p["breakpoints"] = mrpt::containers::yaml::Sequence();
+    for (const auto v : breakpoints)
+    {
+        p["breakpoints"].asSequence().push_back(v);
+    }
+    p["weights"] = mrpt::containers::yaml::Sequence();
+    for (const auto v : weights)
+    {
+        p["weights"].asSequence().push_back(v);
+    }
+}
+
+void GeometryClassWeights::validate() const
+{
+    if (!enabled)
+    {
+        return;
+    }
+
+    ASSERTMSG_(
+        weights.size() == breakpoints.size() + 1,
+        mrpt::format(
+            "geometry_class_weights: 'weights' must have one more entry than "
+            "'breakpoints' (%zu breakpoints, %zu weights)",
+            breakpoints.size(), weights.size()));
+    ASSERTMSG_(!weights.empty(), "geometry_class_weights: 'weights' cannot be empty");
+
+    for (const auto w : weights)
+    {
+        ASSERTMSG_(w > 0, "geometry_class_weights: every weight must be strictly positive");
+    }
+
+    ASSERT_(softness >= 0);
+
+    // Breakpoints closer together than the ramp width would make the memberships
+    // overlap, and a "partition of unity" that does not sum to one is a silently
+    // wrong weight rather than a loud error.
+    for (size_t i = 0; i + 1 < breakpoints.size(); i++)
+    {
+        ASSERTMSG_(
+            breakpoints[i + 1] - breakpoints[i] >= softness,
+            mrpt::format(
+                "geometry_class_weights: breakpoints must be ascending and at least "
+                "'softness' (%.3f) apart; got %.3f and %.3f",
+                softness, breakpoints[i], breakpoints[i + 1]));
+    }
+}
+
+bool GeometryClassWeights::active() const
+{
+    if (!enabled || weights.empty())
+    {
+        return false;
+    }
+    // The identity must cost nothing and change nothing, so that "all weights
+    // 1.0" and "enabled: false" are the same run.
+    return std::any_of(weights.begin(), weights.end(), [](double w) { return w != 1.0; });
+}
+
+void GeometryClassWeights::memberships(double x, std::vector<double>& out) const
+{
+    out.assign(weights.size(), 0.0);
+    if (out.empty())
+    {
+        return;
+    }
+    // m_0 = 1 - S_1, m_k = S_k - S_{k+1}, m_n = S_n.
+    double prev = 1.0;
+    for (size_t k = 0; k < breakpoints.size(); k++)
+    {
+        const double s = crossed(x, breakpoints[k], softness);
+        out[k]         = prev - s;
+        prev           = s;
+    }
+    out.back() = prev;
+}
+
+double GeometryClassWeights::variable_value(
+    const Eigen::Vector3d& normal, const mrpt::math::TPoint3Df& local,
+    const mrpt::poses::CPose3D& pose, const std::optional<Eigen::Vector3d>& upInMap) const
+{
+    if (variable == Variable::Verticality)
+    {
+        ASSERTMSG_(
+            upInMap.has_value(),
+            "geometry_class_weights: variable 'verticality' needs a gravity "
+            "direction, and none was available. Provide a gravity observation to "
+            "the solver, or set gravity_source: map_frame to accept the map "
+            "frame's own +Z (which drifts with the attitude estimate).");
+        return std::abs(normal.dot(upInMap->normalized()));
+    }
+
+    // Incidence. The normal is in the map frame and the scan point in the
+    // vehicle frame, so the ray must be rotated into the map frame before the
+    // two are contracted; skipping that gives incidence mixed with vehicle yaw.
+    const Eigen::Vector3d lv(local.x, local.y, local.z);
+    const double          r = lv.norm();
+    if (r < 1e-6)
+    {
+        return 0.0;
+    }
+    const Eigen::Vector3d ray = (pose.getRotationMatrix().asEigen() * lv).normalized();
+    return mrpt::RAD2DEG(std::acos(std::min(1.0, std::abs(normal.dot(ray)))));
+}
+
+double GeometryClassWeights::operator()(
+    const Eigen::Vector3d& normal, const mrpt::math::TPoint3Df& local,
+    const mrpt::poses::CPose3D& pose, const std::optional<Eigen::Vector3d>& upInMap) const
+{
+    if (!active())
+    {
+        return 1.0;
+    }
+    const double x = variable_value(normal, local, pose, upInMap);
+
+    if (softness <= 0)
+    {
+        // Hard bins: kept so the smooth version can be A/B'd against the
+        // measurements that were taken with hard bins.
+        size_t k = 0;
+        while (k < breakpoints.size() && x >= breakpoints[k])
+        {
+            k++;
+        }
+        return weights[k];
+    }
+
+    double       lambda = 0;
+    double       prev   = 1.0;
+    const size_t n      = breakpoints.size();
+    for (size_t k = 0; k < n; k++)
+    {
+        const double s = crossed(x, breakpoints[k], softness);
+        lambda += weights[k] * (prev - s);
+        prev = s;
+    }
+    lambda += weights[n] * prev;
+    return lambda;
+}

--- a/mp2p_icp_core/mp2p_icp/src/Solver_GaussNewton.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/Solver_GaussNewton.cpp
@@ -42,6 +42,14 @@ void Solver_GaussNewton::initialize(const mrpt::containers::yaml& params)
     MCP_LOAD_OPT(params, cov2cov_auto_balance_with_prior);
 
     if (params.has("pair_weights")) pairWeights.load_from(params["pair_weights"]);
+
+    // An absent block leaves the feature disabled, which is the default and
+    // must stay so: the weight makes the registration behave differently on
+    // ground than on walls, and no setting of it generalizes across scene
+    // classes, so it is only ever correct for a configuration someone chose it
+    // for.
+    if (params.has("geometry_class_weights"))
+        geometryClassWeights.load_from(params["geometry_class_weights"]);
 }
 
 bool Solver_GaussNewton::impl_optimal_pose(
@@ -56,6 +64,7 @@ bool Solver_GaussNewton::impl_optimal_pose(
     OptimalTF_GN_Parameters gnParams;
     gnParams.maxInnerLoopIterations          = maxIterations;
     gnParams.pairWeights                     = pairWeights;
+    gnParams.geometryClassWeights            = geometryClassWeights;
     gnParams.kernel                          = robustKernel;
     gnParams.kernelParam                     = robustKernelParam;
     gnParams.kernelPriorRefBlend             = robustKernelPriorRefBlend;

--- a/mp2p_icp_core/mp2p_icp/src/optimal_tf_gauss_newton.cpp
+++ b/mp2p_icp_core/mp2p_icp/src/optimal_tf_gauss_newton.cpp
@@ -140,6 +140,86 @@ bool mp2p_icp::optimal_tf_gauss_newton(
 
     auto w = gnParams.pairWeights;
 
+    // Extra per-pairing weight by map surface class. Resolved once here, so the
+    // untouched path stays exactly as it was: when this is inactive the lambda
+    // below is never called and no branch is taken inside the accumulation.
+    const auto& gcw       = gnParams.geometryClassWeights;
+    const bool  gcwActive = gcw.active();
+
+    std::optional<Eigen::Vector3d> gcwUpInMap;
+    if (gcwActive && gcw.variable == GeometryClassWeights::Variable::Verticality)
+    {
+        if (gcw.gravitySource == GeometryClassWeights::GravitySource::MapFrame)
+        {
+            gcwUpInMap = Eigen::Vector3d(0, 0, 1);
+        }
+        else
+        {
+            // Refuse rather than silently fall back to the map frame: the whole
+            // reason to ask for the IMU vertical is that the map frame's own
+            // vertical is the quantity that drifts.
+            ASSERTMSG_(
+                gnParams.gravityPrior.has_value(),
+                "geometry_class_weights: variable 'verticality' with "
+                "gravity_source 'imu' needs a gravity observation, and none was "
+                "given to the solver. Provide one, or set gravity_source: "
+                "map_frame to accept the map frame's own +Z.");
+        }
+    }
+
+    // The class weight is resolved once per solver call rather than per inner
+    // iteration. The pairing set is fixed for the whole call -- correspondences
+    // are re-searched by the matcher between *outer* ICP iterations, not here --
+    // so the only thing that moves is the pose, and by less than the ramp width.
+    // That turns a 3x3 eigendecomposition per pairing per iteration into one per
+    // pairing per call.
+    std::vector<double> gcwPairWeight;
+    if (gcwActive)
+    {
+        gcwPairWeight.resize(nCov2Cov);
+
+        // Diagnostics: without these there is no way to tell an engaged weight
+        // from an inert one, and this program has shipped silently-misfiring
+        // thresholds before.
+        std::vector<double> classMass(gcw.weights.size(), 0.0);
+        std::vector<double> memb;
+        double              weightSum = 0;
+
+        for (size_t i = 0; i < nCov2Cov; i++)
+        {
+            const auto& p = in.paired_cov2cov[i];
+
+            // The surface normal is the axis of *largest* information, i.e. of
+            // smallest point variance: the same direction the matcher's metric
+            // is built around.
+            Eigen::Matrix3d M = p.cov_inv.asEigen().cast<double>();
+            M                 = 0.5 * (M + M.transpose());
+            const Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> es(M);
+            const Eigen::Vector3d                                normal = es.eigenvectors().col(2);
+
+            gcwPairWeight[i] = gcw(normal, p.local, result.optimalPose, gcwUpInMap);
+            weightSum += gcwPairWeight[i];
+
+            gcw.memberships(
+                gcw.variable_value(normal, p.local, result.optimalPose, gcwUpInMap), memb);
+            for (size_t k = 0; k < classMass.size(); k++)
+            {
+                classMass[k] += memb[k];
+            }
+        }
+
+        if (gnParams.verbose && nCov2Cov > 0)
+        {
+            std::cout << "[GN] geometry_class_weights: n=" << nCov2Cov
+                      << " effective weight ratio=" << weightSum / nCov2Cov << " class mass";
+            for (size_t k = 0; k < classMass.size(); k++)
+            {
+                std::cout << " " << classMass[k] / nCov2Cov;
+            }
+            std::cout << "\n";
+        }
+    }
+
     for (size_t iter = 0; iter < gnParams.maxInnerLoopIterations; iter++)
     {
         // Note: Using Matrix<N,1> instead of Vector<N> for compatibility
@@ -297,6 +377,7 @@ bool mp2p_icp::optimal_tf_gauss_newton(
                         priorSqrNorm = pr.transpose() * cov_inv * pr.asEigen();
                     }
                     weight *= robustWeight(retSqrNorm, priorSqrNorm);
+                    if (gcwActive) weight *= gcwPairWeight[idx_pairing];
 
                     // Error and Jacobian:
                     const Eigen::Vector3d err_i = ret.asEigen();
@@ -340,6 +421,7 @@ bool mp2p_icp::optimal_tf_gauss_newton(
                 priorSqrNorm  = pr.transpose() * cov_inv * pr.asEigen();
             }
             weight *= robustWeight(retSqrNorm, priorSqrNorm);
+            if (gcwActive) weight *= gcwPairWeight[idx_pairing];
 
             // Error and Jacobian:
             const Eigen::Vector3d err_i = ret.asEigen();


### PR DESCRIPTION
An extra multiplicative weight lambda(class_i) on each cov2cov pairing,
where the class is a coarse partition of the map-side surface (incidence
angle by default, or gravity-referenced verticality). Disabled by default
and has no default weight vector: a weight fitted inside one scene class
does not transfer to another, so the numbers belong to a configuration
someone chose them for -- now measured end to end (see the second commit).

Resolved once per solver call rather than per inner iteration, since the
pairing set is fixed for the whole call. Only cov2cov pairings carry a
surface normal; every other pairing type keeps weight 1 unconditionally.

Verified bit-identical to the stock pipeline when disabled (enabled:false,
or an all-ones weight vector) through icp-gtmap-bench on oxford_d1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional geometry-based weighting for ICP registration, allowing map surface pairings to be weighted by incidence or verticality.
  - Supports configurable breakpoints, class weights, smoothing, and gravity references.
  - Added YAML configuration loading and saving, with validation for invalid settings.
  - Geometry weighting is disabled by default and preserves existing behavior when inactive.
  - Added diagnostic reporting for effective weight ratios and geometry-class distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->